### PR TITLE
Avoid filtering out unused columns.

### DIFF
--- a/crates/prover/src/core/pcs/verifier.rs
+++ b/crates/prover/src/core/pcs/verifier.rs
@@ -63,18 +63,14 @@ impl<MC: MerkleChannel> CommitmentSchemeVerifier<MC> {
 
         let bounds = self
             .column_log_sizes()
-            .zip_cols(&sampled_points)
-            .map_cols(|(log_size, sampled_points)| {
-                vec![
-                    CirclePolyDegreeBound::new(log_size - self.config.fri_config.log_blowup_factor);
-                    sampled_points.len()
-                ]
-            })
-            .flatten_cols()
+            .flatten()
             .into_iter()
             .sorted()
             .rev()
             .dedup()
+            .map(|log_size| {
+                CirclePolyDegreeBound::new(log_size - self.config.fri_config.log_blowup_factor)
+            })
             .collect_vec();
 
         // FRI commitment phase on OODS quotients.


### PR DESCRIPTION
The prover does not filter them out.