### PR TITLE
miri; fix unsafe ub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly-2024-01-04 doc
 
+  ub-detection:
+    if: github.event.pull_request.draft == false
+    name: Check for undefined behaviour (UB)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-01-04
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo miri test
+
   run-wasm32-wasi-tests:
     runs-on: ubuntu-latest
     steps:

--- a/crates/prover/src/core/backend/simd/circle.rs
+++ b/crates/prover/src/core/backend/simd/circle.rs
@@ -136,7 +136,7 @@ impl PolyOps for SimdBackend {
         values: Col<Self, BaseField>,
     ) -> CircleEvaluation<Self, BaseField, BitReversedOrder> {
         // TODO(Ohad): Optimize.
-        let eval = CpuBackend::new_canonical_ordered(coset, values.into_cpu_vec());
+        let eval = CpuBackend::new_canonical_ordered(coset, values.as_slice().to_vec());
         CircleEvaluation::new(
             eval.domain,
             Col::<SimdBackend, BaseField>::from_iter(eval.values),
@@ -421,6 +421,7 @@ mod tests {
     use crate::core::poly::{BitReversedOrder, NaturalOrder};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_interpolate_and_eval() {
         for log_size in MIN_FFT_LOG_SIZE..CACHED_FFT_LOG_SIZE + 4 {
             let domain = CanonicCoset::new(log_size).circle_domain();
@@ -437,6 +438,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eval_extension() {
         for log_size in MIN_FFT_LOG_SIZE..CACHED_FFT_LOG_SIZE + 2 {
             let domain = CanonicCoset::new(log_size).circle_domain();
@@ -457,6 +459,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eval_at_point() {
         for log_size in MIN_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 4 {
             let domain = CanonicCoset::new(log_size).circle_domain();
@@ -480,6 +483,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_circle_poly_extend() {
         for log_size in MIN_FFT_LOG_SIZE..CACHED_FFT_LOG_SIZE + 2 {
             let poly =
@@ -495,6 +499,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_eval_securefield() {
         let mut rng = SmallRng::seed_from_u64(0);
         for log_size in MIN_FFT_LOG_SIZE..CACHED_FFT_LOG_SIZE + 2 {
@@ -515,6 +520,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_optimized_precompute_twiddles() {
         let coset = CanonicCoset::new(10).half_coset();
         let twiddles = SimdBackend::precompute_twiddles(coset);

--- a/crates/prover/src/core/backend/simd/cm31.rs
+++ b/crates/prover/src/core/backend/simd/cm31.rs
@@ -205,6 +205,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
         let lhs = rng.gen();

--- a/crates/prover/src/core/backend/simd/column.rs
+++ b/crates/prover/src/core/backend/simd/column.rs
@@ -1,5 +1,5 @@
+use std::array;
 use std::iter::zip;
-use std::{array, mem};
 
 use bytemuck::allocation::cast_vec;
 use bytemuck::{cast_slice, cast_slice_mut, Zeroable};
@@ -49,15 +49,6 @@ impl BaseColumn {
     /// Extracts a mutable slice containing the entire vector of [`BaseField`]s.
     pub fn as_mut_slice(&mut self) -> &mut [BaseField] {
         &mut cast_slice_mut(&mut self.data)[..self.length]
-    }
-
-    pub fn into_cpu_vec(mut self) -> Vec<BaseField> {
-        let capacity = self.data.capacity() * N_LANES;
-        let length = self.length;
-        let ptr = self.data.as_mut_ptr() as *mut BaseField;
-        let res = unsafe { Vec::from_raw_parts(ptr, length, capacity) };
-        mem::forget(self);
-        res
     }
 
     pub fn from_cpu(values: Vec<BaseField>) -> Self {

--- a/crates/prover/src/core/backend/simd/domain.rs
+++ b/crates/prover/src/core/backend/simd/domain.rs
@@ -67,6 +67,7 @@ impl Iterator for CircleDomainBitRevIterator {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_circle_domain_bit_rev_iterator() {
     let domain = CircleDomain::new(crate::core::circle::Coset::new(
         crate::core::circle::CirclePointIndex::generator(),

--- a/crates/prover/src/core/backend/simd/fft/ifft.rs
+++ b/crates/prover/src/core/backend/simd/fft/ifft.rs
@@ -567,6 +567,7 @@ mod tests {
     use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_ibutterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
         let mut v0: [BaseField; N_LANES] = rng.gen();
@@ -585,6 +586,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_ifft3() {
         let mut rng = SmallRng::seed_from_u64(0);
         let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
@@ -645,6 +647,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_vecwise_ibutterflies() {
         let domain = CanonicCoset::new(5).circle_domain();
         let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
@@ -668,6 +671,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_ifft_lower_with_vecwise() {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
@@ -690,6 +694,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_ifft_full() {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();

--- a/crates/prover/src/core/backend/simd/fft/rfft.rs
+++ b/crates/prover/src/core/backend/simd/fft/rfft.rs
@@ -593,6 +593,7 @@ mod tests {
     use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_butterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
         let mut v0: [BaseField; N_LANES] = rng.gen();
@@ -611,6 +612,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_fft3() {
         let mut rng = SmallRng::seed_from_u64(0);
         let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
@@ -672,6 +674,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_vecwise_butterflies() {
         let domain = CanonicCoset::new(5).circle_domain();
         let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
@@ -699,6 +702,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_fft_lower() {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
@@ -722,6 +726,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_fft_full() {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();

--- a/crates/prover/src/core/backend/simd/fri.rs
+++ b/crates/prover/src/core/backend/simd/fri.rs
@@ -183,6 +183,7 @@ mod tests {
     use crate::qm31;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_fold_line() {
         const LOG_SIZE: u32 = 7;
         let mut rng = SmallRng::seed_from_u64(0);
@@ -205,6 +206,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_fold_circle_into_line() {
         const LOG_SIZE: u32 = 7;
         let values: Vec<SecureField> = (0..(1 << LOG_SIZE))
@@ -239,6 +241,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn decomposition_test() {
         const DOMAIN_LOG_SIZE: u32 = 5;
         const DOMAIN_LOG_HALF_SIZE: u32 = DOMAIN_LOG_SIZE - 1;

--- a/crates/prover/src/core/backend/simd/lookups/gkr.rs
+++ b/crates/prover/src/core/backend/simd/lookups/gkr.rs
@@ -526,6 +526,7 @@ mod tests {
     use crate::core::test_utils::test_channel;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn gen_eq_evals_matches_cpu() {
         let two = BaseField::from(2).into();
         let y = [7, 3, 5, 6, 1, 1, 9].map(|v| BaseField::from(v).into());
@@ -548,6 +549,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn grand_product_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let values = test_channel().draw_felts(N);
@@ -571,6 +573,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn logup_with_generic_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
@@ -610,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn logup_with_multiplicities_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
@@ -649,6 +653,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn logup_with_singles_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);

--- a/crates/prover/src/core/backend/simd/lookups/mle.rs
+++ b/crates/prover/src/core/backend/simd/lookups/mle.rs
@@ -103,6 +103,7 @@ mod tests {
     use crate::core::test_utils::test_channel;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fix_first_variable_with_secure_field_mle_matches_cpu() {
         const N_VARIABLES: u32 = 8;
         let values = test_channel().draw_felts(1 << N_VARIABLES);
@@ -117,6 +118,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn fix_first_variable_with_base_field_mle_matches_cpu() {
         const N_VARIABLES: u32 = 8;
         let values = (0..1 << N_VARIABLES).map(BaseField::from).collect_vec();

--- a/crates/prover/src/core/backend/simd/m31.rs
+++ b/crates/prover/src/core/backend/simd/m31.rs
@@ -7,6 +7,7 @@ use std::simd::{u32x16, Simd, Swizzle};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
+#[cfg(test)]
 use rand::distributions::{Distribution, Standard};
 
 use super::qm31::PackedQM31;
@@ -274,6 +275,7 @@ impl From<BaseField> for PackedM31 {
     }
 }
 
+#[cfg(test)]
 impl Distribution<PackedM31> for Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedM31 {
         PackedM31::from_array(rng.gen())
@@ -611,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
         let lhs = rng.gen();
@@ -654,6 +657,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inverse_works() {
         let mut rng = SmallRng::seed_from_u64(0);
         let values = rng.gen();

--- a/crates/prover/src/core/backend/simd/prefix_sum.rs
+++ b/crates/prover/src/core/backend/simd/prefix_sum.rs
@@ -121,12 +121,12 @@ fn down_sweep_val<F: Sub<Output = F> + Copy>(lo: &mut F, hi: &mut F) {
 }
 
 fn inclusive_prefix_sum_slow(
-    bit_rev_circle_domain_evals: Col<SimdBackend, BaseField>,
+    mut bit_rev_circle_domain_evals: Col<SimdBackend, BaseField>,
 ) -> Col<SimdBackend, BaseField> {
     // Obtain values in coset order.
-    let mut coset_order_eval = bit_rev_circle_domain_evals.into_cpu_vec();
-    bit_reverse(&mut coset_order_eval);
-    coset_order_eval = circle_domain_order_to_coset_order(&coset_order_eval);
+    let coset_order_eval = bit_rev_circle_domain_evals.as_mut_slice();
+    bit_reverse(coset_order_eval);
+    let coset_order_eval = circle_domain_order_to_coset_order(coset_order_eval);
     let coset_order_prefix_sum = coset_order_eval
         .into_iter()
         .scan(BaseField::zero(), |acc, v| {
@@ -150,9 +150,7 @@ mod tests {
     use crate::core::backend::simd::prefix_sum::inclusive_prefix_sum_slow;
     use crate::core::backend::Column;
 
-    #[test]
-    fn exclusive_prefix_sum_simd_with_log_size_3_works() {
-        const LOG_N: u32 = 3;
+    fn exclusive_prefix_sum_simd_with_log_size_n_works<const LOG_N: u32>() {
         let mut rng = SmallRng::seed_from_u64(0);
         let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
@@ -160,29 +158,20 @@ mod tests {
         let res = inclusive_prefix_sum(evals);
 
         assert_eq!(res.to_cpu(), expected.to_cpu());
+    }
+
+    #[test]
+    fn exclusive_prefix_sum_simd_with_log_size_3_works() {
+        exclusive_prefix_sum_simd_with_log_size_n_works::<3>();
     }
 
     #[test]
     fn exclusive_prefix_sum_simd_with_log_size_6_works() {
-        const LOG_N: u32 = 6;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
-        let expected = inclusive_prefix_sum_slow(evals.clone());
-
-        let res = inclusive_prefix_sum(evals);
-
-        assert_eq!(res.to_cpu(), expected.to_cpu());
+        exclusive_prefix_sum_simd_with_log_size_n_works::<6>();
     }
 
     #[test]
     fn exclusive_prefix_sum_simd_with_log_size_8_works() {
-        const LOG_N: u32 = 8;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
-        let expected = inclusive_prefix_sum_slow(evals.clone());
-
-        let res = inclusive_prefix_sum(evals);
-
-        assert_eq!(res.to_cpu(), expected.to_cpu());
+        exclusive_prefix_sum_simd_with_log_size_n_works::<8>();
     }
 }

--- a/crates/prover/src/core/backend/simd/qm31.rs
+++ b/crates/prover/src/core/backend/simd/qm31.rs
@@ -4,6 +4,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
+#[cfg(test)]
 use rand::distributions::{Distribution, Standard};
 
 use super::cm31::PackedCM31;
@@ -292,6 +293,7 @@ impl Neg for PackedQM31 {
     }
 }
 
+#[cfg(test)]
 impl Distribution<PackedQM31> for Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedQM31 {
         PackedQM31::from_array(rng.gen())
@@ -351,6 +353,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
         let lhs = rng.gen();

--- a/crates/prover/src/core/backend/simd/quotients.rs
+++ b/crates/prover/src/core/backend/simd/quotients.rs
@@ -277,6 +277,7 @@ mod tests {
     use crate::qm31;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_accumulate_quotients() {
         const LOG_SIZE: u32 = 8;
         const LOG_BLOWUP_FACTOR: u32 = 1;

--- a/crates/prover/src/core/fields/m31.rs
+++ b/crates/prover/src/core/fields/m31.rs
@@ -4,6 +4,7 @@ use std::ops::{
 };
 
 use bytemuck::{Pod, Zeroable};
+#[cfg(test)]
 use rand::distributions::{Distribution, Standard};
 use serde::{Deserialize, Serialize};
 
@@ -157,6 +158,7 @@ impl From<i32> for M31 {
     }
 }
 
+#[cfg(test)]
 impl Distribution<M31> for Standard {
     // Not intended for cryptographic use. Should only be used in tests and benchmarks.
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> M31 {

--- a/crates/prover/src/core/fields/mod.rs
+++ b/crates/prover/src/core/fields/mod.rs
@@ -280,6 +280,7 @@ macro_rules! impl_field {
 #[macro_export]
 macro_rules! impl_extension_field {
     ($field_name: ident, $extended_field_name: ty) => {
+        #[cfg(test)]
         use rand::distributions::{Distribution, Standard};
         use $crate::core::fields::ExtensionOf;
 
@@ -452,6 +453,7 @@ macro_rules! impl_extension_field {
             }
         }
 
+        #[cfg(test)]
         impl Distribution<$field_name> for Standard {
             // Not intended for cryptographic use. Should only be used in tests and benchmarks.
             fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $field_name {

--- a/crates/prover/src/core/utils.rs
+++ b/crates/prover/src/core/utils.rs
@@ -97,7 +97,7 @@ pub fn offset_bit_reversed_circle_domain_index(
 // the indices instead.
 pub(crate) fn circle_domain_order_to_coset_order(values: &[BaseField]) -> Vec<BaseField> {
     let n = values.len();
-    let mut coset_order = vec![];
+    let mut coset_order = Vec::with_capacity(n);
     for i in 0..(n / 2) {
         coset_order.push(values[i]);
         coset_order.push(values[n - 1 - i]);
@@ -106,8 +106,8 @@ pub(crate) fn circle_domain_order_to_coset_order(values: &[BaseField]) -> Vec<Ba
 }
 
 pub(crate) fn coset_order_to_circle_domain_order<F: Field>(values: &[F]) -> Vec<F> {
-    let mut circle_domain_order = Vec::with_capacity(values.len());
     let n = values.len();
+    let mut circle_domain_order = Vec::with_capacity(n);
     let half_len = n / 2;
     for i in 0..half_len {
         circle_domain_order.push(values[i << 1]);

--- a/crates/prover/src/examples/blake/air.rs
+++ b/crates/prover/src/examples/blake/air.rs
@@ -534,7 +534,7 @@ mod tests {
     use crate::examples::blake::air::{prove_blake, verify_blake};
 
     // Note: this test is slow. Only run in release.
-    #[cfg_attr(not(feature = "slow-tests"), ignore)]
+    #[cfg_attr(any(miri, not(feature = "slow-tests")), ignore)]
     #[test_log::test]
     fn test_simd_blake_prove() {
         // Note: To see time measurement, run test with

--- a/crates/prover/src/examples/blake/round/mod.rs
+++ b/crates/prover/src/examples/blake/round/mod.rs
@@ -66,6 +66,7 @@ mod tests {
     use crate::examples::blake::{BlakeXorElements, XorAccums};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_blake_round() {
         use crate::core::pcs::TreeVec;
 

--- a/crates/prover/src/examples/blake/scheduler/mod.rs
+++ b/crates/prover/src/examples/blake/scheduler/mod.rs
@@ -63,6 +63,7 @@ mod tests {
     use crate::examples::blake::scheduler::{BlakeElements, BlakeSchedulerEval};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_blake_scheduler() {
         use crate::core::pcs::TreeVec;
 

--- a/crates/prover/src/examples/blake/xor_table/mod.rs
+++ b/crates/prover/src/examples/blake/xor_table/mod.rs
@@ -162,6 +162,7 @@ mod tests {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_xor_table() {
         use crate::core::pcs::TreeVec;
 

--- a/crates/prover/src/examples/plonk/mod.rs
+++ b/crates/prover/src/examples/plonk/mod.rs
@@ -275,6 +275,7 @@ mod tests {
     use crate::examples::plonk::{prove_fibonacci_plonk, PlonkLookupElements};
 
     #[test_log::test]
+    #[cfg_attr(miri, ignore)]
     fn test_simd_plonk_prove() {
         // Get from environment variable:
         let log_n_instances = env::var("LOG_N_INSTANCES")

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -441,6 +441,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_apply_internal() {
         let mut state: [BaseField; 16] = (0..16)
             .map(|i| BaseField::from_u32_unchecked(i * 3 + 187))
@@ -461,6 +462,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_poseidon_constraints() {
         const LOG_N_ROWS: u32 = 8;
 
@@ -484,6 +486,7 @@ mod tests {
     }
 
     #[test_log::test]
+    #[cfg_attr(miri, ignore)]
     fn test_simd_poseidon_prove() {
         // Note: To see time measurement, run test with
         //   RUST_LOG_SPAN_EVENTS=enter,close RUST_LOG=info RUST_BACKTRACE=1 RUSTFLAGS="

--- a/crates/prover/src/examples/state_machine/gen.rs
+++ b/crates/prover/src/examples/state_machine/gen.rs
@@ -120,6 +120,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_gen_interaction_trace() {
         let log_size = 8;
         let inc_index = 1;

--- a/crates/prover/src/examples/state_machine/mod.rs
+++ b/crates/prover/src/examples/state_machine/mod.rs
@@ -200,6 +200,7 @@ mod tests {
     use crate::core::poly::circle::CanonicCoset;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_state_machine_constraints() {
         let log_n_rows = 8;
         let initial_state = [M31::zero(); STATE_SIZE];
@@ -240,6 +241,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_state_machine_claimed_sum() {
         let log_n_rows = 8;
         let config = PcsConfig::default();
@@ -263,6 +265,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_state_machine_prove() {
         let log_n_rows = 8;
         let config = PcsConfig::default();
@@ -277,6 +280,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_state_machine_constraint_repr() {
         let log_n_rows = 8;
         let initial_state = [M31::zero(); STATE_SIZE];

--- a/crates/prover/src/examples/wide_fibonacci/mod.rs
+++ b/crates/prover/src/examples/wide_fibonacci/mod.rs
@@ -136,6 +136,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_wide_fibonacci_constraints() {
         const LOG_N_INSTANCES: u32 = 6;
         let traces = TreeVec::new(vec![vec![], generate_test_trace(LOG_N_INSTANCES)]);
@@ -152,6 +153,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg_attr(miri, ignore)]
     fn test_wide_fibonacci_constraints_fails() {
         const LOG_N_INSTANCES: u32 = 6;
 
@@ -171,6 +173,7 @@ mod tests {
     }
 
     #[test_log::test]
+    #[cfg_attr(miri, ignore)]
     fn test_wide_fib_prove_with_blake() {
         for log_n_instances in 2..=6 {
             let config = PcsConfig::default();
@@ -228,6 +231,7 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(miri, ignore)]
     fn test_wide_fib_prove_with_poseidon() {
         const LOG_N_INSTANCES: u32 = 6;
         let config = PcsConfig::default();

--- a/crates/prover/src/examples/xor/gkr_lookups/accumulation.rs
+++ b/crates/prover/src/examples/xor/gkr_lookups/accumulation.rs
@@ -147,6 +147,7 @@ mod tests {
     use crate::examples::xor::gkr_lookups::accumulation::MleCollection;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn random_linear_combine_by_n_variables() {
         const SMALL_N_VARS: usize = 4;
         const LARGE_N_VARS: usize = 6;

--- a/crates/prover/src/examples/xor/gkr_lookups/mle_eval.rs
+++ b/crates/prover/src/examples/xor/gkr_lookups/mle_eval.rs
@@ -771,6 +771,7 @@ mod tests {
     use crate::examples::xor::gkr_lookups::mle_eval::eval_step_selector_with_offset;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn mle_eval_prover_component() -> Result<(), VerificationError> {
         const N_VARIABLES: usize = 8;
         const COEFFS_COL_TRACE: usize = 1;
@@ -845,6 +846,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn mle_eval_verifier_component() -> Result<(), VerificationError> {
         const N_VARIABLES: usize = 8;
         const COEFFS_COL_TRACE: usize = 1;
@@ -935,6 +937,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_mle_eval_constraints_with_log_size_5() {
         const N_VARIABLES: usize = 5;
         const COEFFS_COL_TRACE: usize = 0;
@@ -983,118 +986,61 @@ mod tests {
         )
     }
 
+    fn eq_constraints_with_n_variables<const N_VARIABLES: usize>() {
+        const EQ_EVAL_TRACE: usize = 0;
+        const AUX_TRACE: usize = 1;
+        let mut rng = SmallRng::seed_from_u64(0);
+        let mle = Mle::new(repeat(SecureField::one()).take(1 << N_VARIABLES).collect());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let mle_eval_point = MleEvalPoint::new(&eval_point);
+        let trace = build_trace(&mle, &eval_point, mle.eval_at_point(&eval_point));
+        let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
+        let is_first_col = [gen_is_first(N_VARIABLES as u32)];
+        let aux_trace = chain![carry_quotients_col, is_first_col].collect();
+        let traces = TreeVec::new(vec![trace, aux_trace]);
+        let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
+        let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
+
+        assert_constraints(
+            &trace_polys,
+            trace_domain,
+            |mut eval| {
+                let [carry_quotients_col_eval] =
+                    eval.next_extension_interaction_mask(AUX_TRACE, [0]);
+                let [is_first, is_second] = eval.next_interaction_mask(AUX_TRACE, [0, -1]);
+                eval_eq_constraints(
+                    EQ_EVAL_TRACE,
+                    &mut eval,
+                    &mle_eval_point,
+                    carry_quotients_col_eval,
+                    is_first,
+                    is_second,
+                );
+            },
+            (SecureField::zero(), None),
+        );
+    }
+
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn eq_constraints_with_4_variables() {
-        const N_VARIABLES: usize = 4;
-        const EQ_EVAL_TRACE: usize = 0;
-        const AUX_TRACE: usize = 1;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mle = Mle::new(repeat(SecureField::one()).take(1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
-        let mle_eval_point = MleEvalPoint::new(&eval_point);
-        let trace = build_trace(&mle, &eval_point, mle.eval_at_point(&eval_point));
-        let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
-        let is_first_col = [gen_is_first(N_VARIABLES as u32)];
-        let aux_trace = chain![carry_quotients_col, is_first_col].collect();
-        let traces = TreeVec::new(vec![trace, aux_trace]);
-        let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
-        let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
-
-        assert_constraints(
-            &trace_polys,
-            trace_domain,
-            |mut eval| {
-                let [carry_quotients_col_eval] =
-                    eval.next_extension_interaction_mask(AUX_TRACE, [0]);
-                let [is_first, is_second] = eval.next_interaction_mask(AUX_TRACE, [0, -1]);
-                eval_eq_constraints(
-                    EQ_EVAL_TRACE,
-                    &mut eval,
-                    &mle_eval_point,
-                    carry_quotients_col_eval,
-                    is_first,
-                    is_second,
-                );
-            },
-            (SecureField::zero(), None),
-        );
+        eq_constraints_with_n_variables::<4>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn eq_constraints_with_5_variables() {
-        const N_VARIABLES: usize = 5;
-        const EQ_EVAL_TRACE: usize = 0;
-        const AUX_TRACE: usize = 1;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mle = Mle::new(repeat(SecureField::one()).take(1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
-        let mle_eval_point = MleEvalPoint::new(&eval_point);
-        let trace = build_trace(&mle, &eval_point, mle.eval_at_point(&eval_point));
-        let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
-        let is_first_col = [gen_is_first(N_VARIABLES as u32)];
-        let aux_trace = chain![carry_quotients_col, is_first_col].collect();
-        let traces = TreeVec::new(vec![trace, aux_trace]);
-        let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
-        let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
-
-        assert_constraints(
-            &trace_polys,
-            trace_domain,
-            |mut eval| {
-                let [carry_quotients_col_eval] =
-                    eval.next_extension_interaction_mask(AUX_TRACE, [0]);
-                let [is_first, is_second] = eval.next_interaction_mask(AUX_TRACE, [0, -1]);
-                eval_eq_constraints(
-                    EQ_EVAL_TRACE,
-                    &mut eval,
-                    &mle_eval_point,
-                    carry_quotients_col_eval,
-                    is_first,
-                    is_second,
-                );
-            },
-            (SecureField::zero(), None),
-        );
+        eq_constraints_with_n_variables::<5>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn eq_constraints_with_8_variables() {
-        const N_VARIABLES: usize = 8;
-        const EQ_EVAL_TRACE: usize = 0;
-        const AUX_TRACE: usize = 1;
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mle = Mle::new(repeat(SecureField::one()).take(1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
-        let mle_eval_point = MleEvalPoint::new(&eval_point);
-        let trace = build_trace(&mle, &eval_point, mle.eval_at_point(&eval_point));
-        let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
-        let is_first_col = [gen_is_first(N_VARIABLES as u32)];
-        let aux_trace = chain![carry_quotients_col, is_first_col].collect();
-        let traces = TreeVec::new(vec![trace, aux_trace]);
-        let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
-        let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
-
-        assert_constraints(
-            &trace_polys,
-            trace_domain,
-            |mut eval| {
-                let [carry_quotients_col_eval] =
-                    eval.next_extension_interaction_mask(AUX_TRACE, [0]);
-                let [is_first, is_second] = eval.next_interaction_mask(AUX_TRACE, [0, -1]);
-                eval_eq_constraints(
-                    EQ_EVAL_TRACE,
-                    &mut eval,
-                    &mle_eval_point,
-                    carry_quotients_col_eval,
-                    is_first,
-                    is_second,
-                );
-            },
-            (SecureField::zero(), None),
-        );
+        eq_constraints_with_n_variables::<8>();
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inclusive_prefix_sum_constraints_with_log_size_5() {
         const LOG_SIZE: u32 = 5;
         let mut rng = SmallRng::seed_from_u64(0);
@@ -1117,6 +1063,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn eval_step_selector_with_offset_works() {
         const LOG_SIZE: u32 = 5;
         const OFFSET: usize = 1;
@@ -1132,6 +1079,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn eval_carry_quotient_col_works() {
         const N_VARIABLES: usize = 5;
         let mut rng = SmallRng::seed_from_u64(0);


### PR DESCRIPTION
- [ ] adding miri to ci to detect undefined behaviour (UB) as the codebase quite a lot unsafe code
- [ ] refactoring some tests along the way (to deduplicate the code)
- [ ] fixing UB behaviour by removing the method `into_cpu_vec` as it violates [the invariant ](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.from_raw_parts)of the same element alignment

![Screenshot 2024-11-29 at 09 16 25](https://github.com/user-attachments/assets/f9583802-ec89-46b4-8a77-b4bbe8ed1eb2)


The alignment invariant violation can be reproduced with the program (`cargo +nightly miri run`)

```rust
#![feature(portable_simd)]
#![feature(vec_into_raw_parts)]

use std::mem;
use std::simd::Simd;

fn main() {
    let array: [u32; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];

    let packed: Simd<u32, 16> = array.into();

    println!("PackedBaseField alignment: {} bytes", std::mem::align_of::<Simd<u32, 16>>());
    println!("BaseField alignment: {} bytes", std::mem::align_of::<u32>());

    let mut col = vec![packed];
    let capacity = col.capacity() * 16;
    let length = 8;
    let ptr = col.as_mut_ptr() as *mut u32; // aka BaseField

    let res = unsafe { Vec::from_raw_parts(ptr, length, capacity) };
    mem::forget(col);

    println!("{:?}", res)
}
```
