### PR TITLE
Add Poseidon31 hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "sha2",
  "starknet-crypto",
  "starknet-ff",
  "test-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ num-traits = "0.2.17"
 thiserror = "1.0.56"
 bytemuck = "1.14.3"
 tracing = "0.1.40"
+sha2 = "0.10.8"
 
 [profile.bench]
 codegen-units = 1

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -25,6 +25,7 @@ thiserror.workspace = true
 tracing.workspace = true
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
+sha2.workspace = true
 
 [dev-dependencies]
 aligned = "0.4.2"
@@ -105,3 +106,7 @@ name = "quotients"
 [[bench]]
 harness = false
 name = "pcs"
+
+[[bench]]
+harness = false
+name = "grind"

--- a/crates/prover/benches/grind.rs
+++ b/crates/prover/benches/grind.rs
@@ -1,0 +1,41 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use stwo_prover::core::backend::simd::SimdBackend;
+use stwo_prover::core::backend::CpuBackend;
+use stwo_prover::core::channel::{Blake2sChannel, Channel, Poseidon31Channel};
+use stwo_prover::core::proof_of_work::GrindOps;
+
+pub fn grind<C: Channel, B: GrindOps<C>>(name: impl ToString, c: &mut Criterion) {
+    const POW_BITS: u32 = 20;
+    let mut group = c.benchmark_group(format!("grind {}", name.to_string()));
+    group.bench_function(
+        format!("grind {} {} bits", name.to_string(), POW_BITS),
+        |b| {
+            b.iter(|| {
+                let channel = C::default();
+                <B as GrindOps<C>>::grind(&channel, POW_BITS)
+            });
+        },
+    );
+}
+
+pub fn simd_grind_blake2s(c: &mut Criterion) {
+    grind::<Blake2sChannel, SimdBackend>("blake2s simd", c);
+}
+
+pub fn simd_grind_poseidon31(c: &mut Criterion) {
+    grind::<Poseidon31Channel, SimdBackend>("poseidon31 simd", c);
+}
+
+pub fn cpu_grind_blake2s(c: &mut Criterion) {
+    grind::<Blake2sChannel, CpuBackend>("blake2s cpu", c);
+}
+
+pub fn cpu_grind_poseidon31(c: &mut Criterion) {
+    grind::<Poseidon31Channel, CpuBackend>("poseidon31 cpu", c);
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = simd_grind_blake2s, cpu_grind_blake2s, simd_grind_poseidon31, cpu_grind_poseidon31);
+criterion_main!(benches);

--- a/crates/prover/benches/merkle.rs
+++ b/crates/prover/benches/merkle.rs
@@ -8,6 +8,7 @@ use stwo_prover::core::backend::{Col, CpuBackend};
 use stwo_prover::core::fields::m31::{BaseField, N_BYTES_FELT};
 use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleHasher;
 use stwo_prover::core::vcs::ops::MerkleOps;
+use stwo_prover::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
 
 const LOG_N_ROWS: u32 = 16;
 
@@ -17,7 +18,7 @@ fn bench_blake2s_merkle<B: MerkleOps<Blake2sMerkleHasher>>(c: &mut Criterion, id
     let col: Col<B, BaseField> = (0..1 << LOG_N_ROWS).map(|_| BaseField::zero()).collect();
     let cols = (0..1 << LOG_N_COLS).map(|_| col.clone()).collect_vec();
     let col_refs = cols.iter().collect_vec();
-    let mut group = c.benchmark_group("merkle throughput");
+    let mut group = c.benchmark_group("blake2s merkle throughput");
     let n_elements = 1 << (LOG_N_COLS + LOG_N_ROWS);
     group.throughput(Throughput::Elements(n_elements));
     group.throughput(Throughput::Bytes(N_BYTES_FELT as u64 * n_elements));
@@ -31,8 +32,26 @@ fn blake2s_merkle_benches(c: &mut Criterion) {
     bench_blake2s_merkle::<CpuBackend>(c, "cpu");
 }
 
+fn bench_poseidon31_merkle<B: MerkleOps<Poseidon31MerkleHasher>>(c: &mut Criterion, id: &str) {
+    let col: Col<B, BaseField> = (0..1 << LOG_N_ROWS).map(|_| BaseField::zero()).collect();
+    let cols = (0..1 << LOG_N_COLS).map(|_| col.clone()).collect_vec();
+    let col_refs = cols.iter().collect_vec();
+    let mut group = c.benchmark_group("poseidon31 merkle throughput");
+    let n_elements = 1 << (LOG_N_COLS + LOG_N_ROWS);
+    group.throughput(Throughput::Elements(n_elements));
+    group.throughput(Throughput::Bytes(N_BYTES_FELT as u64 * n_elements));
+    group.bench_function(format!("{id} merkle"), |b| {
+        b.iter_with_large_drop(|| B::commit_on_layer(LOG_N_ROWS, None, &col_refs))
+    });
+}
+
+fn poseidon31_merkle_benches(c: &mut Criterion) {
+    bench_poseidon31_merkle::<SimdBackend>(c, "simd");
+    bench_poseidon31_merkle::<CpuBackend>(c, "cpu");
+}
+
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = blake2s_merkle_benches);
+    targets = blake2s_merkle_benches, poseidon31_merkle_benches);
 criterion_main!(benches);

--- a/crates/prover/benches/poseidon.rs
+++ b/crates/prover/benches/poseidon.rs
@@ -1,18 +1,39 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use stwo_prover::core::pcs::PcsConfig;
+use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
+use stwo_prover::core::vcs::poseidon31_merkle::Poseidon31MerkleChannel;
 use stwo_prover::examples::poseidon::prove_poseidon;
 
-pub fn simd_poseidon(c: &mut Criterion) {
+pub fn simd_poseidon_blake2s(c: &mut Criterion) {
     const LOG_N_INSTANCES: u32 = 18;
-    let mut group = c.benchmark_group("poseidon2");
+    let mut group = c.benchmark_group("poseidon2 with blake2s");
     group.throughput(Throughput::Elements(1u64 << LOG_N_INSTANCES));
-    group.bench_function(format!("poseidon2 2^{} instances", LOG_N_INSTANCES), |b| {
-        b.iter(|| prove_poseidon(LOG_N_INSTANCES, PcsConfig::default()));
-    });
+    group.bench_function(
+        format!("poseidon2 with blake2s 2^{} instances", LOG_N_INSTANCES),
+        |b| {
+            b.iter(|| {
+                prove_poseidon::<Blake2sMerkleChannel>(LOG_N_INSTANCES, PcsConfig::default())
+            });
+        },
+    );
+}
+
+pub fn simd_poseidon_poseidon31(c: &mut Criterion) {
+    const LOG_N_INSTANCES: u32 = 18;
+    let mut group = c.benchmark_group("poseidon2 with poseidon31");
+    group.throughput(Throughput::Elements(1u64 << LOG_N_INSTANCES));
+    group.bench_function(
+        format!("poseidon2 with poseidon31 2^{} instances", LOG_N_INSTANCES),
+        |b| {
+            b.iter(|| {
+                prove_poseidon::<Poseidon31MerkleChannel>(LOG_N_INSTANCES, PcsConfig::default())
+            });
+        },
+    );
 }
 
 criterion_group!(
     name = bit_rev;
     config = Criterion::default().sample_size(10);
-    targets = simd_poseidon);
+    targets = simd_poseidon_blake2s, simd_poseidon_poseidon31);
 criterion_main!(bit_rev);

--- a/crates/prover/src/core/backend/cpu/mod.rs
+++ b/crates/prover/src/core/backend/cpu/mod.rs
@@ -6,6 +6,9 @@ mod grind;
 pub mod lookups;
 #[cfg(not(target_arch = "wasm32"))]
 mod poseidon252;
