### PR TITLE
Change the starting point of logup elements

### DIFF
--- a/crates/prover/src/constraint_framework/logup.rs
+++ b/crates/prover/src/constraint_framework/logup.rs
@@ -251,9 +251,9 @@ mod tests {
     use super::{LogupAtRow, LookupElements};
     use crate::constraint_framework::InfoEvaluator;
     use crate::core::channel::Blake2sChannel;
-    use crate::core::fields::FieldExpOps;
     use crate::core::fields::m31::BaseField;
     use crate::core::fields::qm31::SecureField;
+    use crate::core::fields::FieldExpOps;
     use crate::core::lookups::utils::Fraction;
 
     #[test]

--- a/crates/prover/src/constraint_framework/logup.rs
+++ b/crates/prover/src/constraint_framework/logup.rs
@@ -1,6 +1,6 @@
 use std::ops::{Mul, Sub};
 
-use itertools::Itertools;
+use itertools::{zip_eq, Itertools};
 use num_traits::{One, Zero};
 
 use super::EvalAtRow;
@@ -109,14 +109,9 @@ impl<const N: usize> LookupElements<N> {
     where
         EF: Copy + Zero + From<F> + From<SecureField> + Mul<F, Output = EF> + Sub<EF, Output = EF>,
     {
-        EF::from(values[0])
-            + values[1..]
-                .iter()
-                .zip(self.alpha_powers.iter())
-                .fold(EF::zero(), |acc, (&value, &power)| {
-                    acc + EF::from(power) * value
-                })
-            - EF::from(self.z)
+        zip_eq(values, self.alpha_powers).fold(EF::zero(), |acc, (&value, power)| {
+            acc + EF::from(power) * value
+        }) - EF::from(self.z)
     }
     // TODO(spapini): Try to remove this.
     pub fn dummy() -> Self {

--- a/crates/prover/src/constraint_framework/logup.rs
+++ b/crates/prover/src/constraint_framework/logup.rs
@@ -248,8 +248,11 @@ impl<'a> LogupColGenerator<'a> {
 mod tests {
     use num_traits::One;
 
-    use super::LogupAtRow;
+    use super::{LogupAtRow, LookupElements};
     use crate::constraint_framework::InfoEvaluator;
+    use crate::core::channel::Blake2sChannel;
+    use crate::core::fields::FieldExpOps;
+    use crate::core::fields::m31::BaseField;
     use crate::core::fields::qm31::SecureField;
     use crate::core::lookups::utils::Fraction;
 
@@ -260,6 +263,25 @@ mod tests {
         logup.write_frac(
             &mut InfoEvaluator::default(),
             Fraction::new(SecureField::one(), SecureField::one()),
+        );
+    }
+
+    #[test]
+    fn test_lookup_elements_combine() {
+        let mut channel = Blake2sChannel::default();
+        let lookup_elements = LookupElements::<3>::draw(&mut channel);
+        let values = [
+            BaseField::from_u32_unchecked(123),
+            BaseField::from_u32_unchecked(456),
+            BaseField::from_u32_unchecked(789),
+        ];
+
+        assert_eq!(
+            lookup_elements.combine::<BaseField, SecureField>(&values),
+            BaseField::from_u32_unchecked(123)
+                + BaseField::from_u32_unchecked(456) * lookup_elements.alpha
+                + BaseField::from_u32_unchecked(789) * lookup_elements.alpha.pow(2)
+                - lookup_elements.z
         );
     }
 }

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -43,7 +43,7 @@ const INTERNAL_ROUND_CONSTS: [BaseField; N_PARTIAL_ROUNDS] =
 
 pub type PoseidonComponent = FrameworkComponent<PoseidonEval>;
 
-pub type PoseidonElements = LookupElements<{ N_STATE * 2 }>;
+pub type PoseidonElements = LookupElements<N_STATE>;
 
 #[derive(Clone)]
 pub struct PoseidonEval {


### PR DESCRIPTION
This PR changes how the alpha powers are being applied to the values. In addition, the number of lookup elements needed for the Poseidon example is indeed only N_STATE rather than N_STATE * 2 as previously defined.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo/837)
<!-- Reviewable:end -->
