### PR TITLE
Only compile AVX code on x86

### DIFF
--- a/benches/field.rs
+++ b/benches/field.rs
@@ -42,6 +42,7 @@ pub fn field_operations_bench(c: &mut criterion::Criterion) {
     });
 }
 
+#[cfg(target_arch = "x86_64")]
 pub fn avx512_field_operations_bench(c: &mut criterion::Criterion) {
     use prover_research::platform;
     if !platform::avx512_detected() {
@@ -100,9 +101,12 @@ pub fn avx512_field_operations_bench(c: &mut criterion::Criterion) {
     });
 }
 
+#[cfg(target_arch = "x86_64")]
 criterion::criterion_group!(
     benches,
     field_operations_bench,
     avx512_field_operations_bench
 );
+#[cfg(not(target_arch = "x86_64"))]
+criterion::criterion_group!(benches, field_operations_bench);
 criterion::criterion_main!(benches);

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,1 +1,0 @@
-pub mod field;

--- a/src/core/fields/mod.rs
+++ b/src/core/fields/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(target_arch = "x86_64")]
 pub mod avx512_m31;
 pub mod cm31;
 pub mod m31;


### PR DESCRIPTION
Allows compiling on non x86 targets

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-industries/prover-research/62)
<!-- Reviewable:end -->