+
+mod poseidon31;
+
 pub mod quotients;
 
 use std::fmt::Debug;
@@ -20,6 +23,7 @@ use crate::core::utils::bit_reverse_index;
 use crate::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleChannel;
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct CpuBackend;
@@ -28,6 +32,7 @@ impl Backend for CpuBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for CpuBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for CpuBackend {}
+impl BackendForChannel<Poseidon31MerkleChannel> for CpuBackend {}
 
 /// Performs a naive bit-reversal permutation inplace.
 ///

--- a/crates/prover/src/core/backend/cpu/poseidon31.rs
+++ b/crates/prover/src/core/backend/cpu/poseidon31.rs
@@ -1,0 +1,24 @@
+use itertools::Itertools;
+
+use crate::core::backend::{Col, CpuBackend};
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+use crate::core::vcs::poseidon31_hash::Poseidon31Hash;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
+
+impl MerkleOps<Poseidon31MerkleHasher> for CpuBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Col<Self, Poseidon31Hash>>,
+        columns: &[&Col<Self, BaseField>],
+    ) -> Col<Self, Poseidon31Hash> {
+        (0..(1 << log_size))
+            .map(|i| {
+                Poseidon31MerkleHasher::hash_node(
+                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                    &columns.iter().map(|column| column[i]).collect_vec(),
+                )
+            })
+            .collect()
+    }
+}

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -3,15 +3,18 @@ use std::simd::num::SimdUint;
 use std::simd::u32x16;
 
 use bytemuck::cast_slice;
+use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 use super::blake2s::compress16;
 use super::SimdBackend;
-use crate::core::backend::simd::m31::N_LANES;
-use crate::core::channel::Blake2sChannel;
+use crate::core::backend::simd::m31::{PackedM31, LOG_N_LANES, N_LANES};
+use crate::core::backend::simd::poseidon31::permute;
+use crate::core::channel::{Blake2sChannel, Poseidon31Channel};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::channel::{Channel, Poseidon252Channel};
+use crate::core::fields::m31::M31;
 use crate::core::proof_of_work::GrindOps;
 
 // Note: GRIND_LOW_BITS is a cap on how much extra time we need to wait for all threads to finish.
@@ -76,4 +79,59 @@ impl GrindOps<Poseidon252Channel> for SimdBackend {
             nonce += 1;
         }
     }
+}
+
+impl GrindOps<Poseidon31Channel> for SimdBackend {
+    fn grind(channel: &Poseidon31Channel, pow_bits: u32) -> u64 {
+        // TODO(first): support more than 32 bits.
+        assert!(pow_bits <= 32, "pow_bits > 32 is not supported");
+        let digest = channel.digest();
+
+        #[cfg(not(feature = "parallel"))]
+        let res = (0..=(1 << GRIND_HI_BITS))
+            .find_map(|hi| grind_poseidon31(&digest, hi, pow_bits))
+            .expect("Grind failed to find a solution.");
+
+        #[cfg(feature = "parallel")]
+        let res = (0..=(1 << GRIND_HI_BITS))
+            .into_par_iter()
+            .find_map_any(|hi| grind_poseidon31(&digest, hi, pow_bits))
+            .expect("Grind failed to find a solution.");
+
+        res
+    }
+}
+
+fn grind_poseidon31(digest: &[M31; 8], hi: u64, pow_bits: u32) -> Option<u64> {
+    let zero = PackedM31::zero();
+    let pow_bits = u32x16::splat(pow_bits);
+
+    let mut attempt = [zero; 16];
+    for i in 0..8 {
+        attempt[i + 8] = PackedM31::broadcast(digest[i]);
+    }
+
+    let high_start = hi << GRIND_LOW_BITS;
+
+    for low in (0..(1 << GRIND_LOW_BITS)).step_by(N_LANES) {
+        let start = high_start + (low << LOG_N_LANES);
+
+        attempt[0] = PackedM31::from_array(std::array::from_fn(|i| {
+            M31::from_u32_unchecked(((start + i as u64) % ((1 << 22) - 1)) as u32)
+        }));
+        attempt[1] = PackedM31::from_array(std::array::from_fn(|i| {
+            M31::from_u32_unchecked((((start + i as u64) >> 22) & ((1 << 21) - 1)) as u32)
+        }));
+        attempt[2] = PackedM31::from_array(std::array::from_fn(|i| {
+            M31::from_u32_unchecked((((start + i as u64) >> 43) & ((1 << 21) - 1)) as u32)
+        }));
+
+        let res = permute(attempt)[0];
+        let success_mask = res.into_simd().trailing_zeros().simd_ge(pow_bits);
+        if success_mask.any() {
+            let i = success_mask.to_array().iter().position(|&x| x).unwrap();
+            return Some((hi << GRIND_LOW_BITS) + low + i as u64);
+        }
+    }
+    None
 }

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 
 use super::blake2s::compress16;
 use super::SimdBackend;
-use crate::core::backend::simd::m31::{PackedM31, LOG_N_LANES, N_LANES};
+use crate::core::backend::simd::m31::{PackedM31, N_LANES};
 use crate::core::backend::simd::poseidon31::permute;
 use crate::core::channel::{Blake2sChannel, Poseidon31Channel};
 #[cfg(not(target_arch = "wasm32"))]
