### PR TITLE
Candidate improvement on quotients to use CM31 whenever possible

### DIFF
--- a/crates/prover/src/core/backend/mod.rs
+++ b/crates/prover/src/core/backend/mod.rs
@@ -9,6 +9,7 @@ use super::fields::FieldOps;
 use super::fri::FriOps;
 use super::pcs::quotients::QuotientOps;
 use super::poly::circle::PolyOps;
+use crate::core::fields::cm31::CM31;
 
 pub mod cpu;
 pub mod simd;
@@ -18,6 +19,7 @@ pub trait Backend:
     + Clone
     + Debug
     + FieldOps<BaseField>
+    + FieldOps<CM31>
     + FieldOps<SecureField>
     + PolyOps
     + QuotientOps

--- a/crates/prover/src/core/backend/simd/bit_reverse.rs
+++ b/crates/prover/src/core/backend/simd/bit_reverse.rs
@@ -1,9 +1,10 @@
 use std::array;
 
-use super::column::{BaseFieldVec, SecureFieldVec};
+use super::column::{BaseFieldVec, CM31Vec, SecureFieldVec};
 use super::m31::PackedBaseField;
 use super::SimdBackend;
 use crate::core::backend::ColumnOps;
+use crate::core::fields::cm31::CM31;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::utils::{bit_reverse as cpu_bit_reverse, bit_reverse_index};
@@ -25,6 +26,14 @@ impl ColumnOps<BaseField> for SimdBackend {
         }
 
         bit_reverse_m31(&mut column.data);
+    }
+}
+
+impl ColumnOps<CM31> for SimdBackend {
+    type Column = CM31Vec;
+
+    fn bit_reverse_column(_column: &mut CM31Vec) {
+        todo!()
     }
 }
 

--- a/crates/prover/src/core/backend/simd/cm31.rs
+++ b/crates/prover/src/core/backend/simd/cm31.rs
@@ -1,6 +1,7 @@
 use std::array;
 use std::ops::{Add, Mul, MulAssign, Neg, Sub};
 
+use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
 
 use super::m31::{PackedM31, N_LANES};
@@ -10,6 +11,14 @@ use crate::core::fields::FieldExpOps;
 /// SIMD implementation of [`CM31`].
 #[derive(Copy, Clone, Debug)]
 pub struct PackedCM31(pub [PackedM31; 2]);
+
+unsafe impl Pod for PackedCM31 {}
+
+unsafe impl Zeroable for PackedCM31 {
+    fn zeroed() -> Self {
+        unsafe { core::mem::zeroed() }
+    }
+}
 
 impl PackedCM31 {
     /// Constructs a new instance with all vector elements set to `value`.

--- a/crates/prover/src/core/backend/simd/column.rs
+++ b/crates/prover/src/core/backend/simd/column.rs
@@ -9,6 +9,7 @@ use super::m31::{PackedBaseField, N_LANES};
 use super::qm31::{PackedQM31, PackedSecureField};
 use super::SimdBackend;
 use crate::core::backend::{Column, CpuBackend};
+use crate::core::fields::cm31::CM31;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SecureColumn;
@@ -17,6 +18,12 @@ use crate::core::fields::{FieldExpOps, FieldOps};
 impl FieldOps<BaseField> for SimdBackend {
     fn batch_inverse(column: &BaseFieldVec, dst: &mut BaseFieldVec) {
         PackedBaseField::batch_inverse(&column.data, &mut dst.data);
+    }
+}
+
+impl FieldOps<CM31> for SimdBackend {
+    fn batch_inverse(column: &Self::Column, dst: &mut Self::Column) {
+        PackedCM31::batch_inverse(&column.data, &mut dst.data);
     }
 }
 
@@ -88,6 +95,65 @@ impl FromIterator<BaseField> for BaseFieldVec {
                 data.push(PackedBaseField::from_array(last));
             }
         }
