### PR TITLE
fix compatibility for non-x86 build targets

### DIFF
--- a/benches/bit_rev.rs
+++ b/benches/bit_rev.rs
@@ -2,7 +2,6 @@
 
 use criterion::Criterion;
 
-#[cfg(target_arch = "x86_64")]
 pub fn cpu_bit_rev(c: &mut criterion::Criterion) {
     use stwo::core::fields::m31::BaseField;
 
@@ -51,4 +50,9 @@ criterion::criterion_group!(
     name=avx_bit_rev;
     config = Criterion::default().sample_size(10);
     targets=avx512_bit_rev, cpu_bit_rev);
+#[cfg(not(target_arch = "x86_64"))]
+criterion::criterion_group!(
+    name=avx_bit_rev;
+    config = Criterion::default().sample_size(10);
+    targets=cpu_bit_rev);
 criterion::criterion_main!(avx_bit_rev);

--- a/benches/fft.rs
+++ b/benches/fft.rs
@@ -1,10 +1,11 @@
 #![feature(iter_array_chunks)]
 
 use criterion::Criterion;
-use stwo::core::backend::avx512::fft::ifft::get_itwiddle_dbls;
 
+#[cfg(target_arch = "x86_64")]
 pub fn avx512_ifft(c: &mut criterion::Criterion) {
     use stwo::core::backend::avx512::fft::ifft;
+    use stwo::core::backend::avx512::fft::ifft::get_itwiddle_dbls;
     use stwo::core::backend::avx512::BaseFieldVec;
     use stwo::core::fields::m31::BaseField;
     use stwo::core::poly::circle::CanonicCoset;
@@ -37,6 +38,14 @@ pub fn avx512_ifft(c: &mut criterion::Criterion) {
     });
 }
 
+
+
+#[cfg(not(target_arch = "x86_64"))]
+pub fn avx512_ifft(_: &mut criterion::Criterion) {
+    // todo: add benchmark for cpu backend?
+    // ifft code needs to separated out of the CPUBackend's implementation of PolyOps.interpolate
+    return;
+}
 criterion::criterion_group!(
     name=avx_ifft;
     config = Criterion::default().sample_size(10);

--- a/src/core/backend/mod.rs
+++ b/src/core/backend/mod.rs
@@ -7,6 +7,7 @@ use super::fields::qm31::SecureField;
 use super::fields::FieldOps;
 use super::poly::circle::PolyOps;
 
+#[cfg(target_arch = "x86_64")]
 pub mod avx512;
 pub mod cpu;
 

--- a/src/core/fields/mod.rs
+++ b/src/core/fields/mod.rs
@@ -3,7 +3,6 @@ use std::ops::{Mul, MulAssign, Neg};
 
 use num_traits::{NumAssign, NumAssignOps, NumOps, One};
 
-#[cfg(target_arch = "x86_64")]
 pub mod cm31;
 pub mod m31;
 pub mod qm31;


### PR DESCRIPTION
The current dev branch doesn't compile for non-x86 targets (ex. Apple Silicon Devices), so I updated the code to run without AVX-512 for non-x86 build targets.

Right now all tests are passing, but the benchmark for ifft on non-x86 targets as there is no corresponding ifft function in cpu implementation (the ifft logic is inlined in the PolyOps.interpolate implementation for CPUBackend), so the benchmark just exits on non-x86 targets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/472)
<!-- Reviewable:end -->
