### PR TITLE
Remove InteractionElements and LookupValues

### DIFF
--- a/crates/prover/src/constraint_framework/logup.rs
+++ b/crates/prover/src/constraint_framework/logup.rs
@@ -236,10 +236,7 @@ impl LogupTraceGenerator {
             .into_iter()
             .flat_map(|eval| {
                 eval.columns.map(|c| {
-                    CircleEvaluation::<SimdBackend, _, BitReversedOrder>::new(
-                        CanonicCoset::new(self.log_size).circle_domain(),
-                        c,
-                    )
+                    CircleEvaluation::new(CanonicCoset::new(self.log_size).circle_domain(), c)
                 })
             })
             .collect_vec();

--- a/crates/prover/src/core/backend/simd/quotients.rs
+++ b/crates/prover/src/core/backend/simd/quotients.rs
@@ -282,13 +282,8 @@ mod tests {
         }];
         let cpu_columns = columns
             .iter()
-            .map(|c| {
-                CircleEvaluation::<CpuBackend, _, BitReversedOrder>::new(
-                    c.domain,
-                    c.values.to_cpu(),
-                )
-            })
-            .collect::<Vec<_>>();
+            .map(|c| CircleEvaluation::new(c.domain, c.values.to_cpu()))
+            .collect_vec();
         let cpu_result = CpuBackend::accumulate_quotients(
             domain,
             &cpu_columns.iter().collect_vec(),

--- a/crates/prover/src/core/pcs/prover.rs
+++ b/crates/prover/src/core/pcs/prover.rs
@@ -167,30 +167,28 @@ pub struct TreeBuilder<'a, 'b, B: BackendForChannel<MC>, MC: MerkleChannel> {
 impl<'a, 'b, B: BackendForChannel<MC>, MC: MerkleChannel> TreeBuilder<'a, 'b, B, MC> {
     pub fn extend_evals(
         &mut self,
-        columns: ColumnVec<CircleEvaluation<B, BaseField, BitReversedOrder>>,
+        columns: impl IntoIterator<Item = CircleEvaluation<B, BaseField, BitReversedOrder>>,
     ) -> TreeSubspan {
         let span = span!(Level::INFO, "Interpolation for commitment").entered();
-        let col_start = self.polys.len();
         let polys = columns
             .into_iter()
             .map(|eval| eval.interpolate_with_twiddles(self.commitment_scheme.twiddles))
             .collect_vec();
         span.exit();
-        self.polys.extend(polys);
-        TreeSubspan {
-            tree_index: self.tree_index,
-            col_start,
-            col_end: self.polys.len(),
-        }
+        self.extend_polys(polys)
     }
 
-    pub fn extend_polys(&mut self, polys: ColumnVec<CirclePoly<B>>) -> TreeSubspan {
+    pub fn extend_polys(
+        &mut self,
+        columns: impl IntoIterator<Item = CirclePoly<B>>,
+    ) -> TreeSubspan {
         let col_start = self.polys.len();
-        self.polys.extend(polys);
+        self.polys.extend(columns);
+        let col_end = self.polys.len();
         TreeSubspan {
             tree_index: self.tree_index,
             col_start,
-            col_end: self.polys.len(),
+            col_end,
         }
     }
 

--- a/crates/prover/src/core/poly/circle/secure_poly.rs
+++ b/crates/prover/src/core/poly/circle/secure_poly.rs
@@ -43,6 +43,10 @@ impl<B: PolyOps> SecureCirclePoly<B> {
         let columns = polys.map(|poly| poly.evaluate_with_twiddles(domain, twiddles).values);
         SecureEvaluation::new(domain, SecureColumnByCoords { columns })
     }
+
+    pub fn into_coordinate_polys(self) -> [CirclePoly<B>; SECURE_EXTENSION_DEGREE] {
+        self.0
+    }
 }
 
 impl<B: FieldOps<BaseField>> Deref for SecureCirclePoly<B> {

--- a/crates/prover/src/examples/blake/air.rs
+++ b/crates/prover/src/examples/blake/air.rs
@@ -389,9 +389,7 @@ where
 
     // Prove constraints.
     let components = BlakeComponents::new(&stmt0, &all_elements, &stmt1);
-    let stark_proof =
-        prove::<SimdBackend, _>(&components.component_provers(), channel, commitment_scheme)
-            .unwrap();
+    let stark_proof = prove(&components.component_provers(), channel, commitment_scheme).unwrap();
 
     BlakeProof {
         stmt0,

--- a/crates/prover/src/examples/blake/round/gen.rs
+++ b/crates/prover/src/examples/blake/round/gen.rs
@@ -230,8 +230,8 @@ pub fn generate_trace(
         generator
             .trace
             .into_iter()
-            .map(|eval| CircleEvaluation::<SimdBackend, _, BitReversedOrder>::new(domain, eval))
-            .collect_vec(),
+            .map(|eval| CircleEvaluation::new(domain, eval))
+            .collect(),
         BlakeRoundLookupData {
             xor_lookups: generator.xor_lookups,
             round_lookup: generator.round_lookup,

--- a/crates/prover/src/examples/blake/scheduler/gen.rs
+++ b/crates/prover/src/examples/blake/scheduler/gen.rs
@@ -107,8 +107,8 @@ pub fn gen_trace(
     let domain = CanonicCoset::new(log_size).circle_domain();
     let trace = trace
         .into_iter()
-        .map(|eval| CircleEvaluation::<SimdBackend, _, BitReversedOrder>::new(domain, eval))
-        .collect_vec();
+        .map(|eval| CircleEvaluation::new(domain, eval))
+        .collect();
 
     (trace, lookup_data, round_inputs)
 }

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -278,8 +278,8 @@ pub fn gen_trace(
     let domain = CanonicCoset::new(log_size).circle_domain();
     let trace = trace
         .into_iter()
-        .map(|eval| CircleEvaluation::<SimdBackend, _, BitReversedOrder>::new(domain, eval))
-        .collect_vec();
+        .map(|eval| CircleEvaluation::new(domain, eval))
+        .collect();
     (trace, lookup_data)
 }
 
@@ -367,7 +367,8 @@ pub fn prove_poseidon(
             claimed_sum,
         },
     );
-    let proof = prove::<SimdBackend, _>(&[&component], channel, commitment_scheme).unwrap();
+    let proof = prove(&[&component], channel, commitment_scheme).unwrap();
+
     (component, proof)
 }
 


### PR DESCRIPTION
InteractionElements removed in favour of storing interaction elements the components directly with LookupElements.  LookupValues removed in favour of storing lookup values on a claim struct.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/802)
<!-- Reviewable:end -->