@@ -114,7 +114,7 @@ fn grind_poseidon31(digest: &[M31; 8], hi: u64, pow_bits: u32) -> Option<u64> {
     let high_start = hi << GRIND_LOW_BITS;
 
     for low in (0..(1 << GRIND_LOW_BITS)).step_by(N_LANES) {
-        let start = high_start + (low << LOG_N_LANES);
+        let start = high_start + low;
 
         attempt[0] = PackedM31::from_array(std::array::from_fn(|i| {
             M31::from_u32_unchecked(((start + i as u64) % ((1 << 22) - 1)) as u32)

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -126,11 +126,11 @@ fn grind_poseidon31(digest: &[M31; 8], hi: u64, pow_bits: u32) -> Option<u64> {
             M31::from_u32_unchecked((((start + i as u64) >> 43) & ((1 << 21) - 1)) as u32)
         }));
 
-        let res = permute(attempt)[0];
+        let res = permute(attempt)[8];
         let success_mask = res.into_simd().trailing_zeros().simd_ge(pow_bits);
         if success_mask.any() {
             let i = success_mask.to_array().iter().position(|&x| x).unwrap();
-            return Some((hi << GRIND_LOW_BITS) + low + i as u64);
+            return Some(start + i as u64);
         }
     }
     None

--- a/crates/prover/src/core/backend/simd/mod.rs
+++ b/crates/prover/src/core/backend/simd/mod.rs
@@ -4,6 +4,7 @@ use super::{Backend, BackendForChannel};
 use crate::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleChannel;
 
 pub mod accumulation;
 pub mod bit_reverse;
@@ -20,6 +21,7 @@ pub mod lookups;
 pub mod m31;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod poseidon252;
+pub mod poseidon31;
 pub mod prefix_sum;
 pub mod qm31;
 pub mod quotients;
@@ -33,3 +35,4 @@ impl Backend for SimdBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for SimdBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for SimdBackend {}
+impl BackendForChannel<Poseidon31MerkleChannel> for SimdBackend {}

--- a/crates/prover/src/core/backend/simd/poseidon31.rs
+++ b/crates/prover/src/core/backend/simd/poseidon31.rs
@@ -1,0 +1,356 @@
+use std::array;
+
+use itertools::Itertools;
+use num_traits::Zero;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+use crate::core::backend::simd::m31::{PackedM31, LOG_N_LANES};
+use crate::core::backend::simd::SimdBackend;
+use crate::core::backend::{Col, Column, ColumnOps};
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+use crate::core::vcs::poseidon31_hash::Poseidon31Hash;
+use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
+use crate::core::vcs::poseidon31_ref::{
+    FIRST_FOUR_ROUND_RC, LAST_FOUR_ROUNDS_RC, MAT_DIAG16_M_1, PARTIAL_ROUNDS_RC,
+};
+use crate::parallel_iter;
+
+impl ColumnOps<Poseidon31Hash> for SimdBackend {
+    type Column = Vec<Poseidon31Hash>;
+
+    fn bit_reverse_column(_column: &mut Self::Column) {
+        unimplemented!()
+    }
+}
+
+impl MerkleOps<Poseidon31MerkleHasher> for SimdBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Poseidon31Hash>>,
+        columns: &[&Col<Self, BaseField>],
+    ) -> Vec<Poseidon31Hash> {
+        if log_size < LOG_N_LANES {
+            return parallel_iter!(0..1 << log_size)
+                .map(|i| {
+                    Poseidon31MerkleHasher::hash_node(
+                        prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                        &columns.iter().map(|column| column.at(i)).collect_vec(),
+                    )
+                })
+                .collect();
+        }
+
+        if let Some(prev_layer) = prev_layer {
+            assert_eq!(prev_layer.len(), 1 << (log_size + 1));
+        }
+
+        let mut res = vec![Poseidon31Hash::default(); 1 << log_size];
+        #[cfg(not(feature = "parallel"))]
+        let iter = res.chunks_mut(1 << LOG_N_LANES);
+
+        #[cfg(feature = "parallel")]
+        let iter = res.par_chunks_mut(1 << LOG_N_LANES);
+
+        iter.enumerate().for_each(|(i, chunk)| {
+            let hash_tree = if let Some(prev_layer) = prev_layer {
+                let input = &prev_layer[(i << 5)..((i + 1) << 5)];
+
+                let mut packed_input = [PackedM31::zero(); 16];
+                for i in 0..8 {
+                    packed_input[i] = PackedM31::from_array(array::from_fn(|k| input[2 * k].0[i]));
+                }
+                for i in 0..8 {
+                    packed_input[8 + i] =
+                        PackedM31::from_array(array::from_fn(|k| input[2 * k + 1].0[i]))
+                }
+
+                Some(compress16(packed_input))
+            } else {
+                None
+            };
+
+            let hash_column = if !columns.is_empty() {
+                let len = columns.len();
+                let num_chunk = len.div_ceil(8);
+
+                let mut digest = if num_chunk == 1 {
+                    let mut res = [PackedM31::zero(); 8];
+                    for j in 0..len {
+                        res[j] = columns[j].data[i];
+                    }
+                    res
+                } else {
+                    let mut res = [PackedM31::zero(); 16];
+                    for j in 0..16 {
+                        res[j] = columns[j].data[i];
+                    }
+                    compress16(res)
+                };
+
+                for column_chunk in columns.chunks_exact(8).skip(2) {
+                    let mut state = [PackedM31::zero(); 16];
+                    for j in 0..8 {
+                        state[j] = digest[j];
+                    }
+                    for j in 0..8 {
+                        state[j + 8] = column_chunk[j].data[i];
+                    }
+                    digest = compress16(state);
+                }
+
+                let remain = len % 8;
+                if remain != 0 {
+                    let mut state = [PackedM31::zero(); 16];
+                    for j in 0..8 {
+                        state[j] = digest[j];
+                    }
+                    for j in 0..remain {
+                        state[j + 8] = columns[len - remain + j].data[i];
+                    }
+                    digest = compress16(state);
+                }
+
+                Some(digest)
+            } else {
+                None
+            };
+
+            let final_res = match (hash_tree, hash_column) {
+                (Some(hash_tree), Some(hash_column)) => {
+                    let mut state = [PackedM31::zero(); 16];
+                    for j in 0..8 {
+                        state[j] = hash_tree[j];
+                    }
+                    for j in 0..8 {
+                        state[j + 8] = hash_column[j];
+                    }
+                    compress16(state)
+                }
+                (Some(hash_tree), None) => hash_tree,
+                (None, Some(hash_column)) => hash_column,
+                _ => unreachable!(),
+            };
+
+            for j in 0..8 {
+                let unpacked = final_res[j].to_array();
+                for k in 0..16 {
+                    chunk[k].0[j] = unpacked[k];
+                }
+            }
+        });
+        res
+    }
+}
+
+fn apply_4x4_mds_matrix(
+    x0: PackedM31,
+    x1: PackedM31,
+    x2: PackedM31,
+    x3: PackedM31,
+) -> [PackedM31; 4] {
+    let t0 = x0 + x1;
+    let t1 = x2 + x3;
+    let t2 = x1.double() + t1;
+    let t3 = x3.double() + t0;
+    let t4 = t1.double().double() + t3;
+    let t5 = t0.double().double() + t2;
+    let t6 = t3 + t5;
+    let t7 = t2 + t4;
+
+    [t6, t5, t7, t4]
+}
+
+fn apply_16x16_mds_matrix(state: &mut [PackedM31; 16]) {
+    let p1 = apply_4x4_mds_matrix(state[0], state[1], state[2], state[3]);
+    let p2 = apply_4x4_mds_matrix(state[4], state[5], state[6], state[7]);
+    let p3 = apply_4x4_mds_matrix(state[8], state[9], state[10], state[11]);
+    let p4 = apply_4x4_mds_matrix(state[12], state[13], state[14], state[15]);
+
+    let t = [
+        p1[0] + p2[0] + p3[0] + p4[0],
+        p1[1] + p2[1] + p3[1] + p4[1],
+        p1[2] + p2[2] + p3[2] + p4[2],
+        p1[3] + p2[3] + p3[3] + p4[3],
+    ];
+
+    for i in 0..4 {
+        state[i] = p1[i] + t[i];
+        state[i + 4] = p2[i] + t[i];
+        state[i + 8] = p3[i] + t[i];
+        state[i + 12] = p4[i] + t[i];
+    }
+}
+
+fn pow5(v: PackedM31) -> PackedM31 {
+    let t = v * v;
+    t * t * v
+}
+
+pub(crate) fn permute(mut state: [PackedM31; 16]) -> [PackedM31; 16] {
+    apply_16x16_mds_matrix(&mut state);
+
+    for r in 0..4 {
+        for i in 0..16 {
+            state[i] += PackedM31::broadcast(FIRST_FOUR_ROUND_RC[r][i]);
+        }
+        for i in 0..16 {
+            state[i] = pow5(state[i]);
+        }
+
+        apply_16x16_mds_matrix(&mut state);
+    }
+
+    for r in 0..14 {
+        state[0] += PackedM31::broadcast(PARTIAL_ROUNDS_RC[r]);
+        state[0] = pow5(state[0]);
+
+        let mut sum = state[0];
+        for i in 1..16 {
+            sum += state[i];
+        }
+
+        for i in 0..16 {
+            state[i] = sum + state[i] * PackedM31::broadcast(MAT_DIAG16_M_1[i]);
+        }
+    }
+
+    for r in 0..4 {
+        for i in 0..16 {
+            state[i] += PackedM31::broadcast(LAST_FOUR_ROUNDS_RC[r][i]);
+        }
+        for i in 0..16 {
+            state[i] = pow5(state[i]);
+        }
+
+        apply_16x16_mds_matrix(&mut state);
+    }
+    state
+}
+
+fn compress16(state: [PackedM31; 16]) -> [PackedM31; 8] {
+    let permuted_state = permute(state);
+    let mut res = permuted_state.first_chunk::<8>().unwrap().clone();
+    for i in 0..8 {
+        res[i] += state[i];
+    }
+    res
+}
+
+#[cfg(test)]
+mod test {
+    use num_traits::Zero;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use crate::core::backend::simd::m31::PackedM31;
+    use crate::core::backend::simd::poseidon31::compress16;
+    use crate::core::backend::simd::SimdBackend;
+    use crate::core::backend::{Col, CpuBackend};
+    use crate::core::fields::m31::{BaseField, M31};
+    use crate::core::vcs::ops::MerkleOps;
+    use crate::core::vcs::poseidon31_merkle::Poseidon31MerkleHasher;
+    use crate::core::vcs::poseidon31_ref::poseidon2_permute;
+
+    #[test]
+    fn test_permute_consistency() {
+        let mut prng = SmallRng::seed_from_u64(0);
+        let test_inputs: [[M31; 16]; 16] = prng.gen();
+        let mut test_outputs = [[M31::zero(); 8]; 16];
+
+        for i in 0..16 {
+            let mut state = test_inputs[i].clone();
+            poseidon2_permute(&mut state);
+            for j in 0..8 {
+                test_outputs[i][j] = state[j] + test_inputs[i][j];
+            }
+        }
+
+        let mut packed_inputs = [PackedM31::zero(); 16];
+        for i in 0..16 {
+            packed_inputs[i] = PackedM31::from_array([
+                test_inputs[0][i],
+                test_inputs[1][i],
+                test_inputs[2][i],
+                test_inputs[3][i],
+                test_inputs[4][i],
+                test_inputs[5][i],
+                test_inputs[6][i],
+                test_inputs[7][i],
+                test_inputs[8][i],
+                test_inputs[9][i],
+                test_inputs[10][i],
+                test_inputs[11][i],
+                test_inputs[12][i],
+                test_inputs[13][i],
+                test_inputs[14][i],
+                test_inputs[15][i],
+            ]);
+        }
+
+        let packed_output = compress16(packed_inputs);
+        for i in 0..8 {
+            let arr = packed_output[i].to_array();
+            for j in 0..16 {
+                assert_eq!(arr[j], test_outputs[j][i]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_merkle_consistency() {
+        let mut prng = SmallRng::seed_from_u64(0);
+
+        let mut data = Vec::with_capacity(1 << 10);
+        for _ in 0..(1 << 10) {
+            data.push(prng.gen::<M31>())
+        }
+
+        let cpu_col: Col<CpuBackend, BaseField> = data.iter().copied().collect();
+        let cpu_result = <CpuBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            10,
+            None,
+            &[&cpu_col],
+        );
+
+        let simd_col: Col<SimdBackend, BaseField> = data.iter().copied().collect();
+        let simd_result = <SimdBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            10,
+            None,
+            &[&simd_col],
+        );
+        assert_eq!(cpu_result, simd_result);
+
+        let cpu_result = <CpuBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            9,
+            Some(&cpu_result),
+            &[],
+        );
+        let simd_result = <SimdBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            9,
+            Some(&simd_result),
+            &[],
+        );
+        assert_eq!(cpu_result, simd_result);
+
+        let mut data = Vec::with_capacity(1 << 8);
+        for _ in 0..(1 << 8) {
+            data.push(prng.gen::<M31>())
+        }
+
+        let cpu_col: Col<CpuBackend, BaseField> = data.iter().copied().collect();
+        let cpu_result = <CpuBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            8,
+            Some(&cpu_result),
+            &[&cpu_col],
+        );
+        let simd_col: Col<SimdBackend, BaseField> = data.iter().copied().collect();
+        let simd_result = <SimdBackend as MerkleOps<Poseidon31MerkleHasher>>::commit_on_layer(
+            8,
+            Some(&simd_result),
+            &[&simd_col],
+        );
+        assert_eq!(cpu_result, simd_result);
+    }
+}

