### PR TITLE
fix use of unstable library feature 'int_roundings' error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
     new_uninit,
     slice_group_by,
     stdsimd,
-    get_many_mut
+    get_many_mut,
+    int_roundings
 )]
 pub mod commitment_scheme;
 pub mod core;


### PR DESCRIPTION
While run `cargo test`, get:
```
error[E0658]: use of unstable library feature 'int_roundings'
  --> src/core/backend/avx512/mod.rs:63:56
   |
63 |             data: vec![PackedBaseField::default(); len.div_ceil(K_ELEMENTS)],
   |                                                        ^^^^^^^^
   |
   = note: see issue #88581 <https://github.com/rust-lang/rust/issues/88581> for more information
   = help: add `#![feature(int_roundings)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `stwo` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/422)
<!-- Reviewable:end -->
