### PR TITLE
Replace derivative with educe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -270,17 +270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,10 +281,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_filter"
@@ -625,7 +646,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -670,7 +691,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "criterion",
- "derivative",
+ "educe",
  "hex",
  "itertools 0.12.1",
  "num-traits",
@@ -686,17 +707,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -728,7 +738,7 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -748,7 +758,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -790,7 +800,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
 ]
 
 [[package]]
@@ -887,7 +897,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -909,7 +919,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [workspace.dependencies]
 blake2 = "0.10.6"
 blake3 = "1.5.0"
-derivative = "2.2.0"
+educe = "0.5.0"
 hex = "0.4.3"
 itertools = "0.12.0"
 num-traits = "0.2.17"

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -10,7 +10,7 @@ blake2.workspace = true
 blake3.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 cfg-if = "1.0.0"
-derivative.workspace = true
+educe.workspace = true
 hex.workspace = true
 itertools.workspace = true
 num-traits.workspace = true

--- a/crates/prover/src/core/lookups/mle.rs
+++ b/crates/prover/src/core/lookups/mle.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use derivative::Derivative;
+use educe::Educe;
 
 use crate::core::backend::{Col, Column, ColumnOps};
 use crate::core::fields::qm31::SecureField;
@@ -15,8 +15,8 @@ pub trait MleOps<F: Field>: ColumnOps<F> + Sized {
 
 /// Multilinear Extension stored as evaluations of a multilinear polynomial over the boolean
 /// hypercube in bit-reversed order.
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""), Clone(bound = ""))]
+#[derive(Educe)]
+#[educe(Debug, Clone)]
 pub struct Mle<B: ColumnOps<F>, F: Field> {
     evals: Col<B, F>,
 }

--- a/crates/prover/src/core/poly/circle/evaluation.rs
+++ b/crates/prover/src/core/poly/circle/evaluation.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::ops::{Deref, Index};
 
-use derivative::Derivative;
+use educe::Educe;
 
 use super::{CanonicCoset, CircleDomain, CirclePoly, PolyOps};
 use crate::core::backend::cpu::CpuCircleEvaluation;
@@ -15,8 +15,8 @@ use crate::core::utils::bit_reverse_index;
 
 /// An evaluation defined on a [CircleDomain].
 /// The values are ordered according to the [CircleDomain] ordering.
-#[derive(Derivative)]
-#[derivative(Clone(bound = ""), Debug(bound = ""))]
+#[derive(Educe)]
+#[educe(Clone, Debug)]
 pub struct CircleEvaluation<B: FieldOps<F>, F: ExtensionOf<BaseField>, EvalOrder = NaturalOrder> {
     pub domain: CircleDomain,
     pub values: Col<B, F>,

--- a/crates/prover/src/core/vcs/prover.rs
+++ b/crates/prover/src/core/vcs/prover.rs
@@ -1,6 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
+use educe::Educe;
 use itertools::Itertools;
 
 use super::ops::{MerkleHasher, MerkleOps};
@@ -202,7 +203,8 @@ impl<B: MerkleOps<H>, H: MerkleHasher> MerkleProver<B, H> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Educe)]
+#[educe(Clone)]
 pub struct MerkleDecommitment<H: MerkleHasher> {
     /// Hash values that the verifier needs but cannot deduce from previous computations, in the
     /// order they are needed.
@@ -218,15 +220,6 @@ impl<H: MerkleHasher> MerkleDecommitment<H> {
         Self {
             hash_witness: Vec::new(),
             column_witness: Vec::new(),
-        }
-    }
-}
-// TODO(andreW): Remove these in favor of the `derivative` crate.
-impl<H: MerkleHasher> Clone for MerkleDecommitment<H> {
-    fn clone(&self) -> Self {
-        Self {
-            hash_witness: self.hash_witness.clone(),
-            column_witness: self.column_witness.clone(),
         }
     }
 }


### PR DESCRIPTION
This closes #647 as well as addresses one of the todos by Andrew.
```
// TODO(andreW): Remove these in favor of the `derivative` crate.
```

Educe is a more up-to-date version of the derivative crate that is under maintained. 
It also simplifies auto-derivation when it encounters bounds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/649)
<!-- Reviewable:end -->
