### PR TITLE
Karatsuba algorithm for multiplication

### DIFF
--- a/crates/prover/benches/field.rs
+++ b/crates/prover/benches/field.rs
@@ -4,6 +4,7 @@ use rand::{Rng, SeedableRng};
 use stwo_prover::core::fields::cm31::CM31;
 use stwo_prover::core::fields::m31::M31;
 use stwo_prover::core::fields::qm31::SecureField;
+use stwo_prover::core::fields::FieldExpOps;
 
 pub const N_ELEMENTS: usize = 1 << 16;
 pub const N_STATE_ELEMENTS: usize = 8;
@@ -49,6 +50,18 @@ pub fn cm31_operations_bench(c: &mut criterion::Criterion) {
                 for _ in 0..128 {
                     for state_elem in &mut state {
                         *state_elem *= *elem;
+                    }
+                }
+            }
+        })
+    });
+
+    c.bench_function("CM31 square", |b| {
+        b.iter(|| {
+            for _ in &elements {
+                for _ in 0..128 {
+                    for state_elem in &mut state {
+                        *state_elem = state_elem.square();
                     }
                 }
             }

--- a/crates/prover/src/core/fields/cm31.rs
+++ b/crates/prover/src/core/fields/cm31.rs
@@ -52,7 +52,12 @@ impl Mul for CM31 {
     }
 }
 
-impl FieldExpOps for CM31 {
+impl FieldExpOps for CM31 {    
+    fn square(&self) -> Self {
+        let a0a1 = self.0 * self.1;
+        Self((self.0 + self.1) * (self.0 - self.1), a0a1 + a0a1)    
+    }
+
     fn inverse(&self) -> Self {
         assert!(!self.is_zero(), "0 has no inverse");
         // 1 / (a + bi) = (a - bi) / (a^2 + b^2).

--- a/crates/prover/src/core/fields/cm31.rs
+++ b/crates/prover/src/core/fields/cm31.rs
@@ -54,6 +54,7 @@ impl Mul for CM31 {
 
 impl FieldExpOps for CM31 {    
     fn square(&self) -> Self {
+        // Complex squaring algorithm taken from https://eprint.iacr.org/2006/471.pdf
         let a0a1 = self.0 * self.1;
         Self((self.0 + self.1) * (self.0 - self.1), a0a1 + a0a1)    
     }

--- a/crates/prover/src/core/fields/qm31.rs
+++ b/crates/prover/src/core/fields/qm31.rs
@@ -58,11 +58,11 @@ impl Mul for QM31 {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
-        // (a + bu) * (c + du) = (ac + rbd) + (ad + bc)u.
-        Self(
-            self.0 * rhs.0 + R * self.1 * rhs.1,
-            self.0 * rhs.1 + self.1 * rhs.0,
-        )
+        // Karatsuba algorithm taken from https://eprint.iacr.org/2006/471.pdf
+        let v0 = self.0 * rhs.0;
+        let v1 = self.1 * rhs.1;
+ 
+        Self(v0 + R * v1, (self.0 + self.1) * (rhs.0 + rhs.1) - v0 - v1)
     }
 }
 


### PR DESCRIPTION
### Description
- Add Karatsuba multiplication for **QM31**.
- Add complex squaring for **CM31**.
- Add benchmark for the square operation for **CM31**.

For the detail of the algorithms check [this paper]( https://eprint.iacr.org/2006/471.pdf).

The PR does not include Karatsuba algorithm for **CM31**. When tested it did not improve the benchmarks. Possibly due to the already efficient algorithms for multiplication in M31.

Here's the performance improvement report:

![benchmarkss](https://github.com/starkware-libs/stwo/assets/8537653/7101cc7f-59b8-4e9e-babd-68c5541ecc68)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/628)
<!-- Reviewable:end -->
