### PR TITLE
type conversion (#880)

### DIFF
--- a/crates/prover/src/constraint_framework/mod.rs
+++ b/crates/prover/src/constraint_framework/mod.rs
@@ -243,25 +243,26 @@ impl<'a, F: Clone, EF: RelationEFTraitBound<F>, R: Relation<F, EF>> RelationEntr
     }
 }
 
+#[macro_export]
 macro_rules! relation {
     ($name:tt, $size:tt) => {
         #[derive(Clone, Debug, PartialEq)]
-        pub struct $name(crate::constraint_framework::logup::LookupElements<$size>);
+        pub struct $name($crate::constraint_framework::logup::LookupElements<$size>);
 
         #[allow(dead_code)]
         impl $name {
             pub fn dummy() -> Self {
-                Self(crate::constraint_framework::logup::LookupElements::dummy())
+                Self($crate::constraint_framework::logup::LookupElements::dummy())
             }
-            pub fn draw(channel: &mut impl crate::core::channel::Channel) -> Self {
-                Self(crate::constraint_framework::logup::LookupElements::draw(
+            pub fn draw(channel: &mut impl $crate::core::channel::Channel) -> Self {
+                Self($crate::constraint_framework::logup::LookupElements::draw(
                     channel,
                 ))
             }
         }
 
-        impl<F: Clone, EF: crate::constraint_framework::RelationEFTraitBound<F>>
-            crate::constraint_framework::Relation<F, EF> for $name
+        impl<F: Clone, EF: $crate::constraint_framework::RelationEFTraitBound<F>>
+            $crate::constraint_framework::Relation<F, EF> for $name
         {
             fn combine(&self, values: &[F]) -> EF {
                 values


### PR DESCRIPTION
type conversion (#880)

Co-Authored-By: ilyalesokhin-starkware <ilya@starkware.co>

Rename Constant trace -> Preprocessed trace. (#881)

Remove unused mutability. (#885)

Added LogupAtRow functionality to EvalAtRow. (#875)

Avoid filtering out unused columns. (#886)

The prover does not filter them out.

Abstracted `eval.write_frac`s to `eval.add_to_relation`s. (#876)

Initialize logups automatically when first used. (#879)

Formal Expr logup variables. (#887)

Expr formatting. (#888)

State machine constraint string. (#889)

Separated Xor table types. (#883)

Remove redundant `collect` in framework. (#896)

Add arithmetic op counts to InfoEvaluator (#832)

Make CommitmentSchemeProver::prove_values take ownership (#852)

Add gen_preprocessed_columns. (#891)

Added total_ and claimed_sums as formal variables in ExprEvaluator. (#892)

SIMD backend for poseidon252 merkle ops - CPU IMPL