### PR TITLE
 added parallel conditional compilation for trace interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-traits",
  "rand",
+ "rayon",
  "test-log",
  "thiserror",
  "tracing",

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -3,6 +3,11 @@ name = "stwo-prover"
 version.workspace = true
 edition.workspace = true
 
+
+[features]
+parallel = []
+
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -17,6 +22,7 @@ num-traits.workspace = true
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 thiserror.workspace = true
 tracing.workspace = true
+rayon = "1.10.0"
 
 [dev-dependencies]
 aligned = "0.4.2"

--- a/crates/prover/src/examples/wide_fibonacci/component.rs
+++ b/crates/prover/src/examples/wide_fibonacci/component.rs
@@ -14,7 +14,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::{ColumnVec, InteractionElements};
 use crate::examples::wide_fibonacci::trace_gen::write_lookup_column;
 
-pub const LOG_N_COLUMNS: usize = 8;
+pub const LOG_N_COLUMNS: usize = 10;
 pub const N_COLUMNS: usize = 1 << LOG_N_COLUMNS;
 
 const ALPHA_ID: &str = "wide_fibonacci_alpha";


### PR DESCRIPTION
Description:

We use Rayon to add parallelization option for interpolating the trace. Each thread runs fft in each column.
We extended the wide fibonacci trace to 2^10 columns.
This is achieved by introducing conditional compilation features to switch between parallel and single threads.

We saw improvements of >70% in the trace interpolation time which translates to an improvement of about 5% in total proving time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/659)
<!-- Reviewable:end -->
