### PR TITLE
Merkle simd parallelization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-traits",
  "rand",
+ "rayon",
  "starknet-crypto",
  "starknet-ff",
  "test-log",

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -3,6 +3,9 @@ name = "stwo-prover"
 version.workspace = true
 edition.workspace = true
 
+[features]
+parallel = ["rayon"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,6 +22,7 @@ starknet-crypto = "0.6.2"
 starknet-ff = "0.3.7"
 thiserror.workspace = true
 tracing.workspace = true
+rayon = {version = "1.10.0", optional = true}
 
 [dev-dependencies]
 aligned = "0.4.2"

--- a/crates/prover/src/core/backend/simd/blake2s.rs
+++ b/crates/prover/src/core/backend/simd/blake2s.rs
@@ -7,6 +7,8 @@ use std::mem::transmute;
 use std::simd::u32x16;
 
 use itertools::Itertools;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use super::m31::{LOG_N_LANES, N_LANES};
 use super::SimdBackend;
@@ -48,7 +50,13 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
         columns: &[&Col<Self, BaseField>],
     ) -> Vec<Blake2sHash> {
         if log_size < N_LANES as u32 {
-            return (0..1 << log_size)
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..1 << log_size;
+
+            #[cfg(feature = "parallel")]
+            let iter = (0..1 << log_size).into_par_iter();
+
+            return iter
                 .map(|i| {
                     Blake2sMerkleHasher::hash_node(
                         prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
@@ -65,8 +73,14 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
         let zeros = u32x16::splat(0);
 
         // Commit to columns.
-        let mut res = Vec::with_capacity(1 << log_size);
-        for i in 0..(1 << (log_size - LOG_N_LANES)) {
+        let mut res = vec![Blake2sHash::default(); 1 << log_size];
+        #[cfg(not(feature = "parallel"))]
+        let iter = res.chunks_mut(1 << LOG_N_LANES);
+
+        #[cfg(feature = "parallel")]
+        let iter = res.par_chunks_mut(1 << LOG_N_LANES);
+
+        iter.enumerate().for_each(|(i, chunk)| {
             let mut state: [u32x16; 8] = unsafe { std::mem::zeroed() };
             // Hash prev_layer, if exists.
             if let Some(prev_layer) = prev_layer {
@@ -96,8 +110,8 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
                 state = compress16(state, msgs, zeros, zeros, zeros, zeros);
             }
             let state: [Blake2sHash; 16] = unsafe { transmute(untranspose_states(state)) };
-            res.extend_from_slice(&state);
-        }
+            chunk.copy_from_slice(&state);
+        });
         res
     }
 }


### PR DESCRIPTION
Description:

We use Rayon to add parallelization option for applying hashes when building the merkle tree.
We extended the wide fibonacci trace to 2^10 columns.
This is achieved by introducing conditional compilation features to switch between parallel and single threads.

We saw improvements of about 10% in the total proving time and >80% in the trace commitment. We note that we had to change the total columns of the wide fibonacci trace from 2^8 to 2^10 to see these improvements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/658)
<!-- Reviewable:end -->
