### PR TITLE
Add next_preprocessed_mask()

### DIFF
--- a/crates/prover/src/constraint_framework/info.rs
+++ b/crates/prover/src/constraint_framework/info.rs
@@ -33,7 +33,7 @@ impl EvalAtRow for InfoEvaluator {
     ) -> [Self::F; N] {
         assert!(
             interaction != PREPROCESSED_TRACE_IDX,
-            "Preprocessed should be accesses with `get_preprocessed_column`",
+            "Preprocessed should be accesses with `next_preprocessed_mask`",
         );
 
         // Check if requested a mask from a new interaction
@@ -45,9 +45,13 @@ impl EvalAtRow for InfoEvaluator {
         [BaseField::one(); N]
     }
 
-    fn get_preprocessed_column(&mut self, column: PreprocessedColumn) -> Self::F {
+    fn next_preprocessed_mask<const N: usize>(
+        &mut self,
+        column: PreprocessedColumn,
+        _offsets: [isize; N],
+    ) -> [Self::F; N] {
         self.preprocessed_columns.push(column);
-        BaseField::one()
+        [BaseField::one(); N]
     }
 
     fn add_constraint<G>(&mut self, _constraint: G)

--- a/crates/prover/src/constraint_framework/mod.rs
+++ b/crates/prover/src/constraint_framework/mod.rs
@@ -76,9 +76,9 @@ pub trait EvalAtRow {
         mask_item
     }
 
-    fn get_preprocessed_column(&mut self, _column: PreprocessedColumn) -> Self::F {
-        let [mask_item] = self.next_interaction_mask(PREPROCESSED_TRACE_IDX, [0]);
-        mask_item
+    fn get_preprocessed_column(&mut self, column: PreprocessedColumn) -> Self::F {
+        let [ret] = self.next_preprocessed_mask(column, [0]);
+        ret
     }
 
     /// Returns the mask values of the given offsets for the next column in the interaction.
@@ -87,6 +87,14 @@ pub trait EvalAtRow {
         interaction: usize,
         offsets: [isize; N],
     ) -> [Self::F; N];
+
+    fn next_preprocessed_mask<const N: usize>(
+        &mut self,
+        _column: PreprocessedColumn,
+        offsets: [isize; N],
+    ) -> [Self::F; N] {
+        self.next_interaction_mask(PREPROCESSED_TRACE_IDX, offsets)
+    }
 
     /// Returns the extension mask values of the given offsets for the next extension degree many
     /// columns in the interaction.


### PR DESCRIPTION
This commit adds `next_preprocessed_mask()` to `EvalAtRow` interface. In most cases it's just a thin wrapper over `next_interaction_mask()`. However, in `InfoEvaluator`, `next_preprocessed_mask()` is the only way to access rows except the current one.

**Motivation**

I wanted to use the `IsFirst` column to get both `[is_first, is_last]` by looking at the current row and the next row. An assertion in  `InfoEvaluator::next_interaction_mask()` failed with an error message: use `get_preprocessed_column()`.

However, `get_preprocessed_column()` didn't have access to the next row, so this change.