### PR TITLE
Fix CirclePointIndex bug in debug mode for 32-bit archs

### DIFF
--- a/crates/prover/src/core/circle.rs
+++ b/crates/prover/src/core/circle.rs
@@ -269,7 +269,7 @@ impl Mul<usize> for CirclePointIndex {
     type Output = Self;
 
     fn mul(self, rhs: usize) -> Self::Output {
-        Self(self.0 * rhs).reduce()
+        Self(self.0.wrapping_mul(rhs)).reduce()
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/613)
<!-- Reviewable:end -->
