### PR TITLE
native type for hasher trait, into slice for field

### DIFF
--- a/benches/merkle_bench.rs
+++ b/benches/merkle_bench.rs
@@ -7,14 +7,15 @@ use prover_research::commitment_scheme::blake2_hash::Blake2sHasher;
 use prover_research::commitment_scheme::blake3_hash::Blake3Hasher;
 use prover_research::commitment_scheme::hasher::{Hasher, Name};
 use prover_research::commitment_scheme::merkle_tree::MerkleTree;
+use prover_research::core::fields::m31::M31;
 
 static N_BYTES_U32: usize = 4;
 
-fn prepare_element_vector(size: usize) -> Vec<u32> {
-    (0..size as u32).collect()
+fn prepare_element_vector(size: usize) -> Vec<M31> {
+    (0..size as u32).map(M31::from_u32_unchecked).collect()
 }
 
-fn merkle_bench<T: Hasher>(group: &mut BenchmarkGroup<'_, WallTime>, elems: &[u32]) {
+fn merkle_bench<T: Hasher>(group: &mut BenchmarkGroup<'_, WallTime>, elems: &[M31]) {
     let size = elems.len();
     let elems = elems.to_vec();
     group.sample_size(10);
@@ -24,9 +25,9 @@ fn merkle_bench<T: Hasher>(group: &mut BenchmarkGroup<'_, WallTime>, elems: &[u3
         &size,
         |b: &mut criterion::Bencher<'_>, &_size| {
             b.iter_batched(
-                || -> Vec<u32> { elems.clone() },
+                || -> Vec<M31> { elems.clone() },
                 |elems| {
-                    MerkleTree::<u32, Blake3Hasher>::commit(vec![elems]);
+                    MerkleTree::<M31, Blake3Hasher>::commit(vec![elems]);
                 },
                 BatchSize::LargeInput,
             )
@@ -36,41 +37,37 @@ fn merkle_bench<T: Hasher>(group: &mut BenchmarkGroup<'_, WallTime>, elems: &[u3
 
 fn merkle_blake3_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Blake3_Tree");
-    for exp in 15u32..20u32 {
-        // Set Up.
-        let elems: Vec<u32> = prepare_element_vector(2usize.pow(exp));
+    let exponent = 20u32;
+    // Set Up.
+    let elems = prepare_element_vector(2usize.pow(exponent));
 
-        // Benchmark Loop.
-        merkle_bench::<Blake3Hasher>(&mut group, &elems);
-    }
+    // Benchmark Loop.
+    merkle_bench::<Blake3Hasher>(&mut group, &elems);
     group.finish();
 }
 
 fn merkle_blake2s_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Blake2s_Tree");
-    for exp in 15u32..20u32 {
-        // Set up.
-        let size = 2usize.pow(exp);
-        let elems: Vec<u32> = (0..(size as u32)).collect();
+    let mut group = c.benchmark_group("Blake3_Tree");
+    let exponent = 20u32;
+    // Set Up.
+    let elems = prepare_element_vector(2usize.pow(exponent));
 
-        // Benchmark Loop.
-        merkle_bench::<Blake2sHasher>(&mut group, &elems);
-    }
+    // Benchmark Loop.
+    merkle_bench::<Blake2sHasher>(&mut group, &elems);
     group.finish();
 }
 
 // Compare Blake2s256 w. Blake3.
 fn compare_blakes(c: &mut Criterion) {
     let mut group = c.benchmark_group("Comparison of hashing algorithms and caching overhead");
-    for exp in 15u32..20u32 {
-        // Set up.
-        let size = 2usize.pow(exp);
-        let elems: Vec<u32> = (0..(size as u32)).collect();
+    let exponent = 20u32;
+    // Set up.
+    let elems: Vec<M31> = prepare_element_vector(2usize.pow(exponent));
 
-        // Benchmark Loop.
-        merkle_bench::<Blake2sHasher>(&mut group, &elems);
-        merkle_bench::<Blake3Hasher>(&mut group, &elems);
-    }
+    // Benchmark Loop.
+    merkle_bench::<Blake2sHasher>(&mut group, &elems);
+    merkle_bench::<Blake3Hasher>(&mut group, &elems);
+
     group.finish();
 }
 

--- a/src/commitment_scheme/blake3_hash.rs
+++ b/src/commitment_scheme/blake3_hash.rs
@@ -54,8 +54,9 @@ pub struct Blake3Hasher {}
 
 impl super::hasher::Hasher for Blake3Hasher {
     type Hash = Blake3Hash;
-    const BLOCK_SIZE_IN_BYTES: usize = 64;
-    const OUTPUT_SIZE_IN_BYTES: usize = 32;
+    type NativeType = u8;
+    const BLOCK_SIZE: usize = 64;
+    const OUTPUT_SIZE: usize = 32;
 
     fn hash(val: &[u8]) -> Blake3Hash {
         Blake3Hash(*blake3::hash(val).as_bytes())
@@ -72,13 +73,13 @@ impl super::hasher::Hasher for Blake3Hasher {
     fn hash_one_in_place(data: &[u8], dst: &mut [u8]) {
         assert_eq!(
             dst.len(),
-            Self::OUTPUT_SIZE_IN_BYTES,
+            Self::OUTPUT_SIZE,
             "Attempt to Generate blake3 hash of size different than 32 bytes!"
         );
         let mut hasher = blake3::Hasher::new();
         hasher.update(data);
         let mut output_reader = hasher.finalize_xof();
-        output_reader.fill(&mut dst[..Self::OUTPUT_SIZE_IN_BYTES])
+        output_reader.fill(&mut dst[..Self::OUTPUT_SIZE])
     }
 
     fn hash_many(data: &[Vec<u8>]) -> Vec<Self::Hash> {
@@ -95,12 +96,12 @@ impl super::hasher::Hasher for Blake3Hasher {
             .map(|p| std::slice::from_raw_parts(*p, single_input_length_bytes))
             .zip(
                 dst.iter()
-                    .map(|p| std::slice::from_raw_parts_mut(*p, Self::OUTPUT_SIZE_IN_BYTES)),
+                    .map(|p| std::slice::from_raw_parts_mut(*p, Self::OUTPUT_SIZE)),
             )
             .for_each(|(input, out)| Self::hash_one_in_place(input, out))
     }
 
-    fn hash_many_multi_src(data: &[&[&[u8]]]) -> Vec<Self::Hash> {
+    fn hash_many_multi_src(data: &[Vec<&[u8]>]) -> Vec<Self::Hash> {
         let mut hasher = blake3::Hasher::new();
         data.iter()
             .map(|input_group| {
@@ -172,9 +173,9 @@ mod tests {
         let input2 = b"b";
         let input3 = b"c";
         let input4 = b"d";
-        let input_group_1 = [&input1[..], &input2[..]];
-        let input_group_2 = [&input3[..], &input4[..]];
-        let input_arr = [&input_group_1[..], &input_group_2[..]];
+        let input_group_1 = [&input1[..], &input2[..]].to_vec();
+        let input_group_2 = [&input3[..], &input4[..]].to_vec();
+        let input_arr = [input_group_1, input_group_2];
 
         let hash_results = Blake3Hasher::hash_many_multi_src(&input_arr);
 

--- a/src/commitment_scheme/hasher.rs
+++ b/src/commitment_scheme/hasher.rs
@@ -9,23 +9,24 @@ pub trait Hasher {
     type Hash: Copy
         + Display
         + self::Name
-        + Into<Vec<u8>>
-        + TryFrom<Vec<u8>>
-        + AsRef<[u8]>
-        + for<'a> From<&'a [u8]>;
+        + Into<Vec<Self::NativeType>>
+        + TryFrom<Vec<Self::NativeType>>
+        + AsRef<[Self::NativeType]>
+        + for<'a> From<&'a [Self::NativeType]>;
 
+    type NativeType: Eq;
     // Input size of the compression function.
     // TODO(Ohad): Consider packing hash paramaters in a dedicated struct.
-    const BLOCK_SIZE_IN_BYTES: usize;
-    const OUTPUT_SIZE_IN_BYTES: usize;
+    const BLOCK_SIZE: usize;
+    const OUTPUT_SIZE: usize;
 
     fn concat_and_hash(v1: &Self::Hash, v2: &Self::Hash) -> Self::Hash;
 
-    fn hash(data: &[u8]) -> Self::Hash;
+    fn hash(data: &[Self::NativeType]) -> Self::Hash;
 
-    fn hash_one_in_place(data: &[u8], dst: &mut [u8]);
+    fn hash_one_in_place(data: &[Self::NativeType], dst: &mut [Self::NativeType]);
 
-    fn hash_many(data: &[Vec<u8>]) -> Vec<Self::Hash>;
+    fn hash_many(data: &[Vec<Self::NativeType>]) -> Vec<Self::Hash>;
 
     /// Hash many inputs of the same length.
     /// Writes output directly to corresponding pointers in dst.
@@ -34,13 +35,14 @@ pub trait Hasher {
     ///
     /// Inputs must be of the same size. output locations must all point to valid, allocated and
     /// distinct locations in memory.
+    // TODO(Ohad): Delete.
     unsafe fn hash_many_in_place(
-        data: &[*const u8],
+        data: &[*const Self::NativeType],
         single_input_length_bytes: usize,
-        dst: &[*mut u8],
+        dst: &[*mut Self::NativeType],
     );
 
     // TODO(Ohad): Consider adding a trait for hashers that support multi-source hashing, and
     // defining proper input structure for it.
-    fn hash_many_multi_src(data: &[&[&[u8]]]) -> Vec<Self::Hash>;
+    fn hash_many_multi_src(data: &[Vec<&[Self::NativeType]>]) -> Vec<Self::Hash>;
 }

--- a/src/commitment_scheme/merkle_decommitment.rs
+++ b/src/commitment_scheme/merkle_decommitment.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fmt::{self, Display};
 
 use super::hasher::Hasher;
-use crate::commitment_scheme::utils::to_byte_slice;
+use crate::core::fields::IntoSlice;
 
 /// Merkle proof of queried indices.
 /// Used for storing a merkle proof of a given tree and a set of queries.
@@ -19,7 +19,11 @@ pub struct MerkleDecommitment<T: Sized + Display, H: Hasher> {
     pub n_rows_in_leaf_block: usize,
 }
 
-impl<T: Sized + Display, H: Hasher> MerkleDecommitment<T, H> {
+impl<'a, T: Sized + Display + 'a, H: Hasher> MerkleDecommitment<T, H>
+where
+    T: IntoSlice<H::NativeType>,
+    H::NativeType: 'a,
+{
     pub fn new(
         leaf_blocks: Vec<Vec<T>>,
         layers: Vec<Vec<H::Hash>>,
@@ -52,7 +56,7 @@ impl<T: Sized + Display, H: Hasher> MerkleDecommitment<T, H> {
         let mut curr_hashes = self
             .leaf_blocks
             .iter()
-            .map(|leaf_block| H::hash(to_byte_slice(leaf_block)))
+            .map(|leaf_block| H::hash(<T as IntoSlice<H::NativeType>>::into_slice(leaf_block)))
             .collect::<Vec<H::Hash>>();
 
         let mut layer_queries = leaf_block_queries.clone();

--- a/src/core/fields/m31.rs
+++ b/src/core/fields/m31.rs
@@ -3,6 +3,7 @@ use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
+use super::IntoSlice;
 use crate::impl_field;
 
 pub const P: u32 = 2147483647; // 2 ** 31 - 1
@@ -98,6 +99,13 @@ impl From<u32> for M31 {
 impl From<i32> for M31 {
     fn from(value: i32) -> Self {
         M31::reduce(value.try_into().unwrap())
+    }
+}
+
+// TODO(Ohad): Address platform.
+impl IntoSlice<u8> for M31 {
+    fn into_slice(sl: &[Self]) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(sl.as_ptr() as *const u8, std::mem::size_of_val(sl)) }
     }
 }
 

--- a/src/core/fields/mod.rs
+++ b/src/core/fields/mod.rs
@@ -34,6 +34,10 @@ pub trait Field: NumAssign + Neg<Output = Self> + Copy {
     fn inverse(&self) -> Self;
 }
 
+pub trait IntoSlice<T: Sized>: Sized {
+    fn into_slice(sl: &[Self]) -> &[T];
+}
+
 pub trait ExtensionOf<F: Field>: Field + From<F> + NumOps<F> + NumAssignOps<F> {}
 
 #[macro_export]


### PR DESCRIPTION
Mostly decoupled the tree utilities from the native Blake type (bytes)
Added todos above function that needs to be addressed and probably removed as they are not useful for the mixed degree case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-industries/prover-research/117)
<!-- Reviewable:end -->
