### PR TITLE
add Clone method to StarkProof

### DIFF
--- a/crates/prover/src/core/fri.rs
+++ b/crates/prover/src/core/fri.rs
@@ -607,7 +607,7 @@ impl LinePolyDegreeBound {
 }
 
 /// A FRI proof.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize,Clone)]
 pub struct FriProof<H: MerkleHasher> {
     pub inner_layers: Vec<FriLayerProof<H>>,
     pub last_layer_poly: LinePoly,
@@ -623,7 +623,7 @@ pub const CIRCLE_TO_LINE_FOLD_STEP: u32 = 1;
 /// Stores a subset of evaluations in a fri layer with their corresponding merkle decommitments.
 ///
 /// The subset corresponds to the set of evaluations needed by a FRI verifier.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize,Clone)]
 pub struct FriLayerProof<H: MerkleHasher> {
     /// The subset stored corresponds to the set of evaluations the verifier doesn't have but needs
     /// to fold and verify the merkle decommitment.

--- a/crates/prover/src/core/pcs/prover.rs
+++ b/crates/prover/src/core/pcs/prover.rs
@@ -149,7 +149,7 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize,Clone)]
 pub struct CommitmentSchemeProof<H: MerkleHasher> {
     pub sampled_values: TreeVec<ColumnVec<Vec<SecureField>>>,
     pub decommitments: TreeVec<MerkleDecommitment<H>>,

--- a/crates/prover/src/core/prover/mod.rs
+++ b/crates/prover/src/core/prover/mod.rs
@@ -22,7 +22,7 @@ use crate::core::vcs::hash::Hash;
 use crate::core::vcs::prover::MerkleDecommitment;
 use crate::core::vcs::verifier::MerkleVerificationError;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize,Clone)]
 pub struct StarkProof<H: MerkleHasher> {
     pub commitments: TreeVec<H::Hash>,
     pub commitment_scheme_proof: CommitmentSchemeProof<H>,


### PR DESCRIPTION
**Description**:  
This PR adds a `Clone` implementation for `StarkProof`. In my current project, I need the ability to duplicate `StarkProof` instances to simplify reuse in scenarios where moving it once isn’t sufficient. Specifically, I am implementing a prover and want to check the proof as a sanity check inside prover before actually sending the proof to my verifier.

**Uncertainty**:  
I haven’t identified a specific reason why `Clone` wasn’t implemented initially, and I recognize there might be design considerations or resource management concerns behind that choice. There are potential issues or constraints I might have missed. 

**Request**:  
If adding `Clone` is acceptable within the project’s design, this small change could improve usability for cases like mine. However, if `Clone` is not desired for any reason, I’m open to finding alternative approaches to handle this in my project—though having `Clone` would definitely make things easier! 😊

