### PR TITLE
Fix typos

### DIFF
--- a/crates/prover/src/constraint_framework/component.rs
+++ b/crates/prover/src/constraint_framework/component.rs
@@ -153,7 +153,7 @@ impl<E: FrameworkEval> FrameworkComponent<E> {
                             PreprocessedColumnsAllocationMode::Static
                         ) {
                             panic!(
-                                "Preprocessed column {:?} is missing from static alloction",
+                                "Preprocessed column {:?} is missing from static allocation",
                                 col
                             );
                         }

--- a/crates/prover/src/constraint_framework/expr/degree.rs
+++ b/crates/prover/src/constraint_framework/expr/degree.rs
@@ -2,7 +2,7 @@
 /// variables.
 /// Computes the actual degree with the following caveats:
 ///     1. The constant expression 0 receives degree 0 like all other constants rather than the
-///        mathematically correcy -infinity. This means, for example, that expresisons of the
+///        mathematically correct -infinity. This means, for example, that expresisons of the
 ///        type 0 * expr will return degree deg expr. This should be mitigated by
 ///        simplification.
 ///     2. If expressions p and q cancel out under some operation, this will not be accounted

--- a/crates/prover/src/constraint_framework/expr/degree.rs
+++ b/crates/prover/src/constraint_framework/expr/degree.rs
@@ -2,7 +2,7 @@
 /// variables.
 /// Computes the actual degree with the following caveats:
 ///     1. The constant expression 0 receives degree 0 like all other constants rather than the
-///        mathematically correct -infinity. This means, for example, that expresisons of the
+///        mathematically correct -infinity. This means, for example, that expressions of the
 ///        type 0 * expr will return degree deg expr. This should be mitigated by
 ///        simplification.
 ///     2. If expressions p and q cancel out under some operation, this will not be accounted

--- a/crates/prover/src/examples/wide_fibonacci/mod.rs
+++ b/crates/prover/src/examples/wide_fibonacci/mod.rs
@@ -18,7 +18,7 @@ pub struct FibInput {
 }
 
 /// A component that enforces the Fibonacci sequence.
-/// Each row contains a seperate Fibonacci sequence of length `N`.
+/// Each row contains a separate Fibonacci sequence of length `N`.
 #[derive(Clone)]
 pub struct WideFibonacciEval<const N: usize> {
     pub log_n_rows: u32,


### PR DESCRIPTION
# Fix Typos in Multiple Files

## Description
This pull request fixes minor typos across three files in the repository to improve code readability and maintainability.

## Changes Made
1. **File:** `component.rs`  
   - Fixed a typo in the error message:  
     **Before:** `"Preprocessed column {:?} is missing from static alloction"`  
     **After:** `"Preprocessed column {:?} is missing from static allocation"`

2. **File:** `degree.rs`  
   - Fixed a typo in the comment:  
     **Before:** `"mathematically correcy -infinity. This means, for example, that expresisons of the"`  
     **After:** `"mathematically correct -infinity. This means, for example, that expressions of the"`

3. **File:** `mod.rs`  
   - Fixed a typo in the comment:  
     **Before:** `"Each row contains a seperate Fibonacci sequence of length 'N'"`  
     **After:** `"Each row contains a separate Fibonacci sequence of length 'N'"`

## Motivation
Correcting these typos ensures that the codebase adheres to high documentation standards and reduces potential confusion for contributors and maintainers.

## Checklist
- [x] Verified changes locally.
- [x] Updated comments for clarity.
- [x] No functional changes made; this is a non-breaking update.
