### PR TITLE
Add explicit panic message to queries' size check in Fri verifier

### DIFF
--- a/crates/prover/src/core/fri.rs
+++ b/crates/prover/src/core/fri.rs
@@ -434,7 +434,10 @@ impl<H: MerkleHasher> FriVerifier<H> {
         queries: &Queries,
         decommitted_values: Vec<SparseCircleEvaluation>,
     ) -> Result<(), FriVerificationError> {
-        assert_eq!(queries.log_domain_size, self.expected_query_log_domain_size);
+        assert_eq!(
+            queries.log_domain_size, self.expected_query_log_domain_size,
+            "queries' domain size is invalid"
+        );
         assert_eq!(decommitted_values.len(), self.column_bounds.len());
 
         let (last_layer_queries, last_layer_query_evals) =
@@ -1425,7 +1428,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic = "queries' domain size is invalid"]
     fn decommit_queries_on_invalid_domain_fails_verification() {
         const LOG_DEGREE: u32 = 3;
         let evaluation = polynomial_evaluation(LOG_DEGREE, LOG_BLOWUP_FACTOR);


### PR DESCRIPTION
This is a small PR that adds an explicit error message to an assert and uses it in the test `decommit_queries_on_invalid_domain_fails_verification`.
The test is meant to panic on calling `decommit_on_queries` . This PR adds the message and makes the `should_panic` more specific to pass only in that case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/747)
<!-- Reviewable:end -->
