### PR TITLE
Change release and bench profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "prover_research"
+name = "prover-research"
 version = "0.1.1"
 dependencies = [
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["profile-rustflags"]
-
 [package]
 name = "prover-research"
 version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 cargo-features = ["profile-rustflags"]
 
 [package]
-name = "prover_research"
+name = "prover-research"
 version = "0.1.1"
 edition = "2021"
 
@@ -21,15 +21,13 @@ rand = "0.8.3"
 [features]
 avx512 = []
 
-[profile.release]
-opt-level = 2
-rustflags = ["-C", "target-cpu=native"]
-debug = 2
+[profile.bench]
+codegen-units = 1
+lto = true
 
 [[bench]]
 harness = false
 name = "field"
-
 
 [[bench]]
 name = "merkle_bench"


### PR DESCRIPTION
Made the "bench" and "release" profile more optimised. Note that the "bench" profile inherits from the "release" profile. I'm not sure the reason the release profile was set to the prior settings - something to do with AVX? - maybe you can provide some context on this @shaharsamocha7? I removed rust flags since I think they target-cpu=native is the default (it is on my machine). Also added lto and reduced codegen units for "bench" profile for better performance (lead to ~10% improved benchmark performance on my machine).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/69)
<!-- Reviewable:end -->
