### PR TITLE
Fix incorrect function argument in GKR verifier error handling

### DIFF
--- a/crates/prover/src/core/lookups/gkr_verifier.rs
+++ b/crates/prover/src/core/lookups/gkr_verifier.rs
@@ -94,7 +94,7 @@ pub fn partially_verify_batch(
             let mask = &layer_masks_by_instance[instance][layer - n_unused];
             let gate = &gate_by_instance[instance];
             let gate_output = gate.eval(mask).map_err(|InvalidNumMaskColumnsError| {
-                let instance_layer = instance_n_layers(layer) - n_remaining_layers;
+                let instance_layer = instance_n_layers(instance) - n_remaining_layers;
                 GkrError::InvalidMask {
                     instance,
                     instance_layer,


### PR DESCRIPTION
Fixed a bug in partially_verify_batch where instance_n_layers was incorrectly called with layer parameter instead of instance when calculating instance_layer in error handling path. This ensures correct layer index reporting in InvalidMask error.