### PR TITLE
eval at point todo removed

### DIFF
--- a/crates/prover/src/core/backend/avx512/circle.rs
+++ b/crates/prover/src/core/backend/avx512/circle.rs
@@ -20,7 +20,6 @@ use crate::core::poly::utils::{domain_line_twiddles_from_tree, fold};
 use crate::core::poly::BitReversedOrder;
 
 impl AVX512Backend {
-    // TODO(Ohad): optimize.
     fn twiddle_at<F: Field>(mappings: &[F], mut index: usize) -> F {
         debug_assert!(
             (1 << mappings.len()) as usize >= index,
@@ -32,11 +31,10 @@ impl AVX512Backend {
         for &num in mappings.iter() {
             if index & 1 == 1 {
                 product *= num;
-            }
-            index >>= 1;
-            if index == 0 {
+            } else if index == 0 {
                 break;
             }
+            index >>= 1;
         }
 
         product


### PR DESCRIPTION
Remove redundant TODO

Remove redundant TODO (#590)


Remove redundant TODO

Optimize base field inverse implementation (#571)

Enable 'rng.gen()'ing field types (#591)

removed useless test (#624)

rearranged function, removed todo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/626)
<!-- Reviewable:end -->