--- a/crates/prover/src/core/channel/mod.rs
+++ b/crates/prover/src/core/channel/mod.rs
@@ -6,6 +6,9 @@ mod poseidon252;
 #[cfg(not(target_arch = "wasm32"))]
 pub use poseidon252::Poseidon252Channel;
 
+mod poseidon31;
+pub use poseidon31::Poseidon31Channel;
+
 mod blake2s;
 pub use blake2s::Blake2sChannel;
 

--- a/crates/prover/src/core/channel/poseidon31.rs
+++ b/crates/prover/src/core/channel/poseidon31.rs
@@ -1,0 +1,253 @@
+use std::iter;
+
+use num_traits::Zero;
+
+use crate::core::channel::{Channel, ChannelTime};
+use crate::core::fields::m31::{BaseField, M31, P};
+use crate::core::fields::qm31::SecureField;
+use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
+use crate::core::vcs::poseidon31_ref::poseidon2_permute;
+
+pub const POSEIDON31_BYTES_PER_HASH: usize = 32;
+pub const FELTS_PER_HASH: usize = 8;
+
+/// A channel that can be used to draw random elements from a Poseidon31 hash.
+#[derive(Clone, Default)]
+pub struct Poseidon31Channel {
+    digest: [M31; 8],
+    pub channel_time: ChannelTime,
+}
+
+impl Poseidon31Channel {
+    pub const fn digest(&self) -> [M31; 8] {
+        self.digest
+    }
+    pub fn update_digest(&mut self, new_digest: [M31; 8]) {
+        self.digest = new_digest;
+        self.channel_time.inc_challenges();
+    }
+
+    fn draw_base_felts(&mut self) -> [BaseField; FELTS_PER_HASH] {
+        assert!((self.channel_time.n_sent as u64) < (P as u64));
+        let zero = M31::zero();
+        let mut state = [
+            M31::from(self.channel_time.n_sent),
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            self.digest[0],
+            self.digest[1],
+            self.digest[2],
+            self.digest[3],
+            self.digest[4],
+            self.digest[5],
+            self.digest[6],
+            self.digest[7],
+        ];
+
+        poseidon2_permute(&mut state);
+
+        self.channel_time.inc_sent();
+
+        // extract elements from the first 8 elements, not the last 8 elements
+        state.first_chunk::<8>().unwrap().clone()
+    }
+}
+
+impl Channel for Poseidon31Channel {
+    const BYTES_PER_HASH: usize = POSEIDON31_BYTES_PER_HASH;
+
+    fn trailing_zeros(&self) -> u32 {
+        let mut bytes = [0u8; 16];
+        bytes[0..4].copy_from_slice(&self.digest[0].0.to_le_bytes());
+        bytes[4..8].copy_from_slice(&self.digest[1].0.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.digest[2].0.to_le_bytes());
+        bytes[12..16].copy_from_slice(&self.digest[3].0.to_le_bytes());
+
+        u128::from_le_bytes(bytes).trailing_zeros()
+    }
+
+    fn mix_felts(&mut self, felts: &[SecureField]) {
+        let zero = M31::zero();
+        let mut state = [
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            self.digest[0],
+            self.digest[1],
+            self.digest[2],
+            self.digest[3],
+            self.digest[4],
+            self.digest[5],
+            self.digest[6],
+            self.digest[7],
+        ];
+
+        for chunk in felts.chunks(2) {
+            let felts = chunk[0].to_m31_array();
+            for i in 0..4 {
+                state[i] = felts[i];
+            }
+
+            if chunk.len() == 2 {
+                let felts = chunk[1].to_m31_array();
+                for i in 0..4 {
+                    state[i + 4] = felts[i];
+                }
+            } else {
+                for i in 0..4 {
+                    state[i + 4] = zero;
+                }
+            }
+
+            poseidon2_permute(&mut state);
+        }
+
+        let new_digest = state.last_chunk::<8>().unwrap();
+        self.update_digest(*new_digest);
+    }
+
+    fn mix_u64(&mut self, value: u64) {
+        let zero = M31::zero();
+        let n1 = value % ((1 << 22) - 1); // 22 bits
+        let n2 = (value >> 22) & ((1 << 21) - 1); // 21 bits
+        let n3 = (value >> 43) & ((1 << 21) - 1); // 21 bits
+
+        let mut state = [
+            M31::from(n1 as u32),
+            M31::from(n2 as u32),
+            M31::from(n3 as u32),
+            zero,
+            zero,
+            zero,
+            zero,
+            zero,
+            self.digest[0],
+            self.digest[1],
+            self.digest[2],
+            self.digest[3],
+            self.digest[4],
+            self.digest[5],
+            self.digest[6],
+            self.digest[7],
+        ];
+        poseidon2_permute(&mut state);
+
+        let new_digest = state.last_chunk::<8>().unwrap();
+        self.update_digest(*new_digest);
+    }
+
+    fn draw_felt(&mut self) -> SecureField {
+        let felts: [BaseField; FELTS_PER_HASH] = self.draw_base_felts();
+        SecureField::from_m31_array(felts[..SECURE_EXTENSION_DEGREE].try_into().unwrap())
+    }
+
+    fn draw_felts(&mut self, n_felts: usize) -> Vec<SecureField> {
+        let mut felts = iter::from_fn(|| Some(self.draw_base_felts())).flatten();
+        let secure_felts = iter::from_fn(|| {
+            Some(SecureField::from_m31_array([
+                felts.next()?,
+                felts.next()?,
+                felts.next()?,
+                felts.next()?,
+            ]))
+        });
+        secure_felts.take(n_felts).collect()
+    }
+
+    fn draw_random_bytes(&mut self) -> Vec<u8> {
+        // the implementation here is based on the assumption that the only place draw_random_bytes
+        // will be used is in generating the queries, where only the lowest n bits of every 4 bytes
+        // slice would be used.
+
+        let felts: [BaseField; FELTS_PER_HASH] = self.draw_base_felts();
+        let mut bytes = Vec::with_capacity(FELTS_PER_HASH * 4);
+        for i in 0..FELTS_PER_HASH {
+            // important: only le bytes
+            bytes.extend(felts[i].0.to_le_bytes());
+        }
+
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use crate::core::channel::{Channel, Poseidon31Channel};
+    use crate::core::fields::qm31::SecureField;
+    use crate::m31;
+
+    #[test]
+    fn test_channel_time() {
+        let mut channel = Poseidon31Channel::default();
+
+        assert_eq!(channel.channel_time.n_challenges, 0);
+        assert_eq!(channel.channel_time.n_sent, 0);
+
+        channel.draw_random_bytes();
+        assert_eq!(channel.channel_time.n_challenges, 0);
+        assert_eq!(channel.channel_time.n_sent, 1);
+
+        channel.draw_felts(9);
+        assert_eq!(channel.channel_time.n_challenges, 0);
+        assert_eq!(channel.channel_time.n_sent, 6);
+    }
+
+    #[test]
+    fn test_draw_random_bytes() {
+        let mut channel = Poseidon31Channel::default();
+
+        let first_random_bytes = channel.draw_random_bytes();
+
+        // Assert that next random bytes are different.
+        assert_ne!(first_random_bytes, channel.draw_random_bytes());
+    }
+
+    #[test]
+    pub fn test_draw_felt() {
+        let mut channel = Poseidon31Channel::default();
+
+        let first_random_felt = channel.draw_felt();
+
+        // Assert that next random felt is different.
+        assert_ne!(first_random_felt, channel.draw_felt());
+    }
+
+    #[test]
+    pub fn test_draw_felts() {
+        let mut channel = Poseidon31Channel::default();
+
+        let mut random_felts = channel.draw_felts(5);
+        random_felts.extend(channel.draw_felts(4));
+
+        // Assert that all the random felts are unique.
+        assert_eq!(
+            random_felts.len(),
+            random_felts.iter().collect::<BTreeSet<_>>().len()
+        );
+    }
+
+    #[test]
+    pub fn test_mix_felts() {
+        let mut channel = Poseidon31Channel::default();
+        let initial_digest = channel.digest;
+        let felts: Vec<SecureField> = (0..2)
+            .map(|i| SecureField::from(m31!(i + 1923782)))
+            .collect();
+
+        channel.mix_felts(felts.as_slice());
+
+        assert_ne!(initial_digest, channel.digest);
+    }
+}

--- a/crates/prover/src/core/channel/poseidon31.rs
+++ b/crates/prover/src/core/channel/poseidon31.rs
@@ -30,8 +30,9 @@ impl Poseidon31Channel {
     fn draw_base_felts(&mut self) -> [BaseField; FELTS_PER_HASH] {
         assert!((self.channel_time.n_sent as u64) < (P as u64));
         let zero = M31::zero();
+        let n_sent = M31::from(self.channel_time.n_sent);
         let mut state = [
-            M31::from(self.channel_time.n_sent),
+            n_sent,
             zero,
             zero,
             zero,
@@ -50,6 +51,8 @@ impl Poseidon31Channel {
         ];
 
         poseidon2_permute(&mut state);
+
+        state[0] += n_sent;
 
         self.channel_time.inc_sent();
 

--- a/crates/prover/src/core/vcs/mod.rs
+++ b/crates/prover/src/core/vcs/mod.rs
@@ -8,6 +8,9 @@ pub mod hash;
 pub mod ops;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod poseidon252_merkle;
+pub mod poseidon31_hash;
+pub mod poseidon31_merkle;
+pub mod poseidon31_ref;
 pub mod prover;
 mod utils;
 pub mod verifier;

--- a/crates/prover/src/core/vcs/poseidon31_hash.rs
+++ b/crates/prover/src/core/vcs/poseidon31_hash.rs
@@ -1,0 +1,19 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::core::fields::m31::M31;
+use crate::core::vcs::hash::Hash;
+
+// Wrapper for the Poseidon31 hash type.
+#[repr(C, align(32))]
+#[derive(Clone, Copy, Debug, PartialEq, Default, Eq, Deserialize, Serialize)]
+pub struct Poseidon31Hash(pub [M31; 8]);
+
+impl fmt::Display for Poseidon31Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+impl Hash for Poseidon31Hash {}

--- a/crates/prover/src/core/vcs/poseidon31_merkle.rs
+++ b/crates/prover/src/core/vcs/poseidon31_merkle.rs
@@ -1,0 +1,119 @@
+use num_traits::Zero;
+use serde::{Deserialize, Serialize};
+
+use crate::core::channel::{MerkleChannel, Poseidon31Channel};
+use crate::core::fields::m31::{BaseField, M31};
+use crate::core::vcs::ops::MerkleHasher;
+use crate::core::vcs::poseidon31_hash::Poseidon31Hash;
+use crate::core::vcs::poseidon31_ref::{poseidon2_permute, Poseidon31CRH};
+
+const ELEMENTS_IN_BLOCK: usize = 8;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub struct Poseidon31MerkleHasher;
+impl MerkleHasher for Poseidon31MerkleHasher {
+    type Hash = Poseidon31Hash;
+
+    fn hash_node(
+        children_hashes: Option<(Self::Hash, Self::Hash)>,
+        column_values: &[BaseField],
+    ) -> Self::Hash {
+        let zero = M31::zero();
+
+        let hash_tree = if children_hashes.is_some() {
+            let (left, right) = children_hashes.unwrap();
+            let mut res = [zero; 16];
+            for i in 0..ELEMENTS_IN_BLOCK {
+                res[i] = left.0[i];
+                res[i + ELEMENTS_IN_BLOCK] = right.0[i];
+            }
+            Some(Poseidon31Hash(Poseidon31CRH::compress(&res)))
+        } else {
+            None
+        };
+
+        let hash_column = if !column_values.is_empty() {
+            let len = column_values.len();
+            let num_chunk = len.div_ceil(8);
+
+            let mut digest = if num_chunk == 1 {
+                let mut res = [zero; 8];
+                res[..len].copy_from_slice(column_values);
+                res
+            } else {
+                let mut res = [zero; 16];
+                for i in 0..16 {
+                    res[i] = column_values[i];
+                }
+                Poseidon31CRH::compress(&res)
+            };
+
+            for chunk in column_values.chunks(ELEMENTS_IN_BLOCK).skip(2) {
+                let mut state = [zero; 16];
+                state[..8].copy_from_slice(&digest);
+                state[8..16].copy_from_slice(chunk);
+                digest = Poseidon31CRH::compress(&state);
+            }
+
+            let remain = len % ELEMENTS_IN_BLOCK;
+            if remain != 0 {
+                let mut state = [zero; 16];
+                state[..8].copy_from_slice(&digest);
+                state[8..8 + remain].copy_from_slice(&column_values[len - remain..]);
+                digest = Poseidon31CRH::compress(&state);
+            }
+
+            Some(Poseidon31Hash(digest))
+        } else {
+            None
+        };
+
+        match (hash_tree, hash_column) {
+            (Some(hash_tree), Some(hash_column)) => {
+                let mut state = [zero; 16];
+                state[..8].copy_from_slice(&hash_tree.0);
+                state[8..].copy_from_slice(&hash_column.0);
+                Poseidon31Hash(Poseidon31CRH::compress(&state))
+            }
+            (Some(hash_tree), None) => hash_tree,
+            (None, Some(hash_column)) => hash_column,
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Poseidon31MerkleChannel;
+
+impl MerkleChannel for Poseidon31MerkleChannel {
+    type C = Poseidon31Channel;
+    type H = Poseidon31MerkleHasher;
+
+    fn mix_root(channel: &mut Self::C, root: <Self::H as MerkleHasher>::Hash) {
+        let channel_digest = channel.digest();
+        let mut state = [
+            root.0[0],
+            root.0[1],
+            root.0[2],
+            root.0[3],
+            root.0[4],
+            root.0[5],
+            root.0[6],
+            root.0[7],
+            channel_digest[0],
+            channel_digest[1],
+            channel_digest[2],
+            channel_digest[3],
+            channel_digest[4],
+            channel_digest[5],
+            channel_digest[6],
+            channel_digest[7],
+        ];
+        poseidon2_permute(&mut state);
+
+        let new_digest = state.last_chunk::<8>().unwrap();
+        channel.update_digest(*new_digest);
+    }
+}

--- a/crates/prover/src/core/vcs/poseidon31_ref.rs
+++ b/crates/prover/src/core/vcs/poseidon31_ref.rs
@@ -1,0 +1,429 @@
+use num_traits::Zero;
+use sha2::Digest;
+
+use crate::core::fields::m31::M31;
+use crate::core::fields::Field;
+
+/// Generated using https://github.com/HorizenLabs/poseidon2/blob/main/poseidon2_rust_params.sage
+/// with p = 2^31 - 1 and t = 16
+
+pub static MAT_DIAG16_M_1: [M31; 16] = [
+    M31::from_u32_unchecked(0x07b80ac4),
+    M31::from_u32_unchecked(0x6bd9cb33),
+    M31::from_u32_unchecked(0x48ee3f9f),
+    M31::from_u32_unchecked(0x4f63dd19),
+    M31::from_u32_unchecked(0x18c546b3),
+    M31::from_u32_unchecked(0x5af89e8b),
+    M31::from_u32_unchecked(0x4ff23de8),
+    M31::from_u32_unchecked(0x4f78aaf6),
+    M31::from_u32_unchecked(0x53bdc6d4),
+    M31::from_u32_unchecked(0x5c59823e),
+    M31::from_u32_unchecked(0x2a471c72),
+    M31::from_u32_unchecked(0x4c975e79),
+    M31::from_u32_unchecked(0x58dc64d4),
+    M31::from_u32_unchecked(0x06e9315d),
+    M31::from_u32_unchecked(0x2cf32286),
+    M31::from_u32_unchecked(0x2fb6755d),
+];
+
+pub static FIRST_FOUR_ROUND_RC: [[M31; 16]; 4] = [
+    [
+        M31::from_u32_unchecked(0x768bab52),
+        M31::from_u32_unchecked(0x70e0ab7d),
+        M31::from_u32_unchecked(0x3d266c8a),
+        M31::from_u32_unchecked(0x6da42045),
+        M31::from_u32_unchecked(0x600fef22),
+        M31::from_u32_unchecked(0x41dace6b),
+        M31::from_u32_unchecked(0x64f9bdd4),
+        M31::from_u32_unchecked(0x5d42d4fe),
+        M31::from_u32_unchecked(0x76b1516d),
+        M31::from_u32_unchecked(0x6fc9a717),
+        M31::from_u32_unchecked(0x70ac4fb6),
+        M31::from_u32_unchecked(0x00194ef6),
+        M31::from_u32_unchecked(0x22b644e2),
+        M31::from_u32_unchecked(0x1f7916d5),
+        M31::from_u32_unchecked(0x47581be2),
+        M31::from_u32_unchecked(0x2710a123),
+    ],
+    [
+        M31::from_u32_unchecked(0x6284e867),
+        M31::from_u32_unchecked(0x018d3afe),
+        M31::from_u32_unchecked(0x5df99ef3),
+        M31::from_u32_unchecked(0x4c1e467b),
+        M31::from_u32_unchecked(0x566f6abc),
+        M31::from_u32_unchecked(0x2994e427),
+        M31::from_u32_unchecked(0x538a6d42),
+        M31::from_u32_unchecked(0x5d7bf2cf),
+        M31::from_u32_unchecked(0x7fda2dab),
+        M31::from_u32_unchecked(0x0fd854c4),
+        M31::from_u32_unchecked(0x46922fca),
+        M31::from_u32_unchecked(0x3d7763a1),
+        M31::from_u32_unchecked(0x19fd05ca),
+        M31::from_u32_unchecked(0x0a4bbb43),
+        M31::from_u32_unchecked(0x15075851),
+        M31::from_u32_unchecked(0x3d903d76),
+    ],
+    [
+        M31::from_u32_unchecked(0x2d290ff7),
+        M31::from_u32_unchecked(0x40809fa0),
+        M31::from_u32_unchecked(0x59dac6ec),
+        M31::from_u32_unchecked(0x127927a2),
+        M31::from_u32_unchecked(0x6bbf0ea0),
+        M31::from_u32_unchecked(0x0294140f),
+        M31::from_u32_unchecked(0x24742976),
+        M31::from_u32_unchecked(0x6e84c081),
+        M31::from_u32_unchecked(0x22484f4a),
+        M31::from_u32_unchecked(0x354cae59),
+        M31::from_u32_unchecked(0x0453ffe1),
+        M31::from_u32_unchecked(0x3f47a3cc),
+        M31::from_u32_unchecked(0x0088204e),
+        M31::from_u32_unchecked(0x6066e109),
+        M31::from_u32_unchecked(0x3b7c4b80),
+        M31::from_u32_unchecked(0x6b55665d),
+    ],
+    [
+        M31::from_u32_unchecked(0x3bc4b897),
+        M31::from_u32_unchecked(0x735bf378),
+        M31::from_u32_unchecked(0x508daf42),
+        M31::from_u32_unchecked(0x1884fc2b),
+        M31::from_u32_unchecked(0x7214f24c),
+        M31::from_u32_unchecked(0x7498be0a),
+        M31::from_u32_unchecked(0x1a60e640),
+        M31::from_u32_unchecked(0x3303f928),
+        M31::from_u32_unchecked(0x29b46376),
+        M31::from_u32_unchecked(0x5c96bb68),
+        M31::from_u32_unchecked(0x65d097a5),
+        M31::from_u32_unchecked(0x1d358e9f),
+        M31::from_u32_unchecked(0x4a9a9017),
+        M31::from_u32_unchecked(0x4724cf76),
+        M31::from_u32_unchecked(0x347af70f),
+        M31::from_u32_unchecked(0x1e77e59a),
+    ],
+];
+
+pub static PARTIAL_ROUNDS_RC: [M31; 14] = [
+    M31::from_u32_unchecked(0x7f7ec4bf),
+    M31::from_u32_unchecked(0x0421926f),
+    M31::from_u32_unchecked(0x5198e669),
+    M31::from_u32_unchecked(0x34db3148),
+    M31::from_u32_unchecked(0x4368bafd),
+    M31::from_u32_unchecked(0x66685c7f),
+    M31::from_u32_unchecked(0x78d3249a),
+    M31::from_u32_unchecked(0x60187881),
+    M31::from_u32_unchecked(0x76dad67a),
+    M31::from_u32_unchecked(0x0690b437),
+    M31::from_u32_unchecked(0x1ea95311),
+    M31::from_u32_unchecked(0x40e5369a),
+    M31::from_u32_unchecked(0x38f103fc),
+    M31::from_u32_unchecked(0x1d226a21),
+];
+
+pub static LAST_FOUR_ROUNDS_RC: [[M31; 16]; 4] = [
+    [
+        M31::from_u32_unchecked(0x57090613),
+        M31::from_u32_unchecked(0x1fa42108),
+        M31::from_u32_unchecked(0x17bbef50),
+        M31::from_u32_unchecked(0x1ff7e11c),
+        M31::from_u32_unchecked(0x047b24ca),
+        M31::from_u32_unchecked(0x4e140275),
+        M31::from_u32_unchecked(0x4fa086f5),
+        M31::from_u32_unchecked(0x079b309c),
+        M31::from_u32_unchecked(0x1159bd47),
+        M31::from_u32_unchecked(0x6d37e4e5),
+        M31::from_u32_unchecked(0x075d8dce),
+        M31::from_u32_unchecked(0x12121ca0),
+        M31::from_u32_unchecked(0x7f6a7c40),
+        M31::from_u32_unchecked(0x68e182ba),
+        M31::from_u32_unchecked(0x5493201b),
+        M31::from_u32_unchecked(0x0444a80e),
+    ],
+    [
+        M31::from_u32_unchecked(0x0064f4c6),
+        M31::from_u32_unchecked(0x6467abe6),
+        M31::from_u32_unchecked(0x66975762),
+        M31::from_u32_unchecked(0x2af68f9b),
+        M31::from_u32_unchecked(0x345b33be),
+        M31::from_u32_unchecked(0x1b70d47f),
+        M31::from_u32_unchecked(0x053db717),
+        M31::from_u32_unchecked(0x381189cb),
+        M31::from_u32_unchecked(0x43b915f8),
+        M31::from_u32_unchecked(0x20df3694),
+        M31::from_u32_unchecked(0x0f459d26),
+        M31::from_u32_unchecked(0x77a0e97b),
+        M31::from_u32_unchecked(0x2f73e739),
+        M31::from_u32_unchecked(0x1876c2f9),
+        M31::from_u32_unchecked(0x65a0e29a),
+        M31::from_u32_unchecked(0x4cabefbe),
+    ],
+    [
+        M31::from_u32_unchecked(0x5abd1268),
+        M31::from_u32_unchecked(0x4d34a760),
+        M31::from_u32_unchecked(0x12771799),
+        M31::from_u32_unchecked(0x69a0c9ac),
+        M31::from_u32_unchecked(0x39091e55),
+        M31::from_u32_unchecked(0x7f611cd0),
+        M31::from_u32_unchecked(0x3af055da),
+        M31::from_u32_unchecked(0x7ac0bbdf),
+        M31::from_u32_unchecked(0x6e0f3a24),
+        M31::from_u32_unchecked(0x41e3b6f7),
+        M31::from_u32_unchecked(0x49b3756d),
+        M31::from_u32_unchecked(0x568bc538),
+        M31::from_u32_unchecked(0x20c079d8),
+        M31::from_u32_unchecked(0x1701c72c),
+        M31::from_u32_unchecked(0x7670dc6c),
+        M31::from_u32_unchecked(0x5a439035),
+    ],
+    [
+        M31::from_u32_unchecked(0x7c93e00e),
+        M31::from_u32_unchecked(0x561fbb4d),
+        M31::from_u32_unchecked(0x1178907b),
+        M31::from_u32_unchecked(0x02737406),
+        M31::from_u32_unchecked(0x32fb24f1),
+        M31::from_u32_unchecked(0x6323b60a),
+        M31::from_u32_unchecked(0x6ab12418),
+        M31::from_u32_unchecked(0x42c99cea),
+        M31::from_u32_unchecked(0x155a0b97),
+        M31::from_u32_unchecked(0x53d1c6aa),
+        M31::from_u32_unchecked(0x2bd20347),
+        M31::from_u32_unchecked(0x279b3d73),
+        M31::from_u32_unchecked(0x4f5f3c70),
+        M31::from_u32_unchecked(0x0245af6c),
+        M31::from_u32_unchecked(0x238359d3),
+        M31::from_u32_unchecked(0x49966a59),
+    ],
+];
+
+fn apply_4x4_mds_matrix(x0: M31, x1: M31, x2: M31, x3: M31) -> (M31, M31, M31, M31) {
+    let t0 = x0 + x1;
+    let t1 = x2 + x3;
+    let t2 = x1.double() + t1;
+    let t3 = x3.double() + t0;
+    let t4 = t1.double().double() + t3;
+    let t5 = t0.double().double() + t2;
+    let t6 = t3 + t5;
+    let t7 = t2 + t4;
+
+    (t6, t5, t7, t4)
+}
+
+fn apply_16x16_mds_matrix(state: [M31; 16]) -> [M31; 16] {
+    let p1 = apply_4x4_mds_matrix(state[0], state[1], state[2], state[3]);
+    let p2 = apply_4x4_mds_matrix(state[4], state[5], state[6], state[7]);
+    let p3 = apply_4x4_mds_matrix(state[8], state[9], state[10], state[11]);
+    let p4 = apply_4x4_mds_matrix(state[12], state[13], state[14], state[15]);
+
+    let t = [
+        p1.0, p1.1, p1.2, p1.3, p2.0, p2.1, p2.2, p2.3, p3.0, p3.1, p3.2, p3.3, p4.0, p4.1, p4.2,
+        p4.3,
+    ];
+
+    let mut state = t.clone();
+    for i in 0..16 {
+        state[i] = state[i].double();
+    }
+
+    for i in 0..4 {
+        state[i] += t[i + 4];
+        state[i] += t[i + 8];
+        state[i] += t[i + 12];
+    }
+    for i in 4..8 {
+        state[i] += t[i - 4];
+        state[i] += t[i + 4];
+        state[i] += t[i + 8];
+    }
+    for i in 8..12 {
+        state[i] += t[i - 8];
+        state[i] += t[i - 4];
+        state[i] += t[i + 4];
+    }
+    for i in 12..16 {
+        state[i] += t[i - 12];
+        state[i] += t[i - 8];
+        state[i] += t[i - 4];
+    }
+
+    state
+}
+
+#[inline(always)]
+fn pow5(a: M31) -> M31 {
+    let b = a * a;
+    b * b * a
+}
+
+pub fn poseidon2_permute(p_state: &mut [M31; 16]) {
+    let mut state = p_state.clone();
+    state = apply_16x16_mds_matrix(state);
+
+    for r in 0..4 {
+        for i in 0..16 {
+            state[i] += FIRST_FOUR_ROUND_RC[r][i];
+        }
+        for i in 0..16 {
+            state[i] = pow5(state[i]);
+        }
+
+        state = apply_16x16_mds_matrix(state);
+    }
+
+    for r in 0..14 {
+        state[0] += PARTIAL_ROUNDS_RC[r];
+        state[0] = pow5(state[0]);
+
+        let mut sum = state[0];
+        for i in 1..16 {
+            sum += state[i];
+        }
+
+        for i in 0..16 {
+            state[i] = sum + state[i] * MAT_DIAG16_M_1[i];
+        }
+    }
+
+    for r in 0..4 {
+        for i in 0..16 {
+            state[i] += LAST_FOUR_ROUNDS_RC[r][i];
+        }
+        for i in 0..16 {
+            state[i] = pow5(state[i]);
+        }
+
+        state = apply_16x16_mds_matrix(state);
+    }
+
+    *p_state = state;
+}
+
+fn compute_iv_values(domain_separator: &[u8]) -> [M31; 8] {
+    let mut sha256 = sha2::Sha256::new();
+    Digest::update(&mut sha256, domain_separator);
+
+    let bytes = sha256.finalize().to_vec();
+
+    [
+        M31::from(u32::from_be_bytes(bytes[0..4].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[4..8].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[8..12].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[12..16].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[16..20].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[20..24].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[24..28].try_into().unwrap())),
+        M31::from(u32::from_be_bytes(bytes[28..32].try_into().unwrap())),
+    ]
+}
+
+pub struct Poseidon31Hasher {
+    pub buffer: Vec<M31>,
+}
+
+impl Poseidon31Hasher {
+    pub fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+
+    pub fn update(&mut self, v: impl AsRef<[M31]>) {
+        self.buffer.extend_from_slice(v.as_ref())
+    }
+
+    pub fn finalize(&self, description: impl ToString) -> [M31; 8] {
+        let mut input = self.buffer.clone();
+        let l = input.len();
+
+        let iv = compute_iv_values(
+            format!(
+                "Poseidon2 M31 hashing {} M31 elements for {}",
+                l,
+                description.to_string()
+            )
+            .as_bytes(),
+        );
+
+        let zero = M31::zero();
+        let mut state = [
+            zero, zero, zero, zero, zero, zero, zero, zero, iv[0], iv[1], iv[2], iv[3], iv[4],
+            iv[5], iv[6], iv[7],
+        ];
+        input.resize(l.div_ceil(8) * 8, zero);
+
+        for chunk in input.chunks(8) {
+            state[0..8].copy_from_slice(chunk);
+            poseidon2_permute(&mut state);
+        }
+
+        [
+            state[0], state[1], state[2], state[3], state[4], state[5], state[6], state[7],
+        ]
+    }
+
+    pub fn finalize_reset(&mut self, description: impl ToString) -> [M31; 8] {
+        let res = self.finalize(description);
+        self.buffer.clear();
+        res
+    }
+}
+
+pub struct Poseidon31CRH;
+
+impl Poseidon31CRH {
+    pub fn compress(data: &[M31]) -> [M31; 8] {
+        assert_eq!(data.len(), 16);
+
+        let zero = M31::zero();
+        let mut cur = [zero; 16];
+        cur.copy_from_slice(data);
+
+        poseidon2_permute(&mut cur);
+        for i in 0..8 {
+            cur[i] += data[i];
+        }
+        *cur.first_chunk().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use num_traits::Zero;
+
+    use super::*;
+
+    fn to_u32_array(state: [M31; 16]) -> [u32; 16] {
+        [
+            state[0].0,
+            state[1].0,
+            state[2].0,
+            state[3].0,
+            state[4].0,
+            state[5].0,
+            state[6].0,
+            state[7].0,
+            state[8].0,
+            state[9].0,
+            state[10].0,
+            state[11].0,
+            state[12].0,
+            state[13].0,
+            state[14].0,
+            state[15].0,
+        ]
+    }
+
+    #[test]
+    fn test_poseidon2_permute() {
+        let mut state = [M31::zero(); 16];
+        for i in 0..16 {
+            state[i] = M31::from(i);
+        }
+
+        poseidon2_permute(&mut state);
+
+        assert_eq!(
+            to_u32_array(state),
+            [
+                1348310665, 996460804, 2044919169, 1269301599, 615961333, 595876573, 1377780500,
+                1776267289, 715842585, 1823756332, 1870636634, 1979645732, 311256455, 1364752356,
+                58674647, 323699327,
+            ]
+        );
+    }
+}

--- a/crates/prover/src/core/vcs/poseidon31_ref.rs
+++ b/crates/prover/src/core/vcs/poseidon31_ref.rs
@@ -8,22 +8,22 @@ use crate::core::fields::Field;
 /// with p = 2^31 - 1 and t = 16
 
 pub static MAT_DIAG16_M_1: [M31; 16] = [
-    M31::from_u32_unchecked(0x07b80ac4),
-    M31::from_u32_unchecked(0x6bd9cb33),
-    M31::from_u32_unchecked(0x48ee3f9f),
-    M31::from_u32_unchecked(0x4f63dd19),
-    M31::from_u32_unchecked(0x18c546b3),
-    M31::from_u32_unchecked(0x5af89e8b),
-    M31::from_u32_unchecked(0x4ff23de8),
-    M31::from_u32_unchecked(0x4f78aaf6),
-    M31::from_u32_unchecked(0x53bdc6d4),
-    M31::from_u32_unchecked(0x5c59823e),
-    M31::from_u32_unchecked(0x2a471c72),
-    M31::from_u32_unchecked(0x4c975e79),
-    M31::from_u32_unchecked(0x58dc64d4),
-    M31::from_u32_unchecked(0x06e9315d),
-    M31::from_u32_unchecked(0x2cf32286),
-    M31::from_u32_unchecked(0x2fb6755d),
+    M31::from_u32_unchecked(3),
+    M31::from_u32_unchecked(4),
+    M31::from_u32_unchecked(8),
+    M31::from_u32_unchecked(16),
+    M31::from_u32_unchecked(32),
+    M31::from_u32_unchecked(64),
+    M31::from_u32_unchecked(128),
+    M31::from_u32_unchecked(256),
+    M31::from_u32_unchecked(512),
+    M31::from_u32_unchecked(1024),
+    M31::from_u32_unchecked(2048),
+    M31::from_u32_unchecked(4096),
+    M31::from_u32_unchecked(8192),
+    M31::from_u32_unchecked(16384),
+    M31::from_u32_unchecked(32768),
+    M31::from_u32_unchecked(65536),
 ];
 
 pub static FIRST_FOUR_ROUND_RC: [[M31; 16]; 4] = [
@@ -420,9 +420,9 @@ mod tests {
         assert_eq!(
             to_u32_array(state),
             [
-                1348310665, 996460804, 2044919169, 1269301599, 615961333, 595876573, 1377780500,
-                1776267289, 715842585, 1823756332, 1870636634, 1979645732, 311256455, 1364752356,
-                58674647, 323699327,
+                260776483, 1182896747, 1656699352, 746018898, 102875940, 1812541025, 515874083,
+                755063943, 1682438524, 1265420601, 238640995, 200799880, 1659717477, 2080202267,
+                1269806256, 1287849264
             ]
         );
     }


### PR DESCRIPTION
This PR adds the Poseidon31 hasher, which is useful for recursive proof verification of a M31 proof over the M31 field.
Benchmark for proof generation suggests that the proof time is doubled when using Poseidon31 instead of Blake2s.

The Poseidon31 implementation resembles the one for Poseidon252, in that we do not use Poseidon sponge, but shapes it as a cryptographically secure hash function for compression and derivation.