### PR TITLE
Reconcile the CM31 -> QM31 field extension polynomial with Plonky3

### DIFF
--- a/src/core/backend/avx512/qm31.rs
+++ b/src/core/backend/avx512/qm31.rs
@@ -36,18 +36,21 @@ impl Mul for PackedQM31 {
     fn mul(self, rhs: Self) -> Self::Output {
         // Compute using Karatsuba.
         //   (a + ub) * (c + ud) =
-        //   (ac + (1+2i)bd) + (ad + bc)u =
-        //   ac + bd + 2ibd + (ad + bc)u.
+        //   (ac + (2+i)bd) + (ad + bc)u =
+        //   ac + 2bd + ibd + (ad + bc)u.
         let ac = self.a() * rhs.a();
         let bd = self.b() * rhs.b();
-        let bd2 = bd + bd;
+        let bd_times_1_plus_i = PackedCM31([bd.a() - bd.b(), bd.a() + bd.b()]);
         // Computes ac + bd.
         let ac_p_bd = ac + bd;
         // Computes ad + bc.
         let ad_p_bc = (self.a() + self.b()) * (rhs.a() + rhs.b()) - ac_p_bd;
-        // ac + bd + 2ibd =
-        // ac + bd -Im(2bd) + iRe(2bd)
-        let l = PackedCM31([ac_p_bd.a() - bd2.b(), ac_p_bd.b() + bd2.a()]);
+        // ac + 2bd + ibd =
+        // ac + bd + bd + ibd
+        let l = PackedCM31([
+            ac_p_bd.a() + bd_times_1_plus_i.a(),
+            ac_p_bd.b() + bd_times_1_plus_i.b(),
+        ]);
         Self([l, ad_p_bc])
     }
 }

--- a/src/core/circle.rs
+++ b/src/core/circle.rs
@@ -199,8 +199,8 @@ pub const M31_CIRCLE_LOG_ORDER: u32 = 31;
 
 /// A generator for the circle group over [SecureField].
 pub const SECURE_FIELD_CIRCLE_GEN: CirclePoint<SecureField> = CirclePoint {
-    x: SecureField::from_u32_unchecked(1, 0, 478637715, 513582961),
-    y: SecureField::from_u32_unchecked(568722919, 616616927, 0, 74382916),
+    x: SecureField::from_u32_unchecked(1, 0, 478637715, 513582971),
+    y: SecureField::from_u32_unchecked(992285211, 649143431, 740191619, 1186584352),
 };
 
 /// Order of [SECURE_FIELD_CIRCLE_GEN].

--- a/src/core/fields/qm31.rs
+++ b/src/core/fields/qm31.rs
@@ -10,10 +10,10 @@ use crate::{impl_extension_field, impl_field};
 
 pub const SECURE_FIELD_EXTENSION_DEGREE: usize = 4;
 pub const P4: u128 = 21267647892944572736998860269687930881; // (2 ** 31 - 1) ** 4
-pub const R: CM31 = CM31::from_u32_unchecked(1, 2);
+pub const R: CM31 = CM31::from_u32_unchecked(2, 1);
 
 /// Extension field of CM31.
-/// Equivalent to CM31\[x\] over (x^2 - 1 - 2i) as the irreducible polynomial.
+/// Equivalent to CM31\[x\] over (x^2 - 2 - i) as the irreducible polynomial.
 /// Represented as ((a, b), (c, d)) of (a + bi) + (c + di)u.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QM31(pub CM31, pub CM31);
@@ -85,7 +85,7 @@ mod tests {
         let qm1 = qm31!(4, 5, 6, 7);
         let m = m31!(8);
         let qm = QM31::from(m);
-        let qm0_x_qm1 = qm31!(P - 106, 38, P - 16, 50);
+        let qm0_x_qm1 = qm31!(P - 71, 93, P - 16, 50);
 
         assert_eq!(qm0 + qm1, qm31!(5, 7, 9, 11));
         assert_eq!(qm1 + m, qm1 + qm);


### PR DESCRIPTION
Per conversation with @spapinistarkware, this PR proposes to replace the existing F2 -> F4 extension polynomial from
```
y^2 - 1 - 2i
```
into 
```
y^2 - 2 - i
```
which would then be consistent with https://github.com/Plonky3/Plonky3/ (see this mirrored issue https://github.com/Plonky3/Plonky3/issues/284) and allow interoperability.

The two polynomials should be equivalent, though the extension field would have very different internal structure.

The changes being made include:
- change QM31 CPU implementation's `mul` function
- change AVX512 QM31 implementation's `mul` function
- replace the Circle curve's generator

The new generator starts with the same `x` and gradually increments the last element, until we are able to find a corresponding `y` and that (x, y) is a group generator. The search of `y` is done through Algorithm 8 of https://eprint.iacr.org/2012/685.pdf.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/505)
<!-- Reviewable:end -->
