### PR TITLE
fix: cfg for non x86_64 arch support

### DIFF
--- a/src/core/backend/mod.rs
+++ b/src/core/backend/mod.rs
@@ -7,7 +7,7 @@ use super::fields::qm31::SecureField;
 use super::fields::FieldOps;
 use super::poly::circle::PolyOps;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+#[cfg(target_arch = "x86_64")]
 pub mod avx512;
 pub mod cpu;
 

--- a/src/core/backend/mod.rs
+++ b/src/core/backend/mod.rs
@@ -7,6 +7,7 @@ use super::fields::qm31::SecureField;
 use super::fields::FieldOps;
 use super::poly::circle::PolyOps;
 
+#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
 pub mod avx512;
 pub mod cpu;
 

--- a/src/core/fields/mod.rs
+++ b/src/core/fields/mod.rs
@@ -6,7 +6,6 @@ use num_traits::{NumAssign, NumAssignOps, NumOps, One};
 
 use super::backend::ColumnOps;
 
-#[cfg(target_arch = "x86_64")]
 pub mod cm31;
 pub mod m31;
 pub mod qm31;


### PR DESCRIPTION
Seems like gating cm31 behind a feature flag is accidental, doesn't seem necessary. This fixes build/test for me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/516)
<!-- Reviewable:end -->