+
+        Self { data, length }
+    }
+}
+
+/// An efficient structure for storing and operating on an arbitrary number of [`SecureField`]
+/// values.
+#[derive(Clone, Debug)]
+pub struct CM31Vec {
+    pub data: Vec<PackedCM31>,
+    pub length: usize,
+}
+
+impl Column<CM31> for CM31Vec {
+    fn zeros(length: usize) -> Self {
+        let data = vec![PackedCM31::zeroed(); length.div_ceil(N_LANES)];
+        Self { data, length }
+    }
+
+    fn to_cpu(&self) -> Vec<CM31> {
+        self.data
+            .iter()
+            .flat_map(|x| x.to_array())
+            .take(self.length)
+            .collect()
+    }
+
+    fn len(&self) -> usize {
+        self.length
+    }
+
+    fn at(&self, index: usize) -> CM31 {
+        self.data[index / N_LANES].to_array()[index % N_LANES]
+    }
+}
+
+impl FromIterator<CM31> for CM31Vec {
+    fn from_iter<I: IntoIterator<Item = CM31>>(iter: I) -> Self {
+        let mut chunks = iter.into_iter().array_chunks();
+        let mut data = (&mut chunks).map(PackedCM31::from_array).collect_vec();
+        let mut length = data.len() * N_LANES;
+
+        if let Some(remainder) = chunks.into_remainder() {
+            if !remainder.is_empty() {
+                length += remainder.len();
+                let mut last = [CM31::zero(); N_LANES];
+                last[..remainder.len()].copy_from_slice(remainder.as_slice());
+                data.push(PackedCM31::from_array(last));
+            }
+        }
+
+        Self { data, length }
+    }
+}
+
+impl FromIterator<PackedCM31> for CM31Vec {
+    fn from_iter<I: IntoIterator<Item = PackedCM31>>(iter: I) -> Self {
+        let data = (&mut iter.into_iter()).collect_vec();
+        let length = data.len() * N_LANES;
 
         Self { data, length }
     }

--- a/crates/prover/src/core/backend/simd/qm31.rs
+++ b/crates/prover/src/core/backend/simd/qm31.rs
@@ -198,6 +198,32 @@ impl Sub<PackedM31> for PackedQM31 {
     }
 }
 
+impl Add<PackedCM31> for PackedQM31 {
+    type Output = Self;
+
+    fn add(self, rhs: PackedCM31) -> Self::Output {
+        Self([self.a() + rhs, self.b()])
+    }
+}
+
+impl Mul<PackedCM31> for PackedQM31 {
+    type Output = Self;
+
+    fn mul(self, rhs: PackedCM31) -> Self::Output {
+        let Self([a, b]) = self;
+        Self([a * rhs, b * rhs])
+    }
+}
+
+impl Sub<PackedCM31> for PackedQM31 {
+    type Output = Self;
+
+    fn sub(self, rhs: PackedCM31) -> Self::Output {
+        let Self([a, b]) = self;
+        Self([a - rhs, b])
+    }
+}
+
 impl SubAssign for PackedQM31 {
     fn sub_assign(&mut self, rhs: Self) {
         *self = *self - rhs;

--- a/crates/prover/src/core/fields/mod.rs
+++ b/crates/prover/src/core/fields/mod.rs
@@ -152,6 +152,14 @@ pub trait ComplexConjugate {
     fn complex_conjugate(&self) -> Self;
 }
 
+pub trait ComplexOf<F: Field> {
+    /// Obtain the real part.
+    fn get_real(&self) -> F;
+
+    /// Obtain the imaginary part.
+    fn get_imag(&self) -> F;
+}
+
 pub trait ExtensionOf<F: Field>: Field + From<F> + NumOps<F> + NumAssignOps<F> {
     const EXTENSION_DEGREE: usize;
 }

--- a/crates/prover/src/core/fields/qm31.rs
+++ b/crates/prover/src/core/fields/qm31.rs
@@ -3,7 +3,7 @@ use std::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
-use super::{ComplexConjugate, FieldExpOps};
+use super::{ComplexConjugate, ComplexOf, FieldExpOps};
 use crate::core::fields::cm31::CM31;
 use crate::core::fields::m31::M31;
 use crate::{impl_extension_field, impl_field};
@@ -75,6 +75,32 @@ impl FieldExpOps for QM31 {
         let denom = self.0.square() - (b2 + b2 + ib2);
         let denom_inverse = denom.inverse();
         Self(self.0 * denom_inverse, -self.1 * denom_inverse)
+    }
+}
+
+impl ComplexOf<CM31> for QM31 {
+    fn get_real(&self) -> CM31 {
+        self.0
+    }
+
+    fn get_imag(&self) -> CM31 {
+        self.1
+    }
+}
+
+impl Add<CM31> for QM31 {
+    type Output = QM31;
+
+    fn add(self, rhs: CM31) -> Self::Output {
+        Self(self.0 + rhs, self.1)
+    }
+}
+
+impl Mul<CM31> for QM31 {
+    type Output = QM31;
+
+    fn mul(self, rhs: CM31) -> Self::Output {
+        Self(self.0 * rhs, self.1 * rhs)
     }
 }
 

--- a/crates/prover/src/core/pcs/quotients.rs
+++ b/crates/prover/src/core/pcs/quotients.rs
@@ -160,6 +160,7 @@ pub fn fri_answers_for_log_size(
                 &quotient_constants,
                 row,
                 domain_point,
+                random_coeff,
             );
             values.push(value);
         }


### PR DESCRIPTION
This PR includes some changes that allow stwo to use CM31 whenever possible when computing the quotients. I have tested the solution locally, yet it doesn't seem to have an amazing speedup. 

The best number of the new implementation is 3.26s. You can, however, get the similar number without this PR.

Therefore, this PR is left here for reference. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/699)
<!-- Reviewable:end -->
