### PR TITLE
Rename `target_feature = "avx2f"` to `target_feature = "avx2"`

### DIFF
--- a/crates/prover/src/core/backend/simd/fft/mod.rs
+++ b/crates/prover/src/core/backend/simd/fft/mod.rs
@@ -111,7 +111,7 @@ fn mul_twiddle(v: PackedBaseField, twiddle_dbl: u32x16) -> PackedBaseField {
             crate::core::backend::simd::m31::_mul_doubled_wasm(v, twiddle_dbl)
         } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))] {
             crate::core::backend::simd::m31::_mul_doubled_avx512(v, twiddle_dbl)
-        } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx2f"))] {
+        } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))] {
             crate::core::backend::simd::m31::_mul_doubled_avx2(v, twiddle_dbl)
         } else {
             crate::core::backend::simd::m31::_mul_doubled_simd(v, twiddle_dbl)

--- a/crates/prover/src/core/backend/simd/m31.rs
+++ b/crates/prover/src/core/backend/simd/m31.rs
@@ -148,7 +148,7 @@ impl Mul for PackedM31 {
                 _mul_wasm(self, rhs)
             } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))] {
                 _mul_avx512(self, rhs)
-            } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx2f"))] {
+            } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))] {
                 _mul_avx2(self, rhs)
             } else {
                 _mul_simd(self, rhs)


### PR DESCRIPTION
There is no `avx2f` in the list of target-features `rustc --print target-features`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/783)
<!-- Reviewable:end -->
