### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/prover/src/constraint_framework/component.rs
+++ b/crates/prover/src/constraint_framework/component.rs
@@ -79,7 +79,7 @@ impl TraceLocationAllocator {
     }
 
     /// Create a new `TraceLocationAllocator` with fixed preprocessed columns setup.
-    pub fn new_with_preproccessed_columns(preprocessed_columns: &[PreProcessedColumnId]) -> Self {
+    pub fn new_with_preprocessed_columns(preprocessed_columns: &[PreProcessedColumnId]) -> Self {
         assert!(
             preprocessed_columns.iter().all_unique(),
             "Duplicate preprocessed columns are not allowed!"
@@ -213,7 +213,7 @@ impl<E: FrameworkEval> Component for FrameworkComponent<E> {
         })
     }
 
-    fn preproccessed_column_indices(&self) -> ColumnVec<usize> {
+    fn preprocessed_column_indices(&self) -> ColumnVec<usize> {
         self.preprocessed_column_indices.clone()
     }
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `new_with_preproccessed_columns` to `new_with_preprocessed_columns`
Corrected `preproccessed_column_indices` to `preprocessed_column_indices`

Please review the changes and let me know if any additional changes are needed.