### PR TITLE
initial no-std support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +542,15 @@ checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -587,18 +602,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -791,6 +797,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -810,6 +817,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"
@@ -998,7 +1008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
 dependencies = [
  "crypto-bigint",
- "hex",
  "hmac",
  "num-bigint",
  "num-integer",
@@ -1050,7 +1059,7 @@ name = "stwo-air-utils"
 version = "0.1.1"
 dependencies = [
  "bytemuck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "rayon",
  "stwo-air-utils-derive",
  "stwo-prover",
@@ -1058,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -1077,8 +1086,9 @@ dependencies = [
  "cfg-if",
  "criterion",
  "educe",
+ "hashbrown",
  "hex",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-traits",
  "rand",
  "rayon",
@@ -1144,18 +1154,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,17 @@ version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]
-blake2 = "0.10.6"
-blake3 = "1.5.0"
+blake2 = { version = "0.10.6", default-features = false }
+blake3 = { version = "1.5.0", default-features = false }
 educe = "0.5.0"
-hex = "0.4.3"
-itertools = "0.12.0"
-num-traits = "0.2.17"
-thiserror = "1.0.56"
-bytemuck = "1.14.3"
-tracing = "0.1.40"
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+itertools = { version = "0.14.0", default-features = false, features = ["use_alloc"] }
+num-traits = { version = "0.2.17", default-features = false }
+thiserror = { version = "2.0.12", default-features = false }
+bytemuck = { version = "1.14.3", default-features = false }
+tracing = { version = "0.1.40", default-features = false, features = ["attributes"] }
+starknet-ff = { version = "0.3.7", default-features = false, features=["alloc", "serde"] }
+starknet-crypto = { version = "0.6.2", default-features = false }
 
 [profile.bench]
 codegen-units = 1

--- a/crates/air_utils_derive/Cargo.toml
+++ b/crates/air_utils_derive/Cargo.toml
@@ -1,13 +1,19 @@
 [package]
 name = "stwo-air-utils-derive"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 proc-macro = true
 
+[features]
+default = ["std"]
+std = [
+    "itertools/use_std"
+]
+
 [dependencies]
-syn = "2.0.90"
-quote = "1.0.37"
-itertools = "0.13.0"
-proc-macro2 = "1.0.92"
+syn = { version = "2.0.90" }
+quote = { version = "1.0.37", default-features = false }
+itertools.workspace = true
+proc-macro2 = { version = "1.0.92", default-features = false }

--- a/crates/air_utils_derive/src/allocation.rs
+++ b/crates/air_utils_derive/src/allocation.rs
@@ -3,6 +3,7 @@ use quote::quote;
 use syn::Ident;
 
 use crate::iterable_field::IterableField;
+use crate::prelude::*;
 
 /// Implements an "Uninitialized" function for the struct.
 /// Allocates 2^`log_size` slots for every Vector.

--- a/crates/air_utils_derive/src/iter_mut.rs
+++ b/crates/air_utils_derive/src/iter_mut.rs
@@ -4,6 +4,7 @@ use quote::{format_ident, quote};
 use syn::{Ident, Lifetime};
 
 use crate::iterable_field::IterableField;
+use crate::prelude::*;
 
 pub fn expand_iter_mut_structs(
     struct_name: &Ident,
@@ -31,7 +32,7 @@ fn expand_impl_struct_name(struct_name: &Ident, iterable_fields: &[IterableField
     let as_mut_slice = iterable_fields
         .iter()
         .map(|f| f.as_mut_slice())
-        .collect_vec();
+        .collect::<Vec<_>>();
     quote! {
         impl #struct_name {
             pub fn iter_mut(&mut self) -> #iter_mut_name<'_> {
@@ -81,7 +82,7 @@ fn expand_iter_mut_struct(struct_name: &Ident, iterable_fields: &[IterableField]
     quote! {
         pub struct #iter_mut_name<#lifetime> {
             #(#field_names: #mut_ptr_types,)*
-            phantom: std::marker::PhantomData<&#lifetime ()>,
+            phantom: core::marker::PhantomData<&#lifetime ()>,
         }
         impl<#lifetime> #iter_mut_name<#lifetime> {
             pub fn new(
@@ -89,7 +90,7 @@ fn expand_iter_mut_struct(struct_name: &Ident, iterable_fields: &[IterableField]
             ) -> Self {
                 Self {
                     #(#field_names: #as_mut_ptr,)*
-                    phantom: std::marker::PhantomData,
+                    phantom: core::marker::PhantomData,
                 }
             }
         }

--- a/crates/air_utils_derive/src/iterable_field.rs
+++ b/crates/air_utils_derive/src/iterable_field.rs
@@ -2,6 +2,8 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Expr, Field, Fields, Ident, Lifetime, Type};
 
+use crate::prelude::*;
+
 /// Each variant represents a field that can be iterated over.
 /// Used to derive implementations of `Uninitialized`, `MutIter`, and `ParIterMut`.
 /// Currently supports `Vec<T>` and `[Vec<T>; N]` fields only.
@@ -242,7 +244,7 @@ impl IterableField {
                     let (
                         mut #head,
                         mut #tail
-                    ):([_; #array_size],[_; #array_size])  = unsafe { (std::mem::zeroed(), std::mem::zeroed()) };
+                    ):([_; #array_size],[_; #array_size])  = unsafe { (core::mem::zeroed(), core::mem::zeroed()) };
                     self.#name.into_iter().enumerate().for_each(|(i, v)| {
                         let (head, tail) = v.split_at_mut(#index);
                         #head[i] = head;

--- a/crates/air_utils_derive/src/lib.rs
+++ b/crates/air_utils_derive/src/lib.rs
@@ -1,3 +1,14 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+mod prelude {
+    #[cfg(not(feature = "std"))]
+    pub use alloc::vec::Vec;
+    #[cfg(feature = "std")]
+    pub use std::vec::Vec;
+}
+
 mod allocation;
 mod iter_mut;
 mod iterable_field;

--- a/crates/air_utils_derive/src/par_iter.rs
+++ b/crates/air_utils_derive/src/par_iter.rs
@@ -4,6 +4,7 @@ use quote::{format_ident, quote};
 use syn::{Ident, Lifetime};
 
 use crate::iterable_field::IterableField;
+use crate::prelude::*;
 
 pub fn expand_par_iter_mut_structs(
     struct_name: &Ident,

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -4,7 +4,20 @@ version.workspace = true
 edition.workspace = true
 
 [features]
-parallel = ["rayon"]
+default = ["std"]
+std = [
+    "blake2/std",
+    "blake3/std",
+    "hex/std",
+    "itertools/use_std",
+    "num-traits/std",
+    "rand/std",
+    "serde/std",
+    "tracing/std",
+    "starknet-crypto/std",
+    "starknet-ff/std"
+]
+parallel = ["rayon", "std"]
 slow-tests = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -19,12 +32,13 @@ hex.workspace = true
 itertools.workspace = true
 num-traits.workspace = true
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-starknet-crypto = "0.6.2"
-starknet-ff = "0.3.7"
+starknet-crypto.workspace = true
+starknet-ff.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 rayon = { version = "1.10.0", optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher"] }
 
 [dev-dependencies]
 aligned = "0.4.2"
@@ -46,7 +60,7 @@ version = "0.5.1"
 
 [lib]
 bench = false
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [lints.rust]
 warnings = "deny"

--- a/crates/prover/src/constraint_framework/assert.rs
+++ b/crates/prover/src/constraint_framework/assert.rs
@@ -1,25 +1,20 @@
-use itertools::Itertools;
 use num_traits::Zero;
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
 
 use super::logup::LogupAtRow;
 use super::{EvalAtRow, INTERACTION_TRACE_IDX};
 use crate::core::backend::{Backend, Column};
-use crate::core::fields::m31::{BaseField, M31};
+use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
 use crate::core::lookups::utils::Fraction;
 use crate::core::pcs::TreeVec;
 use crate::core::poly::circle::{CanonicCoset, CirclePoly};
-use crate::core::utils::{
-    bit_reverse_index, circle_domain_index_to_coset_index, coset_index_to_circle_domain_index,
-};
-use crate::parallel_iter;
+use crate::core::utils::circle_domain_order_to_coset_order;
+use crate::prelude::*;
 
 /// Evaluates expressions at a trace domain row, and asserts constraints. Mainly used for testing.
 pub struct AssertEvaluator<'a> {
-    pub trace: &'a TreeVec<Vec<&'a Vec<BaseField>>>,
+    pub trace: &'a TreeVec<Vec<Vec<BaseField>>>,
     pub col_index: TreeVec<usize>,
     pub row: usize,
     pub constraint_counter: usize,
@@ -27,7 +22,7 @@ pub struct AssertEvaluator<'a> {
 }
 impl<'a> AssertEvaluator<'a> {
     pub fn new(
-        trace: &'a TreeVec<Vec<&Vec<BaseField>>>,
+        trace: &'a TreeVec<Vec<Vec<BaseField>>>,
         row: usize,
         log_size: u32,
         claimed_sum: SecureField,
@@ -53,31 +48,16 @@ impl EvalAtRow for AssertEvaluator<'_> {
         let col_index = self.col_index[interaction];
         self.col_index[interaction] += 1;
         offsets.map(|off| {
-            // If the offset is 0, we can just return the value directly from this row.
-            if off == 0 {
-                let col = &self.trace[interaction][col_index];
-                return col[self.row];
-            }
-            // Otherwise, we need to look up the value at the offset.
-            // Since the domain is bit-reversed circle domain ordered, we need to look up the value
-            // at the bit-reversed natural order index at an offset.
-            let log_size = self.logup.log_size;
-            let domain_size = 1 << log_size;
-
-            let coset_index =
-                circle_domain_index_to_coset_index(bit_reverse_index(self.row, log_size), log_size);
-            let next_coset_index = (coset_index as isize + off).rem_euclid(domain_size);
-            let next_index = bit_reverse_index(
-                coset_index_to_circle_domain_index(next_coset_index as usize, log_size),
-                log_size,
-            );
-            self.trace[interaction][col_index].at(next_index)
+            // The mask row might wrap around the column size.
+            let col_size = self.trace[interaction][col_index].len() as isize;
+            self.trace[interaction][col_index]
+                [(self.row as isize + off).rem_euclid(col_size) as usize]
         })
     }
 
     fn add_constraint<G>(&mut self, constraint: G)
     where
-        Self::EF: std::ops::Mul<G, Output = Self::EF> + From<G>,
+        Self::EF: core::ops::Mul<G, Output = Self::EF> + From<G>,
     {
         // Cast to SecureField.
         // The constraint should be zero at the given row, since we are evaluating on the trace
@@ -99,33 +79,28 @@ impl EvalAtRow for AssertEvaluator<'_> {
     super::logup_proxy!();
 }
 
-pub fn assert_constraints_on_polys<B: Backend>(
+pub fn assert_constraints<B: Backend>(
     trace_polys: &TreeVec<Vec<CirclePoly<B>>>,
     trace_domain: CanonicCoset,
-    assert_func: impl Fn(AssertEvaluator<'_>) + Sync,
+    assert_func: impl Fn(AssertEvaluator<'_>),
     claimed_sum: SecureField,
 ) {
     let traces = trace_polys.as_ref().map(|tree| {
         tree.iter()
-            .map(|poly| poly.evaluate(trace_domain.circle_domain()).values.to_cpu())
-            .collect_vec()
+            .map(|poly| {
+                circle_domain_order_to_coset_order(
+                    &poly
+                        .evaluate(trace_domain.circle_domain())
+                        .bit_reverse()
+                        .values
+                        .to_cpu(),
+                )
+            })
+            .collect()
     });
-    let traces = &traces.as_ref();
-    let traces = traces.into();
-    assert_constraints_on_trace(&traces, trace_domain.log_size(), assert_func, claimed_sum);
-}
+    for row in 0..trace_domain.size() {
+        let eval = AssertEvaluator::new(&traces, row, trace_domain.log_size(), claimed_sum);
 
-pub fn assert_constraints_on_trace(
-    evals: &TreeVec<Vec<&Vec<M31>>>,
-    log_size: u32,
-    assert_func: impl Fn(AssertEvaluator<'_>) + Sync,
-    claimed_sum: SecureField,
-) {
-    let n_rows = 1 << log_size;
-
-    let iter = parallel_iter!(0..n_rows);
-    iter.for_each(|row| {
-        let eval = AssertEvaluator::new(evals, row, log_size, claimed_sum);
         assert_func(eval);
-    });
+    }
 }

--- a/crates/prover/src/constraint_framework/component.rs
+++ b/crates/prover/src/constraint_framework/component.rs
@@ -1,9 +1,11 @@
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+use core::fmt::{self, Display, Formatter};
+use core::iter::zip;
+use core::ops::Deref;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
-use std::fmt::{self, Display, Formatter};
-use std::iter::zip;
-use std::ops::Deref;
 
-use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use tracing::{span, Level};
@@ -30,6 +32,7 @@ use crate::core::pcs::{TreeSubspan, TreeVec};
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation, PolyOps};
 use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 const CHUNK_SIZE: usize = 1;
 
@@ -80,10 +83,14 @@ impl TraceLocationAllocator {
 
     /// Create a new `TraceLocationAllocator` with fixed preprocessed columns setup.
     pub fn new_with_preproccessed_columns(preprocessed_columns: &[PreProcessedColumnId]) -> Self {
-        assert!(
-            preprocessed_columns.iter().all_unique(),
-            "Duplicate preprocessed columns are not allowed!"
-        );
+        {
+            let mut used = crate::collections::HashSet::new();
+            assert!(
+                preprocessed_columns.iter().all(move |elt| used.insert(elt)),
+                "Duplicate preprocessed columns are not allowed!"
+            );
+        }
+
         Self {
             next_tree_offsets: Default::default(),
             preprocessed_columns: preprocessed_columns.to_vec(),
@@ -235,7 +242,7 @@ impl<E: FrameworkEval> Component for FrameworkComponent<E> {
             .preprocessed_column_indices
             .iter()
             .map(|idx| &mask[PREPROCESSED_TRACE_IDX][*idx])
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         let mut mask_points = mask.sub_tree(&self.trace_locations);
         mask_points[PREPROCESSED_TRACE_IDX] = preprocessed_mask;
@@ -300,7 +307,7 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
         let log_expand = eval_domain.log_size() - trace_domain.log_size();
         let mut denom_inv = (0..1 << log_expand)
             .map(|i| coset_vanishing(trace_domain.coset(), eval_domain.at(i)).inverse())
-            .collect_vec();
+            .collect::<Vec<_>>();
         bit_reverse(&mut denom_inv);
 
         // Accumulator.

--- a/crates/prover/src/constraint_framework/cpu_domain.rs
+++ b/crates/prover/src/constraint_framework/cpu_domain.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 
 use num_traits::Zero;
 
@@ -13,6 +13,7 @@ use crate::core::pcs::TreeVec;
 use crate::core::poly::circle::CircleEvaluation;
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::offset_bit_reversed_circle_domain_index;
+use crate::prelude::*;
 
 /// Evaluates constraints at an evaluation domain points.
 pub struct CpuDomainEvaluator<'a> {

--- a/crates/prover/src/constraint_framework/expr/assignment.rs
+++ b/crates/prover/src/constraint_framework/expr/assignment.rs
@@ -1,14 +1,19 @@
-use std::collections::{HashMap, HashSet};
-use std::hash::{DefaultHasher, Hash, Hasher};
-use std::ops::{Add, Index};
+#[cfg(not(feature = "std"))]
+use core::hash::{BuildHasher, Hash, Hasher};
+use core::ops::{Add, Index};
+#[cfg(feature = "std")]
+use std::hash::{Hash, Hasher};
 
 use itertools::sorted;
 
 use super::{BaseExpr, ColumnExpr, ExtExpr};
+use crate::collections::hash_map::HashMap;
+use crate::collections::hash_set::HashSet;
 use crate::constraint_framework::{AssertEvaluator, EvalAtRow};
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::FieldExpOps;
+use crate::prelude::*;
 
 /// An assignment to the variables that may appear in an expression.
 pub type ExprVarAssignment = (
@@ -26,6 +31,20 @@ pub struct ExprVariables {
     pub cols: HashSet<ColumnExpr>,
     pub params: HashSet<String>,
     pub ext_params: HashSet<String>,
+}
+
+#[cfg(feature = "std")]
+fn native_hash<T: Hash>(value: T) -> u32 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish() as u32
+}
+
+#[cfg(not(feature = "std"))]
+fn native_hash<T: Hash>(value: T) -> u32 {
+    let mut state = hashbrown::DefaultHashBuilder::default().build_hasher();
+    value.hash(&mut state);
+    state.finish() as u32
 }
 
 impl ExprVariables {
@@ -60,31 +79,17 @@ impl ExprVariables {
         let cols = sorted(self.cols.iter())
             .map(|col| {
                 ((col.interaction, col.idx, col.offset), {
-                    let mut hasher = DefaultHasher::new();
-                    (salt, col).hash(&mut hasher);
-                    (hasher.finish() as u32).into()
+                    native_hash((salt, col)).into()
                 })
             })
             .collect();
 
         let params = sorted(self.params.iter())
-            .map(|param| {
-                (param.clone(), {
-                    let mut hasher = DefaultHasher::new();
-                    (salt, param).hash(&mut hasher);
-                    (hasher.finish() as u32).into()
-                })
-            })
+            .map(|param| (param.clone(), { native_hash((salt, param)).into() }))
             .collect();
 
         let ext_params = sorted(self.ext_params.iter())
-            .map(|param| {
-                (param.clone(), {
-                    let mut hasher = DefaultHasher::new();
-                    (salt, param).hash(&mut hasher);
-                    (hasher.finish() as u32).into()
-                })
-            })
+            .map(|param| (param.clone(), { native_hash((salt, param)).into() }))
             .collect();
 
         (cols, params, ext_params)
@@ -215,10 +220,9 @@ impl ExtExpr {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use num_traits::One;
 
+    use crate::collections::HashMap;
     use crate::constraint_framework::expr::utils::*;
     use crate::constraint_framework::AssertEvaluator;
     use crate::core::fields::m31::BaseField;

--- a/crates/prover/src/constraint_framework/expr/degree.rs
+++ b/crates/prover/src/constraint_framework/expr/degree.rs
@@ -1,3 +1,5 @@
+use super::{BaseExpr, ExtExpr};
+use crate::collections::hash_map::HashMap;
 /// Finds a degree bound for an expressions. The degree is given with respect to columns as
 /// variables.
 /// Computes the actual degree with the following caveats:
@@ -7,9 +9,7 @@
 ///        simplification.
 ///     2. If expressions p and q cancel out under some operation, this will not be accounted
 ///        for, so that (x^2 + 1) - (x^2 + x) will return degree 2.
-use std::collections::HashMap;
-
-use super::{BaseExpr, ExtExpr};
+use crate::prelude::*;
 
 type Degree = usize;
 

--- a/crates/prover/src/constraint_framework/expr/evaluator.rs
+++ b/crates/prover/src/constraint_framework/expr/evaluator.rs
@@ -5,6 +5,7 @@ use crate::constraint_framework::expr::ColumnExpr;
 use crate::constraint_framework::preprocessed_columns::PreProcessedColumnId;
 use crate::constraint_framework::{EvalAtRow, Relation, RelationEntry, INTERACTION_TRACE_IDX};
 use crate::core::lookups::utils::Fraction;
+use crate::prelude::*;
 
 pub struct FormalLogupAtRow {
     pub interaction: usize,
@@ -119,7 +120,7 @@ impl EvalAtRow for ExprEvaluator {
         interaction: usize,
         offsets: [isize; N],
     ) -> [Self::F; N] {
-        let res = std::array::from_fn(|i| {
+        let res = core::array::from_fn(|i| {
             let col = ColumnExpr::from((interaction, self.cur_var_index, offsets[i]));
             BaseExpr::Col(col)
         });

--- a/crates/prover/src/constraint_framework/expr/format.rs
+++ b/crates/prover/src/constraint_framework/expr/format.rs
@@ -1,6 +1,7 @@
 use num_traits::Zero;
 
 use super::{BaseExpr, ColumnExpr, ExtExpr};
+use crate::prelude::*;
 
 impl BaseExpr {
     pub fn format_expr(&self) -> String {

--- a/crates/prover/src/constraint_framework/expr/mod.rs
+++ b/crates/prover/src/constraint_framework/expr/mod.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 pub mod assignment;
 pub mod degree;
 pub mod evaluator;
@@ -5,7 +7,7 @@ pub mod format;
 pub mod simplify;
 pub mod utils;
 
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
 
 pub use evaluator::ExprEvaluator;
 use num_traits::{One, Zero};

--- a/crates/prover/src/constraint_framework/expr/simplify.rs
+++ b/crates/prover/src/constraint_framework/expr/simplify.rs
@@ -2,6 +2,7 @@ use num_traits::{One, Zero};
 
 use super::{BaseExpr, ExtExpr};
 use crate::core::fields::qm31::SecureField;
+use crate::prelude::*;
 
 /// Applies simplifications to arithmetic expressions that can be used both for `BaseExpr` and for
 /// `ExtExpr`.
@@ -150,11 +151,10 @@ impl ExtExpr {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
 
+    use crate::collections::HashMap;
     use crate::constraint_framework::expr::utils::*;
     use crate::constraint_framework::AssertEvaluator;
     use crate::core::fields::m31::BaseField;

--- a/crates/prover/src/constraint_framework/info.rs
+++ b/crates/prover/src/constraint_framework/info.rs
@@ -1,6 +1,9 @@
-use std::array;
-use std::cell::{RefCell, RefMut};
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+use core::array;
+use core::cell::{RefCell, RefMut};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+#[cfg(feature = "std")]
 use std::rc::Rc;
 
 use num_traits::{One, Zero};
@@ -14,6 +17,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::fields::FieldExpOps;
 use crate::core::lookups::utils::Fraction;
 use crate::core::pcs::TreeVec;
+use crate::prelude::*;
 
 /// Collects information about the constraints.
 /// This includes mask offsets and columns at each interaction, the number of constraints and number

--- a/crates/prover/src/constraint_framework/logup.rs
+++ b/crates/prover/src/constraint_framework/logup.rs
@@ -1,6 +1,5 @@
-use std::ops::{Mul, Sub};
+use core::ops::{Mul, Sub};
 
-use itertools::Itertools;
 use num_traits::{One, Zero};
 
 use super::EvalAtRow;
@@ -19,6 +18,7 @@ use crate::core::lookups::utils::Fraction;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// Evaluates constraints for batched logups.
 /// These constraint enforce the sum of multiplicity_i / (z + sum_j alpha^j * x_j) = claimed_sum.
@@ -80,7 +80,7 @@ impl<const N: usize> LookupElements<N> {
     pub fn draw(channel: &mut impl Channel) -> Self {
         let [z, alpha] = channel.draw_felts(2).try_into().unwrap();
         let mut cur = SecureField::one();
-        let alpha_powers = std::array::from_fn(|_| {
+        let alpha_powers = core::array::from_fn(|_| {
             let res = cur;
             cur *= alpha;
             res
@@ -185,7 +185,7 @@ impl LogupTraceGenerator {
                     CircleEvaluation::new(CanonicCoset::new(self.log_size).circle_domain(), col)
                 })
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
         (trace, claimed_sum)
     }
 }

--- a/crates/prover/src/constraint_framework/mod.rs
+++ b/crates/prover/src/constraint_framework/mod.rs
@@ -1,4 +1,6 @@
 /// ! This module contains helpers to express and use constraints for components.
+use crate::prelude::*;
+
 mod assert;
 mod component;
 mod cpu_domain;
@@ -10,11 +12,11 @@ pub mod preprocessed_columns;
 pub mod relation_tracker;
 mod simd_domain;
 
-use std::array;
-use std::fmt::Debug;
-use std::ops::{Add, AddAssign, Mul, Neg, Sub};
+use core::array;
+use core::fmt::Debug;
+use core::ops::{Add, AddAssign, Mul, Neg, Sub};
 
-pub use assert::{assert_constraints_on_polys, assert_constraints_on_trace, AssertEvaluator};
+pub use assert::{assert_constraints, AssertEvaluator};
 pub use component::{FrameworkComponent, FrameworkEval, TraceLocationAllocator};
 pub use info::InfoEvaluator;
 use num_traits::{One, Zero};
@@ -191,7 +193,7 @@ macro_rules! logup_proxy {
             let last_batch = *batching.iter().max().unwrap();
 
             let mut fracs_by_batch =
-                std::collections::HashMap::<usize, Vec<Fraction<Self::EF, Self::EF>>>::new();
+                crate::collections::HashMap::<usize, Vec<Fraction<Self::EF, Self::EF>>>::new();
 
             for (batch, frac) in batching.iter().zip(self.logup.fracs.iter()) {
                 fracs_by_batch
@@ -200,8 +202,8 @@ macro_rules! logup_proxy {
                     .push(frac.clone());
             }
 
-            let keys_set: std::collections::HashSet<_> = fracs_by_batch.keys().cloned().collect();
-            let all_batches_set: std::collections::HashSet<_> = (0..last_batch + 1).collect();
+            let keys_set: crate::collections::HashSet<_> = fracs_by_batch.keys().cloned().collect();
+            let all_batches_set: crate::collections::HashSet<_> = (0..last_batch + 1).collect();
 
             assert_eq!(
                 keys_set, all_batches_set,

--- a/crates/prover/src/constraint_framework/point.rs
+++ b/crates/prover/src/constraint_framework/point.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 
 use super::logup::LogupAtRow;
 use super::{EvalAtRow, INTERACTION_TRACE_IDX};
@@ -8,6 +8,7 @@ use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
 use crate::core::lookups::utils::Fraction;
 use crate::core::pcs::TreeVec;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// Evaluates expressions at a point out of domain.
 pub struct PointEvaluator<'a> {

--- a/crates/prover/src/constraint_framework/preprocessed_columns.rs
+++ b/crates/prover/src/constraint_framework/preprocessed_columns.rs
@@ -1,4 +1,4 @@
-use std::simd::Simd;
+use core::simd::Simd;
 
 use num_traits::{One, Zero};
 
@@ -8,6 +8,7 @@ use crate::core::backend::{Col, Column};
 use crate::core::fields::m31::BaseField;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
+use crate::prelude::*;
 
 /// Used for comparing preprocessed columns.
 /// Column IDs must be unique in a given context.
@@ -30,7 +31,7 @@ impl IsFirst {
         assert!(vec_row < (1 << self.log_size) / N_LANES);
         if vec_row == 0 {
             unsafe {
-                PackedM31::from_simd_unchecked(Simd::from_array(std::array::from_fn(|i| {
+                PackedM31::from_simd_unchecked(Simd::from_array(core::array::from_fn(|i| {
                     if i == 0 {
                         1
                     } else {

--- a/crates/prover/src/constraint_framework/relation_tracker.rs
+++ b/crates/prover/src/constraint_framework/relation_tracker.rs
@@ -1,13 +1,12 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
-use itertools::Itertools;
 use num_traits::Zero;
 
 use super::{
     Batching, EvalAtRow, FrameworkComponent, FrameworkEval, Relation, RelationEntry,
     TraceLocationAllocator, INTERACTION_TRACE_IDX, PREPROCESSED_TRACE_IDX,
 };
+use crate::collections::hash_map::HashMap;
 use crate::core::backend::simd::m31::{PackedBaseField, LOG_N_LANES, N_LANES};
 use crate::core::backend::simd::qm31::PackedSecureField;
 use crate::core::backend::simd::very_packed_m31::LOG_N_VERY_PACKED_ELEMS;
@@ -21,6 +20,7 @@ use crate::core::pcs::{TreeSubspan, TreeVec};
 use crate::core::poly::circle::CircleEvaluation;
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::offset_bit_reversed_circle_domain_index;
+use crate::prelude::*;
 
 #[derive(Debug)]
 pub struct RelationTrackerEntry {
@@ -58,7 +58,7 @@ impl<E: FrameworkEval> RelationTrackerComponent<E> {
         // Deref the sub-tree. Only copies the references.
         let mut sub_tree = trace
             .sub_tree(&self.trace_locations)
-            .map(|vec| vec.into_iter().copied().collect_vec());
+            .map(|vec| vec.into_iter().copied().collect::<Vec<_>>());
         sub_tree[PREPROCESSED_TRACE_IDX] = self
             .preprocessed_column_indices
             .iter()
@@ -130,7 +130,7 @@ impl EvalAtRow for RelationTrackerEvaluator<'_> {
             // Otherwise, we need to look up the value at the offset.
             // Since the domain is bit-reversed circle domain ordered, we need to look up the value
             // at the bit-reversed natural order index at an offset.
-            PackedBaseField::from_array(std::array::from_fn(|i| {
+            PackedBaseField::from_array(core::array::from_fn(|i| {
                 let row_index = offset_bit_reversed_circle_domain_index(
                     (self.vec_row << (LOG_N_LANES + LOG_N_VERY_PACKED_ELEMS)) + i,
                     self.domain_log_size,
@@ -159,12 +159,16 @@ impl EvalAtRow for RelationTrackerEvaluator<'_> {
         entry: RelationEntry<'_, Self::F, Self::EF, R>,
     ) {
         let relation = entry.relation.get_name().to_owned();
-        let values = entry.values.iter().map(|v| v.to_array()).collect_vec();
+        let values = entry
+            .values
+            .iter()
+            .map(|v| v.to_array())
+            .collect::<Vec<_>>();
         let mult = entry.multiplicity.to_array();
 
         // Unpack SIMD.
         for j in 0..N_LANES {
-            let values = values.iter().map(|v| v[j]).collect_vec();
+            let values = values.iter().map(|v| v[j]).collect::<Vec<_>>();
             let mult = mult[j].to_m31_array()[0];
             self.entries.push(RelationTrackerEntry {
                 relation: relation.clone(),
@@ -201,7 +205,7 @@ impl RelationSummary {
                 let mult = relation_sums.entry(values).or_insert(M31::zero());
                 *mult += entry.mult;
             }
-            let relation_sums = relation_sums.into_iter().collect_vec();
+            let relation_sums = relation_sums.into_iter().collect::<Vec<_>>();
             summary.push((relation.clone(), relation_sums));
         }
         Self(summary)
@@ -233,11 +237,11 @@ impl RelationSummary {
     }
 }
 impl Debug for RelationSummary {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for (relation, entries) in &self.0 {
             writeln!(f, "{}:", relation)?;
             for (vector, sum) in entries {
-                let vector = vector.iter().map(|v| v.0).collect_vec();
+                let vector = vector.iter().map(|v| v.0).collect::<Vec<_>>();
                 writeln!(f, "  {:?} -> {}", vector, sum)?;
             }
         }

--- a/crates/prover/src/constraint_framework/simd_domain.rs
+++ b/crates/prover/src/constraint_framework/simd_domain.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use core::ops::Mul;
 
 use num_traits::Zero;
 
@@ -19,6 +19,7 @@ use crate::core::pcs::TreeVec;
 use crate::core::poly::circle::CircleEvaluation;
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::offset_bit_reversed_circle_domain_index;
+use crate::prelude::*;
 
 /// Evaluates constraints at an evaluation domain points.
 pub struct SimdDomainEvaluator<'a> {
@@ -85,7 +86,7 @@ impl EvalAtRow for SimdDomainEvaluator<'_> {
             // Otherwise, we need to look up the value at the offset.
             // Since the domain is bit-reversed circle domain ordered, we need to look up the value
             // at the bit-reversed natural order index at an offset.
-            VeryPackedBaseField::from_array(std::array::from_fn(|i| {
+            VeryPackedBaseField::from_array(core::array::from_fn(|i| {
                 let row_index = offset_bit_reversed_circle_domain_index(
                     (self.vec_row << (LOG_N_LANES + LOG_N_VERY_PACKED_ELEMS)) + i,
                     self.domain_log_size,

--- a/crates/prover/src/core/air/accumulation.rs
+++ b/crates/prover/src/core/air/accumulation.rs
@@ -4,7 +4,6 @@
 //! defined as
 //!   f(p) = sum_i alpha^{N-1-i} u_i(P).
 
-use itertools::Itertools;
 use tracing::{span, Level};
 
 use crate::core::backend::{Backend, Col, Column, ColumnOps, CpuBackend};
@@ -13,6 +12,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SecureColumnByCoords;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation, CirclePoly, SecureCirclePoly};
 use crate::core::poly::BitReversedOrder;
+use crate::prelude::*;
 
 /// Accumulates N evaluations of u_i(P0) at a single point.
 /// Computes f(P0), the combined polynomial at that point.
@@ -90,7 +90,7 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
                     col: col.get_or_insert_with(|| SecureColumnByCoords::zeros(1 << log_size)),
                 }
             })
-            .collect_vec()
+            .collect::<Vec<_>>()
             .try_into()
             .unwrap_or_else(|_| unreachable!())
     }
@@ -141,7 +141,7 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
             })));
         }
         cur_poly.unwrap_or_else(|| {
-            SecureCirclePoly(std::array::from_fn(|_| {
+            SecureCirclePoly(core::array::from_fn(|_| {
                 CirclePoly::new(Col::<B, BaseField>::zeros(1 << log_size))
             }))
         })
@@ -171,7 +171,7 @@ impl ColumnAccumulator<'_, CpuBackend> {
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use core::array;
 
     use num_traits::Zero;
     use rand::rngs::SmallRng;

--- a/crates/prover/src/core/air/components.rs
+++ b/crates/prover/src/core/air/components.rs
@@ -1,6 +1,4 @@
-use std::iter::zip;
-
-use itertools::Itertools;
+use core::iter::zip;
 
 use super::accumulation::{DomainEvaluationAccumulator, PointEvaluationAccumulator};
 use super::{Component, ComponentProver, Trace};
@@ -11,6 +9,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::pcs::TreeVec;
 use crate::core::poly::circle::SecureCirclePoly;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 pub struct Components<'a> {
     pub components: Vec<&'a dyn Component>,
@@ -115,7 +114,7 @@ impl<B: Backend> ComponentProvers<'_, B> {
                 .components
                 .iter()
                 .map(|c| *c as &dyn Component)
-                .collect_vec(),
+                .collect::<Vec<_>>(),
             n_preprocessed_columns: self.n_preprocessed_columns,
         }
     }

--- a/crates/prover/src/core/air/mask.rs
+++ b/crates/prover/src/core/air/mask.rs
@@ -1,12 +1,9 @@
-use std::collections::HashSet;
-use std::vec;
-
-use itertools::Itertools;
-
+use crate::collections::hash_set::HashSet;
 use crate::core::circle::CirclePoint;
 use crate::core::fields::qm31::SecureField;
 use crate::core::poly::circle::CanonicCoset;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// Mask holds a vector with an entry for each column.
 /// Each entry holds a list of mask items, which are the offsets of the mask at that column.
@@ -23,7 +20,7 @@ pub fn fixed_mask_points(
             .flat_map(|mask_entry| mask_entry.iter().collect::<HashSet<_>>())
             .collect::<HashSet<&usize>>()
             .into_iter()
-            .collect_vec(),
+            .collect::<Vec<_>>(),
         vec![&0]
     );
     mask.iter()

--- a/crates/prover/src/core/air/mod.rs
+++ b/crates/prover/src/core/air/mod.rs
@@ -9,6 +9,7 @@ use super::pcs::TreeVec;
 use super::poly::circle::{CircleEvaluation, CirclePoly};
 use super::poly::BitReversedOrder;
 use super::ColumnVec;
+use crate::prelude::*;
 
 pub mod accumulation;
 mod components;

--- a/crates/prover/src/core/backend/cpu/accumulation.rs
+++ b/crates/prover/src/core/backend/cpu/accumulation.rs
@@ -4,6 +4,7 @@ use crate::core::air::accumulation::AccumulationOps;
 use crate::core::backend::cpu::CpuBackend;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SecureColumnByCoords;
+use crate::prelude::*;
 
 impl AccumulationOps for CpuBackend {
     fn accumulate(column: &mut SecureColumnByCoords<Self>, other: &SecureColumnByCoords<Self>) {

--- a/crates/prover/src/core/backend/cpu/blake2s.rs
+++ b/crates/prover/src/core/backend/cpu/blake2s.rs
@@ -1,10 +1,9 @@
-use itertools::Itertools;
-
 use crate::core::backend::CpuBackend;
 use crate::core::fields::m31::BaseField;
 use crate::core::vcs::blake2_hash::Blake2sHash;
 use crate::core::vcs::blake2_merkle::Blake2sMerkleHasher;
 use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
+use crate::prelude::*;
 
 impl MerkleOps<Blake2sMerkleHasher> for CpuBackend {
     fn commit_on_layer(
@@ -16,7 +15,7 @@ impl MerkleOps<Blake2sMerkleHasher> for CpuBackend {
             .map(|i| {
                 Blake2sMerkleHasher::hash_node(
                     prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
-                    &columns.iter().map(|column| column[i]).collect_vec(),
+                    &columns.iter().map(|column| column[i]).collect::<Vec<_>>(),
                 )
             })
             .collect()

--- a/crates/prover/src/core/backend/cpu/circle.rs
+++ b/crates/prover/src/core/backend/cpu/circle.rs
@@ -15,6 +15,7 @@ use crate::core::poly::twiddles::TwiddleTree;
 use crate::core::poly::utils::{domain_line_twiddles_from_tree, fold};
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::coset_order_to_circle_domain_order;
+use crate::prelude::*;
 
 impl PolyOps for CpuBackend {
     type Twiddles = Vec<BaseField>;
@@ -247,7 +248,7 @@ impl<F: ExtensionOf<BaseField>, EvalOrder> IntoIterator
     for CircleEvaluation<CpuBackend, F, EvalOrder>
 {
     type Item = F;
-    type IntoIter = std::vec::IntoIter<F>;
+    type IntoIter = vec::IntoIter<F>;
 
     /// Creates a consuming iterator over the evaluations.
     ///
@@ -259,7 +260,7 @@ impl<F: ExtensionOf<BaseField>, EvalOrder> IntoIterator
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
+    use core::iter::zip;
 
     use num_traits::One;
 

--- a/crates/prover/src/core/backend/cpu/lookups/gkr.rs
+++ b/crates/prover/src/core/backend/cpu/lookups/gkr.rs
@@ -1,4 +1,4 @@
-use std::ops::Index;
+use core::ops::Index;
 
 use num_traits::{One, Zero};
 
@@ -12,6 +12,7 @@ use crate::core::lookups::gkr_prover::{
 use crate::core::lookups::mle::{Mle, MleOps};
 use crate::core::lookups::sumcheck::MultivariatePolyOracle;
 use crate::core::lookups::utils::{Fraction, Reciprocal, UnivariatePoly};
+use crate::prelude::*;
 
 impl GkrOps for CpuBackend {
     fn gen_eq_evals(y: &[SecureField], v: SecureField) -> Mle<Self, SecureField> {
@@ -278,7 +279,7 @@ impl<F: Field> Index<usize> for MleExpr<'_, F> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
+    use core::iter::zip;
 
     use num_traits::{One, Zero};
     use rand::rngs::SmallRng;

--- a/crates/prover/src/core/backend/cpu/lookups/mle.rs
+++ b/crates/prover/src/core/backend/cpu/lookups/mle.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use core::iter::zip;
 
 use num_traits::{One, Zero};
 

--- a/crates/prover/src/core/backend/cpu/mod.rs
+++ b/crates/prover/src/core/backend/cpu/mod.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 pub mod accumulation;
 mod blake2s;
 pub mod circle;
@@ -8,7 +10,7 @@ pub mod lookups;
 mod poseidon252;
 pub mod quotients;
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
@@ -83,7 +85,6 @@ pub type CpuMle<F> = Mle<CpuBackend, F>;
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
     use rand::prelude::*;
     use rand::rngs::SmallRng;
 
@@ -111,7 +112,7 @@ mod tests {
     fn batch_inverse_in_place_test() {
         let mut rng = SmallRng::seed_from_u64(0);
         let column = rng.gen::<[QM31; 16]>().to_vec();
-        let expected = column.iter().map(|e| e.inverse()).collect_vec();
+        let expected = column.iter().map(|e| e.inverse()).collect::<Vec<_>>();
         let mut dst = Vec::zeros(column.len());
 
         batch_inverse_in_place(&column, &mut dst);

--- a/crates/prover/src/core/backend/cpu/poseidon252.rs
+++ b/crates/prover/src/core/backend/cpu/poseidon252.rs
@@ -1,10 +1,10 @@
-use itertools::Itertools;
 use starknet_ff::FieldElement as FieldElement252;
 
 use super::CpuBackend;
 use crate::core::fields::m31::BaseField;
 use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleHasher;
+use crate::prelude::*;
 
 impl MerkleOps<Poseidon252MerkleHasher> for CpuBackend {
     fn commit_on_layer(
@@ -16,7 +16,7 @@ impl MerkleOps<Poseidon252MerkleHasher> for CpuBackend {
             .map(|i| {
                 Poseidon252MerkleHasher::hash_node(
                     prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
-                    &columns.iter().map(|column| column[i]).collect_vec(),
+                    &columns.iter().map(|column| column[i]).collect::<Vec<_>>(),
                 )
             })
             .collect()

--- a/crates/prover/src/core/backend/cpu/quotients.rs
+++ b/crates/prover/src/core/backend/cpu/quotients.rs
@@ -1,4 +1,4 @@
-use itertools::{izip, zip_eq, Itertools};
+use itertools::{izip, zip_eq};
 use num_traits::{One, Zero};
 
 use super::CpuBackend;
@@ -13,6 +13,7 @@ use crate::core::pcs::quotients::{ColumnSampleBatch, PointSample, QuotientOps};
 use crate::core::poly::circle::{CircleDomain, CircleEvaluation, SecureEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::bit_reverse_index;
+use crate::prelude::*;
 
 impl QuotientOps for CpuBackend {
     fn accumulate_quotients(
@@ -27,7 +28,7 @@ impl QuotientOps for CpuBackend {
 
         for row in 0..domain.size() {
             let domain_point = domain.at(bit_reverse_index(row, domain.log_size()));
-            let query_values_at_row = columns.iter().map(|col| col[row]).collect_vec();
+            let query_values_at_row = columns.iter().map(|col| col[row]).collect::<Vec<_>>();
             let row_value = accumulate_row_quotients(
                 sample_batches,
                 &query_values_at_row,

--- a/crates/prover/src/core/backend/mod.rs
+++ b/crates/prover/src/core/backend/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 pub use cpu::CpuBackend;
 
@@ -12,6 +12,7 @@ use super::pcs::quotients::QuotientOps;
 use super::poly::circle::PolyOps;
 use super::proof_of_work::GrindOps;
 use super::vcs::ops::MerkleOps;
+use crate::prelude::*;
 
 pub mod cpu;
 pub mod simd;

--- a/crates/prover/src/core/backend/simd/accumulation.rs
+++ b/crates/prover/src/core/backend/simd/accumulation.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::core::air::accumulation::AccumulationOps;
 use crate::core::backend::simd::m31::N_LANES;
 use crate::core::backend::simd::qm31::PackedSecureField;
@@ -7,6 +5,7 @@ use crate::core::backend::simd::SimdBackend;
 use crate::core::backend::CpuBackend;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SecureColumnByCoords;
+use crate::prelude::*;
 
 impl AccumulationOps for SimdBackend {
     fn accumulate(column: &mut SecureColumnByCoords<Self>, other: &SecureColumnByCoords<Self>) {
@@ -35,7 +34,7 @@ impl AccumulationOps for SimdBackend {
             })
             .flat_map(|x| x.to_array())
             .take(n_powers)
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 }
 

--- a/crates/prover/src/core/backend/simd/bit_reverse.rs
+++ b/crates/prover/src/core/backend/simd/bit_reverse.rs
@@ -1,4 +1,4 @@
-use std::array;
+use core::array;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -148,8 +148,6 @@ fn bit_reverse16(mut data: [PackedBaseField; 16]) -> [PackedBaseField; 16] {
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-
     use super::{bit_reverse16, bit_reverse_m31, MIN_LOG_SIZE};
     use crate::core::backend::cpu::bit_reverse as cpu_bit_reverse;
     use crate::core::backend::simd::column::BaseColumn;
@@ -185,7 +183,7 @@ mod tests {
     #[test]
     fn bit_reverse_small_column_works() {
         const LOG_SIZE: u32 = MIN_LOG_SIZE - 1;
-        let column = (0..1 << LOG_SIZE).map(BaseField::from).collect_vec();
+        let column = (0..1 << LOG_SIZE).map(BaseField::from).collect::<Vec<_>>();
         let mut expected = column.clone();
         cpu_bit_reverse(&mut expected);
 
@@ -198,7 +196,7 @@ mod tests {
     #[test]
     fn bit_reverse_large_column_works() {
         const LOG_SIZE: u32 = MIN_LOG_SIZE;
-        let column = (0..1 << LOG_SIZE).map(BaseField::from).collect_vec();
+        let column = (0..1 << LOG_SIZE).map(BaseField::from).collect::<Vec<_>>();
         let mut expected = column.clone();
         cpu_bit_reverse(&mut expected);
 

--- a/crates/prover/src/core/backend/simd/blake2s.rs
+++ b/crates/prover/src/core/backend/simd/blake2s.rs
@@ -1,13 +1,12 @@
 //! A SIMD implementation of the BLAKE2s compression function.
 //! Based on <https://github.com/oconnor663/blake2_simd/blob/master/blake2s/src/avx2.rs>.
 
-use std::array;
-use std::iter::repeat;
-use std::mem::transmute;
-use std::simd::u32x16;
+use core::array;
+use core::iter::repeat;
+use core::mem::transmute;
+use core::simd::u32x16;
 
 use bytemuck::cast_slice;
-use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -19,6 +18,7 @@ use crate::core::vcs::blake2_hash::Blake2sHash;
 use crate::core::vcs::blake2_merkle::Blake2sMerkleHasher;
 use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
 use crate::parallel_iter;
+use crate::prelude::*;
 
 const IV: [u32; 8] = [
     0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
@@ -56,7 +56,10 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
                 .map(|i| {
                     Blake2sMerkleHasher::hash_node(
                         prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
-                        &columns.iter().map(|column| column.at(i)).collect_vec(),
+                        &columns
+                            .iter()
+                            .map(|column| column.at(i))
+                            .collect::<Vec<_>>(),
                     )
                 })
                 .collect();
@@ -77,13 +80,13 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
         let iter = res.par_chunks_mut(1 << LOG_N_LANES);
 
         iter.enumerate().for_each(|(i, chunk)| {
-            let mut state: [u32x16; 8] = unsafe { std::mem::zeroed() };
+            let mut state: [u32x16; 8] = unsafe { core::mem::zeroed() };
             // Hash prev_layer, if exists.
             if let Some(prev_layer) = prev_layer {
                 let prev_chunk_u32s = cast_slice::<_, u32>(&prev_layer[(i << 5)..((i + 1) << 5)]);
                 // Note: prev_layer might be unaligned.
                 let msgs: [u32x16; 16] = array::from_fn(|j| {
-                    u32x16::from_array(std::array::from_fn(|k| prev_chunk_u32s[16 * j + k]))
+                    u32x16::from_array(core::array::from_fn(|k| prev_chunk_u32s[16 * j + k]))
                 });
                 state = compress16(state, transpose_msgs(msgs), zeros, zeros, zeros, zeros);
             }
@@ -103,7 +106,7 @@ impl MerkleOps<Blake2sMerkleHasher> for SimdBackend {
                     .map(|column| column.data[i].into_simd())
                     .chain(repeat(zeros))
                     .take(N_LANES)
-                    .collect_vec()
+                    .collect::<Vec<_>>()
                     .try_into()
                     .unwrap();
                 state = compress16(state, msgs, zeros, zeros, zeros, zeros);
@@ -337,9 +340,9 @@ pub fn compress16(
 
 #[cfg(test)]
 mod tests {
-    use std::array;
-    use std::mem::transmute;
-    use std::simd::u32x16;
+    use core::array;
+    use core::mem::transmute;
+    use core::simd::u32x16;
 
     use aligned::{Aligned, A64};
 

--- a/crates/prover/src/core/backend/simd/circle.rs
+++ b/crates/prover/src/core/backend/simd/circle.rs
@@ -1,6 +1,6 @@
-use std::iter::zip;
-use std::mem::transmute;
-use std::simd::Simd;
+use core::iter::zip;
+use core::mem::transmute;
+use core::simd::Simd;
 
 use bytemuck::Zeroable;
 use num_traits::One;
@@ -24,6 +24,7 @@ use crate::core::poly::twiddles::TwiddleTree;
 use crate::core::poly::utils::{domain_line_twiddles_from_tree, fold};
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::bit_reverse_index;
+use crate::prelude::*;
 
 impl SimdBackend {
     // TODO(Ohad): optimize.
@@ -180,10 +181,10 @@ impl PolyOps for SimdBackend {
         // 8 lowest mappings produce the first 2^8 twiddles. Separate to optimize each calculation.
         let (map_low, map_high) = mappings.split_at(4);
         let twiddle_lows =
-            PackedSecureField::from_array(std::array::from_fn(|i| Self::twiddle_at(map_low, i)));
+            PackedSecureField::from_array(core::array::from_fn(|i| Self::twiddle_at(map_low, i)));
         let (map_mid, map_high) = map_high.split_at(4);
         let twiddle_mids =
-            PackedSecureField::from_array(std::array::from_fn(|i| Self::twiddle_at(map_mid, i)));
+            PackedSecureField::from_array(core::array::from_fn(|i| Self::twiddle_at(map_mid, i)));
 
         // Compute the high twiddle steps.
         let twiddle_steps = Self::twiddle_steps(map_high);
@@ -347,7 +348,7 @@ fn compute_coset_twiddles(coset: Coset, twiddles: &mut Vec<PackedM31>) {
     assert!(log_size >= LOG_N_LANES);
 
     // Compute the first `N_LANES` circle points.
-    let initial_points = std::array::from_fn(|i| coset.at(bit_reverse_index(i, log_size)));
+    let initial_points = core::array::from_fn(|i| coset.at(bit_reverse_index(i, log_size)));
     let mut current = CirclePoint {
         x: PackedM31::from_array(initial_points.each_ref().map(|p| p.x)),
         y: PackedM31::from_array(initial_points.each_ref().map(|p| p.y)),
@@ -402,7 +403,6 @@ fn slow_eval_at_point(
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
 
@@ -521,7 +521,7 @@ mod tests {
                 .twiddles
                 .iter()
                 .map(|x| x.0 * 2)
-                .collect_vec()
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/crates/prover/src/core/backend/simd/cm31.rs
+++ b/crates/prover/src/core/backend/simd/cm31.rs
@@ -1,5 +1,5 @@
-use std::array;
-use std::ops::{Add, Mul, MulAssign, Neg, Sub};
+use core::array;
+use core::ops::{Add, Mul, MulAssign, Neg, Sub};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
@@ -8,6 +8,7 @@ use super::m31::{PackedM31, N_LANES};
 use super::PACKED_CM31_BATCH_INVERSE_CHUNK_SIZE;
 use crate::core::fields::cm31::CM31;
 use crate::core::fields::{batch_inverse_chunked, FieldExpOps};
+use crate::prelude::*;
 
 /// SIMD implementation of [`CM31`].
 #[derive(Copy, Clone, Debug)]
@@ -176,7 +177,7 @@ impl Neg for PackedCM31 {
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use core::array;
 
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};

--- a/crates/prover/src/core/backend/simd/column.rs
+++ b/crates/prover/src/core/backend/simd/column.rs
@@ -1,9 +1,9 @@
-use std::iter::zip;
-use std::{array, mem};
+use core::iter::zip;
+use core::{array, mem};
 
 use bytemuck::allocation::cast_vec;
 use bytemuck::{cast_slice, cast_slice_mut, Zeroable};
-use itertools::{izip, Itertools};
+use itertools::izip;
 use num_traits::Zero;
 
 use super::cm31::PackedCM31;
@@ -18,6 +18,7 @@ use crate::core::fields::cm31::CM31;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::{SecureColumnByCoords, SECURE_EXTENSION_DEGREE};
+use crate::prelude::*;
 
 /// An efficient structure for storing and operating on a arbitrary number of [`BaseField`] values.
 #[derive(Clone, Debug)]
@@ -64,7 +65,7 @@ impl BaseColumn {
         self.data
             .chunks_mut(chunk_size)
             .map(BaseColumnMutSlice)
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 
     pub fn into_secure_column(self) -> SecureColumn {
@@ -109,7 +110,9 @@ impl Column<BaseField> for BaseColumn {
 impl FromIterator<BaseField> for BaseColumn {
     fn from_iter<I: IntoIterator<Item = BaseField>>(iter: I) -> Self {
         let mut chunks = iter.into_iter().array_chunks();
-        let mut data = (&mut chunks).map(PackedBaseField::from_array).collect_vec();
+        let mut data = (&mut chunks)
+            .map(PackedBaseField::from_array)
+            .collect::<Vec<_>>();
         let mut length = data.len() * N_LANES;
 
         if let Some(remainder) = chunks.into_remainder() {
@@ -173,7 +176,9 @@ impl Column<CM31> for CM31Column {
 impl FromIterator<CM31> for CM31Column {
     fn from_iter<I: IntoIterator<Item = CM31>>(iter: I) -> Self {
         let mut chunks = iter.into_iter().array_chunks();
-        let mut data = (&mut chunks).map(PackedCM31::from_array).collect_vec();
+        let mut data = (&mut chunks)
+            .map(PackedCM31::from_array)
+            .collect::<Vec<_>>();
         let mut length = data.len() * N_LANES;
 
         if let Some(remainder) = chunks.into_remainder() {
@@ -191,7 +196,7 @@ impl FromIterator<CM31> for CM31Column {
 
 impl FromIterator<PackedCM31> for CM31Column {
     fn from_iter<I: IntoIterator<Item = PackedCM31>>(iter: I) -> Self {
-        let data = (&mut iter.into_iter()).collect_vec();
+        let data = (&mut iter.into_iter()).collect::<Vec<_>>();
         let length = data.len() * N_LANES;
 
         Self { data, length }
@@ -290,7 +295,7 @@ impl FromIterator<SecureField> for SecureColumn {
         let mut chunks = iter.into_iter().array_chunks();
         let mut data = (&mut chunks)
             .map(PackedSecureField::from_array)
-            .collect_vec();
+            .collect::<Vec<_>>();
         let mut length = data.len() * N_LANES;
 
         if let Some(remainder) = chunks.into_remainder() {
@@ -308,7 +313,7 @@ impl FromIterator<SecureField> for SecureColumn {
 
 impl FromIterator<PackedSecureField> for SecureColumn {
     fn from_iter<I: IntoIterator<Item = PackedSecureField>>(iter: I) -> Self {
-        let data = iter.into_iter().collect_vec();
+        let data = iter.into_iter().collect::<Vec<_>>();
         let length = data.len() * N_LANES;
         Self { data, length }
     }
@@ -356,7 +361,7 @@ impl VeryPackedSecureColumnByCoordsMutSlice<'_> {
     ///
     /// `vec_index` must be a valid index.
     pub unsafe fn packed_at(&self, vec_index: usize) -> VeryPackedSecureField {
-        VeryPackedQM31::from_very_packed_m31s(std::array::from_fn(|i| {
+        VeryPackedQM31::from_very_packed_m31s(core::array::from_fn(|i| {
             *self.0[i].0.get_unchecked(vec_index)
         }))
     }
@@ -427,7 +432,7 @@ impl SecureColumnByCoords<SimdBackend> {
             .map(|x| x.chunks_mut(chunk_size));
         izip!(a, b, c, d)
             .map(|(a, b, c, d)| SecureColumnByCoordsMutSlice([a, b, c, d]))
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 
     pub fn from_cpu(cpu: SecureColumnByCoords<CpuBackend>) -> Self {
@@ -458,14 +463,14 @@ impl VeryPackedBaseColumn {
     ///
     /// The resulting pointer does not update the underlying `data`'s length.
     pub const unsafe fn transform_under_ref(value: &BaseColumn) -> &Self {
-        &*(std::ptr::addr_of!(*value) as *const VeryPackedBaseColumn)
+        &*(core::ptr::addr_of!(*value) as *const VeryPackedBaseColumn)
     }
 
     pub fn chunks_mut(&mut self, chunk_size: usize) -> Vec<VeryPackedBaseColumnMutSlice<'_>> {
         self.data
             .chunks_mut(chunk_size)
             .map(VeryPackedBaseColumnMutSlice)
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 }
 
@@ -540,7 +545,7 @@ impl From<SecureColumnByCoords<SimdBackend>> for VeryPackedSecureColumnByCoords 
                 .columns
                 .into_iter()
                 .map(VeryPackedBaseColumn::from)
-                .collect_vec()
+                .collect::<Vec<_>>()
                 .try_into()
                 .unwrap(),
         }
@@ -554,7 +559,7 @@ impl From<VeryPackedSecureColumnByCoords> for SecureColumnByCoords<SimdBackend> 
                 .columns
                 .into_iter()
                 .map(BaseColumn::from)
-                .collect_vec()
+                .collect::<Vec<_>>()
                 .try_into()
                 .unwrap(),
         }
@@ -615,7 +620,7 @@ impl VeryPackedSecureColumnByCoords {
     ///
     /// The resulting pointer does not update the underlying columns' `data`'s lengths.
     pub unsafe fn transform_under_mut(value: &mut SecureColumnByCoords<SimdBackend>) -> &mut Self {
-        &mut *(std::ptr::addr_of!(*value) as *mut VeryPackedSecureColumnByCoords)
+        &mut *(core::ptr::addr_of!(*value) as *mut VeryPackedSecureColumnByCoords)
     }
 
     pub fn chunks_mut(
@@ -629,13 +634,13 @@ impl VeryPackedSecureColumnByCoords {
             .map(|x| x.chunks_mut(chunk_size));
         izip!(a, b, c, d)
             .map(|(a, b, c, d)| VeryPackedSecureColumnByCoordsMutSlice([a, b, c, d]))
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use core::array;
 
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};

--- a/crates/prover/src/core/backend/simd/conversion.rs
+++ b/crates/prover/src/core/backend/simd/conversion.rs
@@ -34,14 +34,14 @@ impl<T: Pack, const N: usize> Pack for [T; N] {
     type SimdType = [T::SimdType; N];
 
     fn pack(inputs: [[T; N]; N_LANES]) -> Self::SimdType {
-        std::array::from_fn(|i| T::pack(std::array::from_fn(|j| inputs[j][i])))
+        core::array::from_fn(|i| T::pack(core::array::from_fn(|j| inputs[j][i])))
     }
 }
 
 impl<T: Unpack, const N: usize> Unpack for [T; N] {
     type CpuType = [T::CpuType; N];
     fn unpack(self) -> [Self::CpuType; N_LANES] {
-        std::array::from_fn(|i| std::array::from_fn(|j| T::unpack(self[j])[i]))
+        core::array::from_fn(|i| core::array::from_fn(|j| T::unpack(self[j])[i]))
     }
 }
 
@@ -53,7 +53,7 @@ macro_rules! impl_tuple_conversion {
                 fn pack(inputs: [($($type,)+); N_LANES]) -> Self::SimdType {
                     (
                         $(
-                            $type::pack(std::array::from_fn(|i|
+                            $type::pack(core::array::from_fn(|i|
                                 inputs[i].$idx
                             )),
                         )+
@@ -70,7 +70,7 @@ macro_rules! impl_tuple_conversion {
                             $type::unpack(self.$idx),
                         )+
                     );
-                    std::array::from_fn(|i| ($(arrays.$idx[i],)+))
+                    core::array::from_fn(|i| ($(arrays.$idx[i],)+))
                 }
             }
         };
@@ -104,10 +104,10 @@ mod tests {
                     M31::from(rng.gen::<u32>()),
                     M31::from(rng.gen::<u32>()),
                 ],
-                std::array::from_fn(|_| M31::from(rng.gen::<u32>())),
+                core::array::from_fn(|_| M31::from(rng.gen::<u32>())),
             )
         };
-        let inputs: [_; N_LANES] = std::array::from_fn(|_| rand_input());
+        let inputs: [_; N_LANES] = core::array::from_fn(|_| rand_input());
 
         let simd_vals = <_ as Pack>::pack(inputs);
         let outputs = simd_vals.unpack();

--- a/crates/prover/src/core/backend/simd/domain.rs
+++ b/crates/prover/src/core/backend/simd/domain.rs
@@ -1,4 +1,4 @@
-use std::simd::{simd_swizzle, u32x2, Simd};
+use core::simd::{simd_swizzle, u32x2, Simd};
 
 use super::m31::{PackedM31, LOG_N_LANES};
 use crate::core::circle::{CirclePoint, M31_CIRCLE_LOG_ORDER};
@@ -17,7 +17,7 @@ impl CircleDomainBitRevIterator {
         let log_size = domain.log_size();
         assert!(log_size >= LOG_N_LANES);
 
-        let initial_points = std::array::from_fn(|i| domain.at(bit_reverse_index(i, log_size)));
+        let initial_points = core::array::from_fn(|i| domain.at(bit_reverse_index(i, log_size)));
         let current = CirclePoint {
             x: PackedM31::from_array(initial_points.each_ref().map(|p| p.x)),
             y: PackedM31::from_array(initial_points.each_ref().map(|p| p.y)),
@@ -76,7 +76,7 @@ fn test_circle_domain_bit_rev_iterator() {
     crate::core::backend::cpu::bit_reverse(&mut expected);
     let actual = CircleDomainBitRevIterator::new(domain)
         .flat_map(|c| -> [_; 16] {
-            std::array::from_fn(|i| CirclePoint {
+            core::array::from_fn(|i| CirclePoint {
                 x: c.x.to_array()[i],
                 y: c.y.to_array()[i],
             })

--- a/crates/prover/src/core/backend/simd/fft/ifft.rs
+++ b/crates/prover/src/core/backend/simd/fft/ifft.rs
@@ -1,8 +1,6 @@
 //! Inverse fft.
+use core::simd::{simd_swizzle, u32x16, u32x2, u32x4};
 
-use std::simd::{simd_swizzle, u32x16, u32x2, u32x4};
-
-use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -14,6 +12,7 @@ use crate::core::backend::simd::m31::{PackedBaseField, LOG_N_LANES};
 use crate::core::backend::simd::utils::UnsafeMut;
 use crate::core::circle::Coset;
 use crate::parallel_iter;
+use crate::prelude::*;
 
 /// Performs an Inverse Circle Fast Fourier Transform (ICFFT) on the given values.
 ///
@@ -188,9 +187,9 @@ pub unsafe fn ifft_vecwise_loop(
         (val0, val1) = vecwise_ibutterflies(
             val0,
             val1,
-            std::array::from_fn(|i| *twiddle_dbl[0].get_unchecked(index * 8 + i)),
-            std::array::from_fn(|i| *twiddle_dbl[1].get_unchecked(index * 4 + i)),
-            std::array::from_fn(|i| *twiddle_dbl[2].get_unchecked(index * 2 + i)),
+            core::array::from_fn(|i| *twiddle_dbl[0].get_unchecked(index * 8 + i)),
+            core::array::from_fn(|i| *twiddle_dbl[1].get_unchecked(index * 4 + i)),
+            core::array::from_fn(|i| *twiddle_dbl[2].get_unchecked(index * 2 + i)),
         );
         (val0, val1) = simd_ibutterfly(
             val0,
@@ -231,13 +230,13 @@ pub unsafe fn ifft3_loop(
                 values,
                 offset + l,
                 layer,
-                std::array::from_fn(|i| {
+                core::array::from_fn(|i| {
                     *twiddle_dbl[0].get_unchecked((index * 4 + i) & (twiddle_dbl[0].len() - 1))
                 }),
-                std::array::from_fn(|i| {
+                core::array::from_fn(|i| {
                     *twiddle_dbl[1].get_unchecked((index * 2 + i) & (twiddle_dbl[1].len() - 1))
                 }),
-                std::array::from_fn(|i| {
+                core::array::from_fn(|i| {
                     *twiddle_dbl[2].get_unchecked((index + i) & (twiddle_dbl[2].len() - 1))
                 }),
             );
@@ -266,10 +265,10 @@ unsafe fn ifft2_loop(values: *mut u32, twiddle_dbl: &[&[u32]], layer: usize, ind
             values,
             offset + l,
             layer,
-            std::array::from_fn(|i| {
+            core::array::from_fn(|i| {
                 *twiddle_dbl[0].get_unchecked((index * 2 + i) & (twiddle_dbl[0].len() - 1))
             }),
-            std::array::from_fn(|i| {
+            core::array::from_fn(|i| {
                 *twiddle_dbl[1].get_unchecked((index + i) & (twiddle_dbl[1].len() - 1))
             }),
         );
@@ -295,7 +294,7 @@ unsafe fn ifft1_loop(values: *mut u32, twiddle_dbl: &[&[u32]], layer: usize, ind
             values,
             offset + l,
             layer,
-            std::array::from_fn(|i| {
+            core::array::from_fn(|i| {
                 *twiddle_dbl[0].get_unchecked((index + i) & (twiddle_dbl[0].len() - 1))
             }),
         );
@@ -394,7 +393,7 @@ pub fn get_itwiddle_dbls(mut coset: Coset) -> Vec<Vec<u32>> {
                 .iter()
                 .take(coset.size() / 2)
                 .map(|p| p.x.inverse().0 * 2)
-                .collect_vec(),
+                .collect::<Vec<_>>(),
         );
         bit_reverse(res.last_mut().unwrap());
         coset = coset.double();
@@ -545,10 +544,9 @@ pub unsafe fn ifft1(values: *mut u32, offset: usize, log_step: usize, twiddles_d
 
 #[cfg(test)]
 mod tests {
-    use std::mem::transmute;
-    use std::simd::u32x16;
+    use core::mem::transmute;
+    use core::simd::u32x16;
 
-    use itertools::Itertools;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
 
@@ -671,14 +669,17 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.gen()).collect::<Vec<_>>();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
             unsafe {
                 ifft_lower_with_vecwise(
                     transmute::<*mut PackedBaseField, *mut u32>(res.data.as_mut_ptr()),
-                    &twiddle_dbls.iter().map(|x| x.as_slice()).collect_vec(),
+                    &twiddle_dbls
+                        .iter()
+                        .map(|x| x.as_slice())
+                        .collect::<Vec<_>>(),
                     log_size as usize,
                     log_size as usize,
                 );
@@ -693,14 +694,17 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.gen()).collect::<Vec<_>>();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
             unsafe {
                 ifft(
                     transmute::<*mut PackedBaseField, *mut u32>(res.data.as_mut_ptr()),
-                    &twiddle_dbls.iter().map(|x| x.as_slice()).collect_vec(),
+                    &twiddle_dbls
+                        .iter()
+                        .map(|x| x.as_slice())
+                        .collect::<Vec<_>>(),
                     log_size as usize,
                 );
                 transpose_vecs(

--- a/crates/prover/src/core/backend/simd/fft/mod.rs
+++ b/crates/prover/src/core/backend/simd/fft/mod.rs
@@ -1,4 +1,4 @@
-use std::simd::{simd_swizzle, u32x16, u32x8};
+use core::simd::{simd_swizzle, u32x16, u32x8};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -98,12 +98,12 @@ pub fn compute_first_twiddles(twiddle1_dbl: u32x8) -> (u32x16, u32x16) {
 
 #[inline]
 const unsafe fn load(mem_addr: *const u32) -> u32x16 {
-    std::ptr::read(mem_addr as *const u32x16)
+    core::ptr::read(mem_addr as *const u32x16)
 }
 
 #[inline]
 const unsafe fn store(mem_addr: *mut u32, a: u32x16) {
-    std::ptr::write(mem_addr as *mut u32x16, a);
+    core::ptr::write(mem_addr as *mut u32x16, a);
 }
 
 /// Computes `v * twiddle`

--- a/crates/prover/src/core/backend/simd/fft/rfft.rs
+++ b/crates/prover/src/core/backend/simd/fft/rfft.rs
@@ -1,9 +1,7 @@
 //! Regular (forward) fft.
+use core::array;
+use core::simd::{simd_swizzle, u32x16, u32x2, u32x4, u32x8};
 
-use std::array;
-use std::simd::{simd_swizzle, u32x16, u32x2, u32x4, u32x8};
-
-use itertools::Itertools;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -15,6 +13,7 @@ use crate::core::backend::simd::m31::{PackedBaseField, LOG_N_LANES};
 use crate::core::backend::simd::utils::{UnsafeConst, UnsafeMut};
 use crate::core::circle::Coset;
 use crate::parallel_iter;
+use crate::prelude::*;
 
 /// Performs a Circle Fast Fourier Transform (CFFT) on the given values.
 ///
@@ -411,7 +410,7 @@ pub fn get_twiddle_dbls(mut coset: Coset) -> Vec<Vec<u32>> {
                 .iter()
                 .take(coset.size() / 2)
                 .map(|p| p.x.0 * 2)
-                .collect_vec(),
+                .collect::<Vec<_>>(),
         );
         bit_reverse(res.last_mut().unwrap());
         coset = coset.double();
@@ -573,10 +572,9 @@ pub unsafe fn fft1(
 
 #[cfg(test)]
 mod tests {
-    use std::mem::transmute;
-    use std::simd::u32x16;
+    use core::mem::transmute;
+    use core::simd::u32x16;
 
-    use itertools::Itertools;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
 
@@ -703,7 +701,7 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.gen()).collect::<Vec<_>>();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -711,7 +709,10 @@ mod tests {
                 fft_lower_with_vecwise(
                     transmute::<*const PackedBaseField, *const u32>(res.data.as_ptr()),
                     transmute::<*mut PackedBaseField, *mut u32>(res.data.as_mut_ptr()),
-                    &twiddle_dbls.iter().map(|x| x.as_slice()).collect_vec(),
+                    &twiddle_dbls
+                        .iter()
+                        .map(|x| x.as_slice())
+                        .collect::<Vec<_>>(),
                     log_size as usize,
                     log_size as usize,
                 )
@@ -726,7 +727,7 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.gen()).collect::<Vec<_>>();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -738,7 +739,10 @@ mod tests {
                 fft(
                     transmute::<*const PackedBaseField, *const u32>(res.data.as_ptr()),
                     transmute::<*mut PackedBaseField, *mut u32>(res.data.as_mut_ptr()),
-                    &twiddle_dbls.iter().map(|x| x.as_slice()).collect_vec(),
+                    &twiddle_dbls
+                        .iter()
+                        .map(|x| x.as_slice())
+                        .collect::<Vec<_>>(),
                     log_size as usize,
                 );
             }

--- a/crates/prover/src/core/backend/simd/fri.rs
+++ b/crates/prover/src/core/backend/simd/fri.rs
@@ -1,5 +1,5 @@
-use std::array;
-use std::simd::{u32x16, u32x8};
+use core::array;
+use core::simd::{u32x16, u32x8};
 
 use num_traits::Zero;
 
@@ -166,7 +166,6 @@ fn decomposition_coefficient(
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
     use num_traits::One;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
@@ -187,7 +186,7 @@ mod tests {
     fn test_fold_line() {
         const LOG_SIZE: u32 = 7;
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let values = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect::<Vec<_>>();
         let alpha = qm31!(1, 3, 5, 7);
         let domain = LineDomain::new(CanonicCoset::new(LOG_SIZE + 1).half_coset());
         let cpu_fold = CpuBackend::fold_line(

--- a/crates/prover/src/core/backend/simd/grind.rs
+++ b/crates/prover/src/core/backend/simd/grind.rs
@@ -1,6 +1,6 @@
-use std::simd::cmp::SimdPartialOrd;
-use std::simd::num::SimdUint;
-use std::simd::u32x16;
+use core::simd::cmp::SimdPartialOrd;
+use core::simd::num::SimdUint;
+use core::simd::u32x16;
 
 use bytemuck::cast_slice;
 #[cfg(feature = "parallel")]
@@ -44,11 +44,11 @@ fn grind_blake(digest: &[u32], hi: u64, pow_bits: u32) -> Option<u64> {
     let zero: u32x16 = u32x16::default();
     let pow_bits = u32x16::splat(pow_bits);
 
-    let state: [u32x16; 8] = std::array::from_fn(|i| u32x16::splat(digest[i]));
+    let state: [u32x16; 8] = core::array::from_fn(|i| u32x16::splat(digest[i]));
 
     let mut attempt = [zero; 16];
     attempt[0] = u32x16::splat((hi << GRIND_LOW_BITS) as u32);
-    attempt[0] += u32x16::from(std::array::from_fn(|i| i as u32));
+    attempt[0] += u32x16::from(core::array::from_fn(|i| i as u32));
     attempt[1] = u32x16::splat((hi >> (32 - GRIND_LOW_BITS)) as u32);
     for low in (0..(1 << GRIND_LOW_BITS)).step_by(N_LANES) {
         let res = compress16(state, attempt, zero, zero, zero, zero);

--- a/crates/prover/src/core/backend/simd/lookups/gkr.rs
+++ b/crates/prover/src/core/backend/simd/lookups/gkr.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use core::iter::zip;
 
 use num_traits::Zero;
 
@@ -16,6 +16,7 @@ use crate::core::lookups::gkr_prover::{
 use crate::core::lookups::mle::Mle;
 use crate::core::lookups::sumcheck::MultivariatePolyOracle;
 use crate::core::lookups::utils::{Fraction, Reciprocal, UnivariatePoly};
+use crate::prelude::*;
 
 impl GkrOps for SimdBackend {
     #[allow(clippy::uninit_vec)]
@@ -508,7 +509,7 @@ fn into_simd_layer(cpu_layer: Layer<CpuBackend>) -> Layer<SimdBackend> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
+    use core::iter::zip;
 
     use num_traits::One;
     use rand::rngs::SmallRng;

--- a/crates/prover/src/core/backend/simd/lookups/mle.rs
+++ b/crates/prover/src/core/backend/simd/lookups/mle.rs
@@ -1,6 +1,5 @@
-use core::ops::Sub;
-use std::iter::zip;
-use std::ops::{Add, Mul};
+use core::iter::zip;
+use core::ops::{Add, Mul, Sub};
 
 use crate::core::backend::simd::column::SecureColumn;
 use crate::core::backend::simd::m31::N_LANES;
@@ -91,8 +90,6 @@ fn fold_packed_mle_evals<
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-
     use crate::core::backend::simd::SimdBackend;
     use crate::core::backend::{Column, CpuBackend};
     use crate::core::channel::Channel;
@@ -118,7 +115,9 @@ mod tests {
     #[test]
     fn fix_first_variable_with_base_field_mle_matches_cpu() {
         const N_VARIABLES: u32 = 8;
-        let values = (0..1 << N_VARIABLES).map(BaseField::from).collect_vec();
+        let values = (0..1 << N_VARIABLES)
+            .map(BaseField::from)
+            .collect::<Vec<_>>();
         let mle_simd = Mle::<SimdBackend, BaseField>::new(values.iter().copied().collect());
         let mle_cpu = Mle::<CpuBackend, BaseField>::new(values);
         let random_assignment = SecureField::from_u32_unchecked(7, 12, 3, 2);

--- a/crates/prover/src/core/backend/simd/m31.rs
+++ b/crates/prover/src/core/backend/simd/m31.rs
@@ -1,9 +1,9 @@
-use std::iter::Sum;
-use std::mem::transmute;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::ptr;
-use std::simd::cmp::SimdOrd;
-use std::simd::{u32x16, Simd};
+use core::iter::Sum;
+use core::mem::transmute;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::ptr;
+use core::simd::cmp::SimdOrd;
+use core::simd::{u32x16, Simd};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
@@ -14,6 +14,7 @@ use super::PACKED_M31_BATCH_INVERSE_CHUNK_SIZE;
 use crate::core::fields::m31::{pow2147483645, BaseField, M31, P};
 use crate::core::fields::qm31::QM31;
 use crate::core::fields::{batch_inverse_chunked, FieldExpOps};
+use crate::prelude::*;
 
 pub const LOG_N_LANES: u32 = 4;
 
@@ -25,7 +26,7 @@ pub type PackedBaseField = PackedM31;
 
 /// Holds a vector of unreduced [`M31`] elements in the range `[0, P]`.
 ///
-/// Implemented with [`std::simd`] to support multiple targets (avx512, neon, wasm etc.).
+/// Implemented with [`core::simd`] to support multiple targets (avx512, neon, wasm etc.).
 // TODO: Remove `pub` visibility
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
@@ -293,7 +294,7 @@ impl Sum for PackedM31 {
 cfg_if::cfg_if! {
     if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
         use core::arch::aarch64::{uint32x2_t, vmull_u32, int32x2_t, vqdmull_s32};
-        use std::simd::u32x4;
+        use core::simd::u32x4;
 
         /// Returns `a * b`.
         pub(crate) fn mul_neon(a: PackedM31, b: PackedM31) -> PackedM31 {
@@ -366,7 +367,7 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))] {
         use core::arch::wasm32::{i64x2_extmul_high_u32x4, i64x2_extmul_low_u32x4, v128};
-        use std::simd::u32x4;
+        use core::simd::u32x4;
 
         /// Returns `a * b`.
         pub(crate) fn mul_wasm(a: PackedM31, b: PackedM31) -> PackedM31 {
@@ -405,7 +406,7 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))] {
         use std::arch::x86_64::{__m512i, _mm512_mul_epu32, _mm512_srli_epi64};
-        use std::simd::Swizzle;
+        use core::simd::Swizzle;
 
         use crate::core::backend::simd::utils::swizzle::{InterleaveEvens, InterleaveOdds};
 
@@ -456,7 +457,7 @@ cfg_if::cfg_if! {
         }
     } else if #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))] {
         use std::arch::x86_64::{__m256i, _mm256_mul_epu32, _mm256_srli_epi64};
-        use std::simd::Swizzle;
+        use core::simd::Swizzle;
 
         use crate::core::backend::simd::utils::swizzle::{InterleaveEvens, InterleaveOdds};
 
@@ -517,7 +518,7 @@ cfg_if::cfg_if! {
             PackedM31(prod_lo) + PackedM31(prod_hi)
         }
     } else {
-        use std::simd::Swizzle;
+        use core::simd::Swizzle;
 
         use crate::core::backend::simd::utils::swizzle::{InterleaveEvens, InterleaveOdds};
 
@@ -587,7 +588,7 @@ cfg_if::cfg_if! {
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use core::array;
 
     use aligned::{Aligned, A64};
     use rand::rngs::SmallRng;

--- a/crates/prover/src/core/backend/simd/poseidon252.rs
+++ b/crates/prover/src/core/backend/simd/poseidon252.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use starknet_ff::FieldElement as FieldElement252;
 
 use super::SimdBackend;
@@ -8,6 +7,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::vcs::ops::MerkleHasher;
 use crate::core::vcs::ops::MerkleOps;
 use crate::core::vcs::poseidon252_merkle::Poseidon252MerkleHasher;
+use crate::prelude::*;
 
 impl ColumnOps<FieldElement252> for SimdBackend {
     type Column = Vec<FieldElement252>;
@@ -28,7 +28,10 @@ impl MerkleOps<Poseidon252MerkleHasher> for SimdBackend {
             .map(|i| {
                 Poseidon252MerkleHasher::hash_node(
                     prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
-                    &columns.iter().map(|column| column.at(i)).collect_vec(),
+                    &columns
+                        .iter()
+                        .map(|column| column.at(i))
+                        .collect::<Vec<_>>(),
                 )
             })
             .collect()

--- a/crates/prover/src/core/backend/simd/prefix_sum.rs
+++ b/crates/prover/src/core/backend/simd/prefix_sum.rs
@@ -1,7 +1,7 @@
-use std::iter::zip;
-use std::ops::{AddAssign, Sub};
+use core::iter::zip;
+use core::ops::{AddAssign, Sub};
 
-use itertools::{izip, Itertools};
+use itertools::izip;
 use num_traits::Zero;
 
 use crate::core::backend::cpu::bit_reverse;
@@ -10,6 +10,7 @@ use crate::core::backend::simd::SimdBackend;
 use crate::core::backend::{Col, Column};
 use crate::core::fields::m31::BaseField;
 use crate::core::utils::{circle_domain_order_to_coset_order, coset_order_to_circle_domain_order};
+use crate::prelude::*;
 
 /// Performs a inclusive prefix sum on values in `Coset` order when provided
 /// with evaluations in bit-reversed `CircleDomain` order.
@@ -132,7 +133,7 @@ fn inclusive_prefix_sum_slow(
             *acc += v;
             Some(*acc)
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
     let mut circle_domain_order_eval = coset_order_to_circle_domain_order(&coset_order_prefix_sum);
     bit_reverse(&mut circle_domain_order_eval);
     circle_domain_order_eval.into_iter().collect()

--- a/crates/prover/src/core/backend/simd/qm31.rs
+++ b/crates/prover/src/core/backend/simd/qm31.rs
@@ -1,6 +1,6 @@
-use std::array;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::array;
+use core::iter::Sum;
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
@@ -12,6 +12,7 @@ use super::PACKED_QM31_BATCH_INVERSE_CHUNK_SIZE;
 use crate::core::fields::m31::M31;
 use crate::core::fields::qm31::QM31;
 use crate::core::fields::{batch_inverse_chunked, FieldExpOps};
+use crate::prelude::*;
 
 pub type PackedSecureField = PackedQM31;
 
@@ -322,7 +323,7 @@ impl From<QM31> for PackedQM31 {
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use core::array;
 
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};

--- a/crates/prover/src/core/backend/simd/quotients.rs
+++ b/crates/prover/src/core/backend/simd/quotients.rs
@@ -1,4 +1,4 @@
-use itertools::{izip, zip_eq, Itertools};
+use itertools::{izip, zip_eq};
 use num_traits::Zero;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -20,6 +20,7 @@ use crate::core::fields::FieldExpOps;
 use crate::core::pcs::quotients::{ColumnSampleBatch, QuotientOps};
 use crate::core::poly::circle::{CircleDomain, CircleEvaluation, PolyOps, SecureEvaluation};
 use crate::core::poly::BitReversedOrder;
+use crate::prelude::*;
 
 pub struct QuotientConstants {
     pub line_coeffs: Vec<Vec<(SecureField, SecureField, SecureField)>>,
@@ -43,10 +44,10 @@ impl QuotientOps for SimdBackend {
             let columns = columns
                 .iter()
                 .map(|circle_eval| circle_eval.to_cpu())
-                .collect_vec();
+                .collect::<Vec<_>>();
             let eval = CpuBackend::accumulate_quotients(
                 domain,
-                &columns.iter().collect_vec(),
+                &columns.iter().collect::<Vec<_>>(),
                 random_coeff,
                 sample_batches,
                 log_blowup_factor,
@@ -118,7 +119,7 @@ fn accumulate_quotients_on_subdomain(
     let span = span!(Level::INFO, "Quotient accumulation").entered();
     let quad_rows = CircleDomainBitRevIterator::new(subdomain)
         .array_chunks::<4>()
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     #[cfg(not(feature = "parallel"))]
     let iter = quad_rows.iter().zip(values.chunks_mut(4)).enumerate();
@@ -184,7 +185,7 @@ pub fn accumulate_row_quotients(
         for ((column_index, _), (a, b, c)) in zip_eq(&sample_batch.columns_and_values, line_coeffs)
         {
             let column = &columns[*column_index];
-            let cvalues: [_; 4] = std::array::from_fn(|i| {
+            let cvalues: [_; 4] = core::array::from_fn(|i| {
                 PackedSecureField::broadcast(*c) * column.data[(quad_row << 2) + i]
             });
 
@@ -226,7 +227,7 @@ fn denominator_inverses(
 ) -> Vec<CM31Column> {
     // We want a P to be on a line that passes through a point Pr + uPi in QM31^2, and its conjugate
     // Pr - uPi. Thus, Pr - P is parallel to Pi. Or, (Pr - P).x * Pi.y - (Pr - P).y * Pi.x = 0.
-    let domain_points = CircleDomainBitRevIterator::new(domain).collect_vec();
+    let domain_points = CircleDomainBitRevIterator::new(domain).collect::<Vec<_>>();
 
     #[cfg(not(feature = "parallel"))]
     let iter = domain_points.into_iter();
@@ -277,8 +278,6 @@ fn quotient_constants(
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-
     use crate::core::backend::simd::column::BaseColumn;
     use crate::core::backend::simd::SimdBackend;
     use crate::core::backend::{Column, CpuBackend};
@@ -316,10 +315,10 @@ mod tests {
         let cpu_columns = columns
             .iter()
             .map(|c| CircleEvaluation::new(c.domain, c.values.to_cpu()))
-            .collect_vec();
+            .collect::<Vec<_>>();
         let cpu_result = CpuBackend::accumulate_quotients(
             domain,
-            &cpu_columns.iter().collect_vec(),
+            &cpu_columns.iter().collect::<Vec<_>>(),
             random_coeff,
             &samples,
             LOG_BLOWUP_FACTOR,
@@ -329,7 +328,7 @@ mod tests {
 
         let res = SimdBackend::accumulate_quotients(
             domain,
-            &columns.iter().collect_vec(),
+            &columns.iter().collect::<Vec<_>>(),
             random_coeff,
             &samples,
             LOG_BLOWUP_FACTOR,

--- a/crates/prover/src/core/backend/simd/utils.rs
+++ b/crates/prover/src/core/backend/simd/utils.rs
@@ -30,7 +30,7 @@ unsafe impl<T> Sync for UnsafeConst<T> {}
     all(target_arch = "wasm32", target_feature = "simd128")
 )))]
 pub mod swizzle {
-    use std::simd::Swizzle;
+    use core::simd::Swizzle;
 
     /// Used with [`Swizzle::concat_swizzle`] to interleave the even values of two vectors.
     pub struct InterleaveEvens;

--- a/crates/prover/src/core/backend/simd/very_packed_m31.rs
+++ b/crates/prover/src/core/backend/simd/very_packed_m31.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
@@ -23,7 +23,7 @@ impl<A: Copy, const N: usize> Vectorized<A, N> {
     where
         F: FnMut(usize) -> A,
     {
-        Vectorized(std::array::from_fn(cb))
+        Vectorized(core::array::from_fn(cb))
     }
 }
 
@@ -65,9 +65,12 @@ impl VeryPackedM31 {
         // N_VERY_PACKED_ELEMS] because we know that A contains [i32; N_LANES] and the
         // memory layout is contiguous.
         unsafe {
-            std::slice::from_raw_parts(self.0.as_ptr() as *const M31, N_LANES * N_VERY_PACKED_ELEMS)
-                .try_into()
-                .unwrap()
+            core::slice::from_raw_parts(
+                self.0.as_ptr() as *const M31,
+                N_LANES * N_VERY_PACKED_ELEMS,
+            )
+            .try_into()
+            .unwrap()
         }
     }
 }
@@ -88,7 +91,7 @@ impl VeryPackedQM31 {
     }
 
     pub fn into_very_packed_m31s(self) -> [VeryPackedM31; 4] {
-        std::array::from_fn(|i| VeryPackedM31::from(self.0.map(|v| v.into_packed_m31s()[i])))
+        core::array::from_fn(|i| VeryPackedM31::from(self.0.map(|v| v.into_packed_m31s()[i])))
     }
 }
 impl From<M31> for VeryPackedM31 {

--- a/crates/prover/src/core/channel/blake2s.rs
+++ b/crates/prover/src/core/channel/blake2s.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use core::iter;
+#[cfg(feature = "std")]
 use std::iter;
 
 use super::{Channel, ChannelTime};
@@ -7,6 +10,7 @@ use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
 use crate::core::fields::IntoSlice;
 use crate::core::vcs::blake2_hash::{Blake2sHash, Blake2sHasher};
 use crate::core::vcs::blake2s_ref::compress;
+use crate::prelude::*;
 
 pub const BLAKE_BYTES_PER_HASH: usize = 32;
 pub const FELTS_PER_HASH: usize = 8;
@@ -56,7 +60,7 @@ impl Channel for Blake2sChannel {
     const BYTES_PER_HASH: usize = BLAKE_BYTES_PER_HASH;
 
     fn trailing_zeros(&self) -> u32 {
-        u128::from_le_bytes(std::array::from_fn(|i| self.digest.0[i])).trailing_zeros()
+        u128::from_le_bytes(core::array::from_fn(|i| self.digest.0[i])).trailing_zeros()
     }
 
     fn mix_felts(&mut self, felts: &[SecureField]) {
@@ -68,14 +72,14 @@ impl Channel for Blake2sChannel {
     }
 
     fn mix_u64(&mut self, nonce: u64) {
-        let digest: [u32; 8] = unsafe { std::mem::transmute(self.digest) };
+        let digest: [u32; 8] = unsafe { core::mem::transmute(self.digest) };
         let mut msg = [0; 16];
         msg[0] = nonce as u32;
         msg[1] = (nonce >> 32) as u32;
-        let res = compress(std::array::from_fn(|i| digest[i]), msg, 0, 0, 0, 0);
+        let res = compress(core::array::from_fn(|i| digest[i]), msg, 0, 0, 0, 0);
 
         // TODO(shahars) Channel should always finalize hash.
-        self.update_digest(unsafe { std::mem::transmute::<[u32; 8], Blake2sHash>(res) });
+        self.update_digest(unsafe { core::mem::transmute::<[u32; 8], Blake2sHash>(res) });
     }
 
     fn draw_felt(&mut self) -> SecureField {
@@ -113,8 +117,7 @@ impl Channel for Blake2sChannel {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
+    use crate::collections::BTreeSet;
     use crate::core::channel::blake2s::Blake2sChannel;
     use crate::core::channel::Channel;
     use crate::core::fields::qm31::SecureField;

--- a/crates/prover/src/core/channel/mod.rs
+++ b/crates/prover/src/core/channel/mod.rs
@@ -1,5 +1,6 @@
 use super::fields::qm31::SecureField;
 use super::vcs::ops::MerkleHasher;
+use crate::prelude::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod poseidon252;

--- a/crates/prover/src/core/channel/poseidon252.rs
+++ b/crates/prover/src/core/channel/poseidon252.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use core::iter;
+#[cfg(feature = "std")]
 use std::iter;
 
 use starknet_crypto::{poseidon_hash, poseidon_hash_many};
@@ -7,6 +10,7 @@ use super::{Channel, ChannelTime};
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
+use crate::prelude::*;
 
 pub const BYTES_PER_FELT252: usize = 31;
 pub const FELTS_PER_HASH: usize = 8;
@@ -38,7 +42,7 @@ impl Poseidon252Channel {
         let shift = (1u64 << 31).into();
 
         let mut cur = self.draw_felt252();
-        let u32s: [u32; 8] = std::array::from_fn(|_| {
+        let u32s: [u32; 8] = core::array::from_fn(|_| {
             let next = cur.floor_div(shift);
             let res = cur - next * shift;
             cur = next;
@@ -58,7 +62,7 @@ impl Channel for Poseidon252Channel {
 
     fn trailing_zeros(&self) -> u32 {
         let bytes = self.digest.to_bytes_be();
-        u128::from_le_bytes(std::array::from_fn(|i| bytes[i])).trailing_zeros()
+        u128::from_le_bytes(core::array::from_fn(|i| bytes[i])).trailing_zeros()
     }
 
     fn mix_felts(&mut self, felts: &[SecureField]) {
@@ -105,7 +109,7 @@ impl Channel for Poseidon252Channel {
     fn draw_random_bytes(&mut self) -> Vec<u8> {
         let shift = (1u64 << 8).into();
         let mut cur = self.draw_felt252();
-        let bytes: [u8; 31] = std::array::from_fn(|_| {
+        let bytes: [u8; 31] = core::array::from_fn(|_| {
             let next = cur.floor_div(shift);
             let res = cur - next * shift;
             cur = next;
@@ -117,8 +121,7 @@ impl Channel for Poseidon252Channel {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
+    use crate::collections::BTreeSet;
     use crate::core::channel::poseidon252::Poseidon252Channel;
     use crate::core::channel::Channel;
     use crate::core::fields::qm31::SecureField;

--- a/crates/prover/src/core/circle.rs
+++ b/crates/prover/src/core/circle.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 
 use num_traits::{One, Zero};
 
@@ -463,11 +463,10 @@ impl<T: Add<Output = T> + Copy> Iterator for CosetIterator<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use num_traits::{One, Pow};
 
     use super::{CirclePointIndex, Coset};
+    use crate::collections::BTreeSet;
     use crate::core::channel::Blake2sChannel;
     use crate::core::circle::{CirclePoint, SECURE_FIELD_CIRCLE_GEN};
     use crate::core::fields::qm31::{SecureField, P4};

--- a/crates/prover/src/core/fft.rs
+++ b/crates/prover/src/core/fft.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Mul, Sub};
+use core::ops::{Add, AddAssign, Mul, Sub};
 
 use super::fields::m31::BaseField;
 

--- a/crates/prover/src/core/fields/cm31.rs
+++ b/crates/prover/src/core/fields/cm31.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Debug, Display};
-use std::ops::{
+use core::fmt::{Debug, Display};
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{ComplexConjugate, FieldExpOps};
 use crate::core::fields::m31::M31;
+use crate::prelude::*;
 use crate::{impl_extension_field, impl_field};
 pub const P2: u64 = 4611686014132420609; // (2 ** 31 - 1) ** 2
 
@@ -30,13 +31,13 @@ impl CM31 {
 }
 
 impl Display for CM31 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} + {}i", self.0, self.1)
     }
 }
 
 impl Debug for CM31 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{} + {}i", self.0, self.1)
     }
 }

--- a/crates/prover/src/core/fields/m31.rs
+++ b/crates/prover/src/core/fields/m31.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
-use std::ops::{
+use core::fmt::Display;
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{ComplexConjugate, FieldExpOps};
 use crate::impl_field;
+use crate::prelude::*;
 pub const MODULUS_BITS: u32 = 31;
 pub const N_BYTES_FELT: usize = 4;
 pub const P: u32 = 2147483647; // 2 ** 31 - 1
@@ -70,7 +71,7 @@ impl M31 {
 }
 
 impl Display for M31 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/crates/prover/src/core/fields/mod.rs
+++ b/crates/prover/src/core/fields/mod.rs
@@ -1,10 +1,12 @@
-use std::fmt::{Debug, Display};
-use std::iter::{Product, Sum};
-use std::ops::{Mul, MulAssign, Neg};
+use core::fmt::{Debug, Display};
+use core::iter::{Product, Sum};
+use core::ops::{Mul, MulAssign, Neg};
 
 use num_traits::{NumAssign, NumAssignOps, NumOps, One};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
+
+use crate::prelude::*;
 
 pub mod cm31;
 pub mod m31;
@@ -77,7 +79,7 @@ pub fn batch_inverse_in_place<F: FieldExpOps>(column: &[F], dst: &mut [F]) {
 
     // First pass. Compute 'WIDTH' cumulative products in an interleaving fashion, reducing
     // instruction dependency and allowing better pipelining.
-    let mut cum_prod: [F; WIDTH] = std::array::from_fn(|_| F::one());
+    let mut cum_prod: [F; WIDTH] = core::array::from_fn(|_| F::one());
     dst[..WIDTH].clone_from_slice(&cum_prod);
     for i in 0..n {
         cum_prod[i % WIDTH] *= column[i].clone();
@@ -86,7 +88,7 @@ pub fn batch_inverse_in_place<F: FieldExpOps>(column: &[F], dst: &mut [F]) {
 
     // Inverse cumulative products.
     // Use classic batch inversion.
-    let mut tail_inverses: [F; WIDTH] = std::array::from_fn(|_| F::one());
+    let mut tail_inverses: [F; WIDTH] = core::array::from_fn(|_| F::one());
     batch_inverse_classic(&dst[n - WIDTH..], &mut tail_inverses);
 
     // Second pass.
@@ -98,7 +100,7 @@ pub fn batch_inverse_in_place<F: FieldExpOps>(column: &[F], dst: &mut [F]) {
 }
 
 pub fn batch_inverse<F: FieldExpOps>(column: &[F]) -> Vec<F> {
-    let mut dst = vec![unsafe { std::mem::zeroed() }; column.len()];
+    let mut dst = vec![unsafe { core::mem::zeroed() }; column.len()];
     batch_inverse_in_place(column, &mut dst);
     dst
 }
@@ -107,7 +109,7 @@ pub fn batch_inverse_chunked<T: FieldExpOps + Send + Sync>(
     column: &[T],
     chunk_size: usize,
 ) -> Vec<T> {
-    let mut dst = vec![unsafe { std::mem::zeroed() }; column.len()];
+    let mut dst = vec![unsafe { core::mem::zeroed() }; column.len()];
 
     #[cfg(not(feature = "parallel"))]
     let iter = dst.chunks_mut(chunk_size).zip(column.chunks(chunk_size));
@@ -155,9 +157,9 @@ pub trait Field:
 pub unsafe trait IntoSlice<T: Sized>: Sized {
     fn into_slice(sl: &[Self]) -> &[T] {
         unsafe {
-            std::slice::from_raw_parts(
+            core::slice::from_raw_parts(
                 sl.as_ptr() as *const T,
-                std::mem::size_of_val(sl) / std::mem::size_of::<T>(),
+                core::mem::size_of_val(sl) / core::mem::size_of::<T>(),
             )
         }
     }
@@ -193,13 +195,13 @@ impl<F: Field> ExtensionOf<F> for F {
 #[macro_export]
 macro_rules! impl_field {
     ($field_name: ty, $field_size: ident) => {
-        use std::iter::{Product, Sum};
+        use core::iter::{Product, Sum};
 
         use num_traits::{Num, One, Zero};
         use $crate::core::fields::Field;
 
         impl Num for $field_name {
-            type FromStrRadixErr = Box<dyn std::error::Error>;
+            type FromStrRadixErr = Box<dyn core::error::Error>;
 
             fn from_str_radix(_str: &str, _radix: u32) -> Result<Self, Self::FromStrRadixErr> {
                 unimplemented!(

--- a/crates/prover/src/core/fields/qm31.rs
+++ b/crates/prover/src/core/fields/qm31.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Debug, Display};
-use std::ops::{
+use core::fmt::{Debug, Display};
+use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
@@ -9,6 +9,7 @@ use super::secure_column::SECURE_EXTENSION_DEGREE;
 use super::{ComplexConjugate, FieldExpOps};
 use crate::core::fields::cm31::CM31;
 use crate::core::fields::m31::M31;
+use crate::prelude::*;
 use crate::{impl_extension_field, impl_field};
 
 pub const P4: u128 = 21267647892944572736998860269687930881; // (2 ** 31 - 1) ** 4
@@ -62,13 +63,13 @@ impl QM31 {
 }
 
 impl Display for QM31 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "({}) + ({})u", self.0, self.1)
     }
 }
 
 impl Debug for QM31 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "({}) + ({})u", self.0, self.1)
     }
 }

--- a/crates/prover/src/core/fields/secure_column.rs
+++ b/crates/prover/src/core/fields/secure_column.rs
@@ -1,10 +1,11 @@
-use std::array;
-use std::iter::zip;
+use core::array;
+use core::iter::zip;
 
 use super::m31::BaseField;
 use super::qm31::SecureField;
 use super::ExtensionOf;
 use crate::core::backend::{Col, Column, ColumnOps, CpuBackend};
+use crate::prelude::*;
 
 pub const SECURE_EXTENSION_DEGREE: usize =
     <SecureField as ExtensionOf<BaseField>>::EXTENSION_DEGREE;
@@ -23,19 +24,19 @@ impl SecureColumnByCoords<CpuBackend> {
 }
 impl<B: ColumnOps<BaseField>> SecureColumnByCoords<B> {
     pub fn at(&self, index: usize) -> SecureField {
-        SecureField::from_m31_array(std::array::from_fn(|i| self.columns[i].at(index)))
+        SecureField::from_m31_array(core::array::from_fn(|i| self.columns[i].at(index)))
     }
 
     pub fn zeros(len: usize) -> Self {
         Self {
-            columns: std::array::from_fn(|_| Col::<B, BaseField>::zeros(len)),
+            columns: core::array::from_fn(|_| Col::<B, BaseField>::zeros(len)),
         }
     }
 
     /// # Safety
     pub unsafe fn uninitialized(len: usize) -> Self {
         Self {
-            columns: std::array::from_fn(|_| Col::<B, BaseField>::uninitialized(len)),
+            columns: core::array::from_fn(|_| Col::<B, BaseField>::uninitialized(len)),
         }
     }
 

--- a/crates/prover/src/core/fri.rs
+++ b/crates/prover/src/core/fri.rs
@@ -1,8 +1,7 @@
-use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Debug;
-use std::iter::zip;
-use std::ops::RangeInclusive;
+use core::cmp::Reverse;
+use core::fmt::Debug;
+use core::iter::zip;
+use core::ops::RangeInclusive;
 
 use itertools::{zip_eq, Itertools};
 use num_traits::Zero;
@@ -21,6 +20,7 @@ use super::poly::twiddles::TwiddleTree;
 use super::poly::BitReversedOrder;
 use super::queries::Queries;
 use super::ColumnVec;
+use crate::collections::{BTreeMap, BTreeSet};
 use crate::core::circle::Coset;
 use crate::core::fft::ibutterfly;
 use crate::core::fields::FieldExpOps;
@@ -30,6 +30,7 @@ use crate::core::utils::bit_reverse_index;
 use crate::core::vcs::ops::{MerkleHasher, MerkleOps};
 use crate::core::vcs::prover::{MerkleDecommitment, MerkleProver};
 use crate::core::vcs::verifier::{MerkleVerificationError, MerkleVerifier};
+use crate::prelude::*;
 
 /// FRI proof config
 // TODO(andrew): Support different step sizes.
@@ -632,7 +633,7 @@ impl CirclePolyDegreeBound {
 }
 
 impl PartialOrd<LinePolyDegreeBound> for CirclePolyDegreeBound {
-    fn partial_cmp(&self, other: &LinePolyDegreeBound) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &LinePolyDegreeBound) -> Option<core::cmp::Ordering> {
         Some(self.log_degree_bound.cmp(&other.log_degree_bound))
     }
 }
@@ -835,7 +836,7 @@ impl<H: MerkleHasher> FriInnerLayerVerifier<H> {
             .iter()
             .flatten()
             .flat_map(|qm31| qm31.to_m31_array())
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         let merkle_verifier = MerkleVerifier::new(
             self.proof.commitment,
@@ -955,7 +956,8 @@ struct FriInnerLayerProver<B: FriOps + MerkleOps<H>, H: MerkleHasher> {
 
 impl<B: FriOps + MerkleOps<H>, H: MerkleHasher> FriInnerLayerProver<B, H> {
     fn new(evaluation: LineEvaluation<B>) -> Self {
-        let merkle_tree = MerkleProver::commit(evaluation.values.columns.iter().collect_vec());
+        let merkle_tree =
+            MerkleProver::commit(evaluation.values.columns.iter().collect::<Vec<_>>());
         FriInnerLayerProver {
             evaluation,
             merkle_tree,
@@ -973,7 +975,7 @@ impl<B: FriOps + MerkleOps<H>, H: MerkleHasher> FriInnerLayerProver<B, H> {
         let layer_log_size = self.evaluation.domain().log_size();
         let (_evals, decommitment) = self.merkle_tree.decommit(
             &BTreeMap::from_iter([(layer_log_size, decommitment_positions)]),
-            self.evaluation.values.columns.iter().collect_vec(),
+            self.evaluation.values.columns.iter().collect::<Vec<_>>(),
         );
 
         let commitment = self.merkle_tree.root();
@@ -1182,7 +1184,6 @@ mod tests {
     use std::assert_matches::assert_matches;
     use std::iter::zip;
 
-    use itertools::Itertools;
     use num_traits::{One, Zero};
 
     use super::FriVerificationError;
@@ -1229,7 +1230,7 @@ mod tests {
         let evals = LineEvaluation::new(domain, values.into_iter().collect());
 
         let drp_evals = fold_line(&evals, alpha);
-        let mut drp_evals = drp_evals.values.into_iter().collect_vec();
+        let mut drp_evals = drp_evals.values.into_iter().collect::<Vec<_>>();
         CpuBackend::bit_reverse_column(&mut drp_evals);
 
         assert_eq!(drp_evals.len(), DEGREE / 2);

--- a/crates/prover/src/core/lookups/gkr_prover.rs
+++ b/crates/prover/src/core/lookups/gkr_prover.rs
@@ -1,10 +1,12 @@
 //! GKR batch prover for Grand Product and LogUp lookup arguments.
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+use core::iter::{successors, zip};
+use core::ops::Deref;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
-use std::iter::{successors, zip};
-use std::ops::Deref;
 
 use educe::Educe;
-use itertools::Itertools;
 use num_traits::{One, Zero};
 use thiserror::Error;
 
@@ -18,6 +20,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::{Field, FieldExpOps};
 use crate::core::lookups::sumcheck;
+use crate::prelude::*;
 
 pub trait GkrOps: MleOps<BaseField> + MleOps<SecureField> {
     /// Returns evaluations `eq(x, y) * v` for all `x` in `{0, 1}^n`.
@@ -406,17 +409,17 @@ pub fn prove_batch<B: GkrOps>(
     let n_layers_by_instance = input_layer_by_instance
         .iter()
         .map(|l| l.n_variables())
-        .collect_vec();
+        .collect::<Vec<_>>();
     let n_layers = *n_layers_by_instance.iter().max().unwrap();
 
     // Evaluate all instance circuits and collect the layer values.
     let mut layers_by_instance = input_layer_by_instance
         .into_iter()
         .map(|input_layer| gen_layers(input_layer).into_iter().rev())
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     let mut output_claims_by_instance = vec![None; n_instances];
-    let mut layer_masks_by_instance = (0..n_instances).map(|_| Vec::new()).collect_vec();
+    let mut layer_masks_by_instance = (0..n_instances).map(|_| Vec::new()).collect::<Vec<_>>();
     let mut sumcheck_proofs = Vec::new();
 
     let mut ood_point = Vec::new();
@@ -466,7 +469,7 @@ pub fn prove_batch<B: GkrOps>(
         let masks = constant_poly_oracles
             .into_iter()
             .map(|oracle| oracle.try_into_mask().unwrap())
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         // Seed the channel with the layer masks.
         for (&instance, mask) in zip(&sumcheck_instances, &masks) {
@@ -512,7 +515,7 @@ pub fn prove_batch<B: GkrOps>(
 /// Executes the GKR circuit on the input layer and returns all the circuit's layers.
 fn gen_layers<B: GkrOps>(input_layer: Layer<B>) -> Vec<Layer<B>> {
     let n_variables = input_layer.n_variables();
-    let layers = successors(Some(input_layer), |layer| layer.next_layer()).collect_vec();
+    let layers = successors(Some(input_layer), |layer| layer.next_layer()).collect::<Vec<_>>();
     assert_eq!(layers.len(), n_variables + 1);
     layers
 }

--- a/crates/prover/src/core/lookups/gkr_verifier.rs
+++ b/crates/prover/src/core/lookups/gkr_verifier.rs
@@ -8,6 +8,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::lookups::sumcheck;
 use crate::core::lookups::utils::Fraction;
+use crate::prelude::*;
 
 /// Partially verifies a batch GKR proof.
 ///

--- a/crates/prover/src/core/lookups/mle.rs
+++ b/crates/prover/src/core/lookups/mle.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use educe::Educe;
 

--- a/crates/prover/src/core/lookups/sumcheck.rs
+++ b/crates/prover/src/core/lookups/sumcheck.rs
@@ -4,9 +4,8 @@
 //! `g` in the context of the protocol. It is intended to be used in conjunction with
 //! [`prove_batch()`] to generate proofs.
 
-use std::iter::zip;
+use core::iter::zip;
 
-use itertools::Itertools;
 use num_traits::{One, Zero};
 use thiserror::Error;
 
@@ -14,6 +13,7 @@ use super::utils::UnivariatePoly;
 use crate::core::channel::Channel;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
+use crate::prelude::*;
 
 /// Something that can be seen as a multivariate polynomial `g(x_0, ..., x_{n-1})`.
 pub trait MultivariatePolyOracle: Sized {
@@ -97,7 +97,7 @@ pub fn prove_batch<O: MultivariatePolyOracle>(
 
                 round_poly
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         let round_poly = random_linear_combination(&this_round_polys, lambda);
 

--- a/crates/prover/src/core/lookups/utils.rs
+++ b/crates/prover/src/core/lookups/utils.rs
@@ -1,10 +1,11 @@
-use std::iter::{zip, Sum};
-use std::ops::{Add, Deref, Mul, Neg, Sub};
+use core::iter::{zip, Sum};
+use core::ops::{Add, Deref, Mul, Neg, Sub};
 
 use num_traits::{One, Zero};
 
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::{ExtensionOf, Field};
+use crate::prelude::*;
 
 /// Univariate polynomial stored as coefficients in the monomial basis.
 #[derive(Debug, Clone)]
@@ -287,7 +288,7 @@ impl<T: Sub<Output = T> + Mul<Output = T> + Clone> Sub for Reciprocal<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
+    use core::iter::zip;
 
     use num_traits::{One, Zero};
 

--- a/crates/prover/src/core/mod.rs
+++ b/crates/prover/src/core/mod.rs
@@ -1,4 +1,6 @@
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
+
+use crate::prelude::*;
 
 pub mod air;
 pub mod backend;

--- a/crates/prover/src/core/pcs/prover.rs
+++ b/crates/prover/src/core/pcs/prover.rs
@@ -1,6 +1,3 @@
-use std::collections::BTreeMap;
-
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::{span, Level};
 
@@ -13,6 +10,7 @@ use super::super::ColumnVec;
 use super::quotients::{compute_fri_quotients, PointSample};
 use super::utils::TreeVec;
 use super::{PcsConfig, TreeSubspan};
+use crate::collections::BTreeMap;
 use crate::core::air::Trace;
 use crate::core::backend::BackendForChannel;
 use crate::core::channel::{Channel, MerkleChannel};
@@ -20,6 +18,7 @@ use crate::core::poly::circle::{CircleEvaluation, CirclePoly};
 use crate::core::poly::twiddles::TwiddleTree;
 use crate::core::vcs::ops::MerkleHasher;
 use crate::core::vcs::prover::{MerkleDecommitment, MerkleProver};
+use crate::prelude::*;
 
 /// The prover side of a FRI polynomial commitment scheme. See [super].
 pub struct CommitmentSchemeProver<'a, B: BackendForChannel<MC>, MC: MerkleChannel> {
@@ -97,7 +96,7 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
                         point,
                         value: poly.eval_at_point(point),
                     })
-                    .collect_vec()
+                    .collect::<Vec<_>>()
             });
         span.exit();
         let sampled_values = samples
@@ -238,7 +237,7 @@ impl<B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentTreeProver<B, MC> {
             .evaluations
             .iter()
             .map(|eval| &eval.values)
-            .collect_vec();
+            .collect::<Vec<_>>();
         self.commitment.decommit(queries, eval_vec)
     }
 }

--- a/crates/prover/src/core/pcs/quotients.rs
+++ b/crates/prover/src/core/pcs/quotients.rs
@@ -1,11 +1,11 @@
-use std::cmp::Reverse;
-use std::collections::BTreeMap;
-use std::iter::zip;
+use core::cmp::Reverse;
+use core::iter::zip;
 
 use itertools::{izip, multiunzip, Itertools};
 use tracing::{span, Level};
 
 use super::TreeVec;
+use crate::collections::BTreeMap;
 use crate::core::backend::cpu::quotients::{accumulate_row_quotients, quotient_constants};
 use crate::core::circle::CirclePoint;
 use crate::core::fields::m31::BaseField;
@@ -17,6 +17,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::prover::VerificationError;
 use crate::core::utils::bit_reverse_index;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 pub trait QuotientOps: PolyOps {
     /// Accumulates the quotients of the columns at the given domain.
@@ -82,7 +83,7 @@ pub fn compute_fri_quotients<B: QuotientOps>(
     let _span = span!(Level::INFO, "Compute FRI quotients").entered();
     zip(columns, samples)
         .sorted_by_key(|(c, _)| Reverse(c.domain.log_size()))
-        .group_by(|(c, _)| c.domain.log_size())
+        .chunk_by(|(c, _)| c.domain.log_size())
         .into_iter()
         .map(|(log_size, tuples)| {
             let (columns, samples): (Vec<_>, Vec<_>) = tuples.unzip();
@@ -112,7 +113,7 @@ pub fn fri_answers(
 
     izip!(column_log_sizes.flatten(), samples.flatten().iter())
         .sorted_by_key(|(log_size, ..)| Reverse(*log_size))
-        .group_by(|(log_size, ..)| *log_size)
+        .chunk_by(|(log_size, ..)| *log_size)
         .into_iter()
         .map(|(log_size, tuples)| {
             let (_, samples): (Vec<_>, Vec<_>) = multiunzip(tuples);

--- a/crates/prover/src/core/pcs/utils.rs
+++ b/crates/prover/src/core/pcs/utils.rs
@@ -1,11 +1,12 @@
-use std::collections::BTreeSet;
-use std::ops::{Deref, DerefMut};
+use core::ops::{Deref, DerefMut};
 
 use itertools::zip_eq;
 use serde::{Deserialize, Serialize};
 
 use super::TreeSubspan;
+use crate::collections::BTreeSet;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// A container that holds an element for each commitment tree.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/prover/src/core/pcs/verifier.rs
+++ b/crates/prover/src/core/pcs/verifier.rs
@@ -1,4 +1,4 @@
-use std::iter::zip;
+use core::iter::zip;
 
 use itertools::Itertools;
 
@@ -13,6 +13,7 @@ use crate::core::prover::VerificationError;
 use crate::core::vcs::ops::MerkleHasher;
 use crate::core::vcs::verifier::MerkleVerifier;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// The verifier side of a FRI polynomial commitment scheme. See [super].
 #[derive(Default)]
@@ -71,7 +72,7 @@ impl<MC: MerkleChannel> CommitmentSchemeVerifier<MC> {
             .map(|log_size| {
                 CirclePolyDegreeBound::new(log_size - self.config.fri_config.log_blowup_factor)
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         // FRI commitment phase on OODS quotients.
         let mut fri_verifier =
@@ -103,7 +104,7 @@ impl<MC: MerkleChannel> CommitmentSchemeVerifier<MC> {
             |(sampled_points, sampled_values)| {
                 zip(sampled_points, sampled_values)
                     .map(|(point, value)| PointSample { point, value })
-                    .collect_vec()
+                    .collect()
             },
         );
 

--- a/crates/prover/src/core/poly/circle/domain.rs
+++ b/crates/prover/src/core/poly/circle/domain.rs
@@ -1,11 +1,10 @@
-use std::iter::Chain;
-
-use itertools::Itertools;
+use core::iter::Chain;
 
 use crate::core::circle::{
     CirclePoint, CirclePointIndex, Coset, CosetIterator, M31_CIRCLE_LOG_ORDER,
 };
 use crate::core::fields::m31::BaseField;
+use crate::prelude::*;
 
 pub const MAX_CIRCLE_DOMAIN_LOG_SIZE: u32 = M31_CIRCLE_LOG_ORDER - 1;
 
@@ -90,7 +89,7 @@ impl CircleDomain {
         ));
         let shifts = (0..1 << log_parts)
             .map(|i| self.half_coset.step_size * i)
-            .collect_vec();
+            .collect::<Vec<_>>();
         (subdomain, shifts)
     }
 
@@ -121,8 +120,6 @@ type CircleDomainIndexIterator =
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
-
     use super::CircleDomain;
     use crate::core::circle::{CirclePointIndex, Coset};
     use crate::core::poly::circle::CanonicCoset;
@@ -174,16 +171,16 @@ mod tests {
         let domain_points = domain.iter().collect::<Vec<_>>();
         let points_for_each_domain = shifts
             .iter()
-            .map(|&shift| (subdomain.shift(shift)).iter().collect_vec())
+            .map(|&shift| (subdomain.shift(shift)).iter().collect::<Vec<_>>())
             .collect::<Vec<_>>();
         // Interleave the points from each subdomain.
         let extended_points = (0..(1 << 3))
             .flat_map(|point_ind| {
                 (0..(1 << 2))
                     .map(|shift_ind| points_for_each_domain[shift_ind][point_ind])
-                    .collect_vec()
+                    .collect::<Vec<_>>()
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
         assert_eq!(domain_points, extended_points);
     }
 }

--- a/crates/prover/src/core/poly/circle/evaluation.rs
+++ b/crates/prover/src/core/poly/circle/evaluation.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
-use std::ops::{Deref, Index};
+use core::marker::PhantomData;
+use core::ops::{Deref, Index};
 
 use educe::Educe;
 

--- a/crates/prover/src/core/poly/circle/ops.rs
+++ b/crates/prover/src/core/poly/circle/ops.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use super::{CanonicCoset, CircleDomain, CircleEvaluation, CirclePoly};
 use crate::core::backend::{Col, ColumnOps};
 use crate::core::circle::{CirclePoint, Coset};
@@ -8,6 +6,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::poly::twiddles::TwiddleTree;
 use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// Operations on BaseField polynomials.
 pub trait PolyOps: ColumnOps<BaseField> + Sized {
@@ -68,7 +67,7 @@ pub trait PolyOps: ColumnOps<BaseField> + Sized {
                     twiddles,
                 )
             })
-            .collect_vec()
+            .collect::<Vec<_>>()
     }
 
     /// Precomputes twiddles for a given coset.

--- a/crates/prover/src/core/poly/circle/secure_poly.rs
+++ b/crates/prover/src/core/poly/circle/secure_poly.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
 
 use super::{CircleDomain, CircleEvaluation, CirclePoly, PolyOps};
 use crate::core::backend::{ColumnOps, CpuBackend};

--- a/crates/prover/src/core/poly/line.rs
+++ b/crates/prover/src/core/poly/line.rs
@@ -1,9 +1,8 @@
-use std::cmp::Ordering;
-use std::fmt::Debug;
-use std::iter::Map;
-use std::ops::{Deref, DerefMut};
+use core::cmp::Ordering;
+use core::fmt::Debug;
+use core::iter::Map;
+use core::ops::{Deref, DerefMut};
 
-use itertools::Itertools;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +16,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::secure_column::SecureColumnByCoords;
 use crate::core::fields::ExtensionOf;
+use crate::prelude::*;
 
 /// Domain comprising of the x-coordinates of points in a [Coset].
 ///
@@ -226,7 +226,7 @@ impl<B: ColumnOps<BaseField>> LineEvaluation<B> {
 impl LineEvaluation<CpuBackend> {
     /// Interpolates the polynomial as evaluations on `domain`.
     pub fn interpolate(self) -> LinePoly {
-        let mut values = self.values.into_iter().collect_vec();
+        let mut values = self.values.into_iter().collect::<Vec<_>>();
         CpuBackend::bit_reverse_column(&mut values);
         line_ifft(&mut values, self.domain);
         // Normalize the coefficients.
@@ -275,8 +275,6 @@ fn line_ifft<F: ExtensionOf<BaseField> + Copy>(values: &mut [F], mut domain: Lin
 #[cfg(test)]
 mod tests {
     type B = CpuBackend;
-
-    use itertools::Itertools;
 
     use super::LineDomain;
     use crate::core::backend::{ColumnOps, CpuBackend};
@@ -375,7 +373,7 @@ mod tests {
                     + poly.coeffs[2] * x
                     + poly.coeffs[3] * pi_x * x
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
         CpuBackend::bit_reverse_column(&mut values);
         let evals = LineEvaluation::<B>::new(domain, values.into_iter().collect());
 

--- a/crates/prover/src/core/poly/utils.rs
+++ b/crates/prover/src/core/poly/utils.rs
@@ -1,5 +1,6 @@
 use super::line::LineDomain;
 use crate::core::fields::{ExtensionOf, Field};
+use crate::prelude::*;
 
 /// Folds values recursively in `O(n)` by a hierarchical application of folding factors.
 ///

--- a/crates/prover/src/core/prover/mod.rs
+++ b/crates/prover/src/core/prover/mod.rs
@@ -1,5 +1,5 @@
-use std::ops::Deref;
-use std::{array, mem};
+use core::ops::Deref;
+use core::{array, mem};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -22,6 +22,7 @@ use crate::core::pcs::{CommitmentSchemeProver, CommitmentSchemeVerifier};
 use crate::core::vcs::hash::Hash;
 use crate::core::vcs::prover::MerkleDecommitment;
 use crate::core::vcs::verifier::MerkleVerificationError;
+use crate::prelude::*;
 
 #[instrument(skip_all)]
 pub fn prove<B: BackendForChannel<MC>, MC: MerkleChannel>(

--- a/crates/prover/src/core/queries.rs
+++ b/crates/prover/src/core/queries.rs
@@ -1,9 +1,10 @@
-use std::collections::BTreeSet;
-use std::ops::Deref;
+use core::ops::Deref;
 
 use itertools::Itertools;
 
 use super::channel::Channel;
+use crate::collections::BTreeSet;
+use crate::prelude::*;
 
 pub const UPPER_BOUND_QUERY_BYTES: usize = 4;
 
@@ -112,7 +113,7 @@ mod tests {
         let folded_queries = queries.fold(n_folds);
         let repeated_folded_queries = folded_queries
             .iter()
-            .flat_map(|q| std::iter::repeat(q).take(ratio));
+            .flat_map(|q| core::iter::repeat(q).take(ratio));
         for (query, folded_query) in queries.iter().zip(repeated_folded_queries) {
             // Check only the x coordinate since folding might give you the conjugate point.
             assert_eq!(

--- a/crates/prover/src/core/utils.rs
+++ b/crates/prover/src/core/utils.rs
@@ -1,7 +1,8 @@
-use std::iter::Peekable;
+use core::iter::Peekable;
 
 use super::fields::m31::BaseField;
 use super::fields::Field;
+use crate::prelude::*;
 
 pub trait IteratorMutExt<'a, T: 'a>: Iterator<Item = &'a mut T> {
     fn assign(self, other: impl IntoIterator<Item = T>)
@@ -114,22 +115,6 @@ pub(crate) fn coset_order_to_circle_domain_order<F: Field>(values: &[F]) -> Vec<
     circle_domain_order
 }
 
-/// Converts an index within a [`CircleDomain`] to the corresponding index in a [`Coset`].
-///
-/// [`CircleDomain`]: crate::core::poly::circle::CircleDomain
-/// [`Coset`]: crate::core::circle::Coset
-pub(crate) const fn circle_domain_index_to_coset_index(
-    circle_index: usize,
-    log_domain_size: u32,
-) -> usize {
-    let n = 1 << log_domain_size;
-    if circle_index < n / 2 {
-        circle_index * 2
-    } else {
-        (n - 1 - circle_index) * 2 + 1
-    }
-}
-
 /// Converts an index within a [`Coset`] to the corresponding index in a [`CircleDomain`].
 ///
 /// [`CircleDomain`]: crate::core::poly::circle::CircleDomain
@@ -169,9 +154,6 @@ mod tests {
     use crate::core::backend::cpu::CpuCircleEvaluation;
     use crate::core::poly::circle::CanonicCoset;
     use crate::core::poly::NaturalOrder;
-    use crate::core::utils::{
-        circle_domain_index_to_coset_index, coset_index_to_circle_domain_index,
-    };
     use crate::m31;
 
     #[test]
@@ -204,7 +186,7 @@ mod tests {
         let log_size = 4;
         let n = 1 << log_size;
         let domain = CanonicCoset::new(log_size).circle_domain();
-        let values = (0..n).map(|i| m31!(i as u32)).collect_vec();
+        let values = (0..n).map(|i| m31!(i as u32)).collect::<Vec<_>>();
         let evaluation = CpuCircleEvaluation::<_, NaturalOrder>::new(domain, values);
         let bit_reversed_evaluation = evaluation.clone().bit_reverse();
 
@@ -233,7 +215,7 @@ mod tests {
                 )
             })
             .sorted()
-            .collect_vec();
+            .collect::<Vec<_>>();
         let mut expected_neighbor_pairs = vec![
             (m31!(0), m31!(4)),
             (m31!(15), m31!(11)),
@@ -255,18 +237,5 @@ mod tests {
         expected_neighbor_pairs.sort();
 
         assert_eq!(neighbor_pairs, expected_neighbor_pairs);
-    }
-
-    #[test]
-    fn test_circle_domain_and_coset_index_conversion() {
-        let log_size = 3;
-        let n = 1 << log_size;
-
-        // Test that both functions are inverses of each other
-        for i in 0..n {
-            let coset_idx = circle_domain_index_to_coset_index(i, log_size);
-            let circle_idx = coset_index_to_circle_domain_index(coset_idx, log_size);
-            assert_eq!(i, circle_idx);
-        }
     }
 }

--- a/crates/prover/src/core/vcs/blake2_hash.rs
+++ b/crates/prover/src/core/vcs/blake2_hash.rs
@@ -1,8 +1,10 @@
-use std::fmt;
+use core::fmt;
 
 use blake2::{Blake2s256, Digest};
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
 
 // Wrapper for the blake2s hash type.
 #[repr(C, align(32))]

--- a/crates/prover/src/core/vcs/blake2_merkle.rs
+++ b/crates/prover/src/core/vcs/blake2_merkle.rs
@@ -20,7 +20,7 @@ impl MerkleHasher for Blake2sMerkleHasher {
         if let Some((left, right)) = children_hashes {
             state = compress(
                 state,
-                unsafe { std::mem::transmute::<[Blake2sHash; 2], [u32; 16]>([left, right]) },
+                unsafe { core::mem::transmute::<[Blake2sHash; 2], [u32; 16]>([left, right]) },
                 0,
                 0,
                 0,
@@ -31,11 +31,11 @@ impl MerkleHasher for Blake2sMerkleHasher {
         let padded_values = column_values
             .iter()
             .copied()
-            .chain(std::iter::repeat(BaseField::zero()).take(rem));
+            .chain(core::iter::repeat(BaseField::zero()).take(rem));
         for chunk in padded_values.array_chunks::<16>() {
             state = compress(
                 state,
-                unsafe { std::mem::transmute::<[BaseField; 16], [u32; 16]>(chunk) },
+                unsafe { core::mem::transmute::<[BaseField; 16], [u32; 16]>(chunk) },
                 0,
                 0,
                 0,

--- a/crates/prover/src/core/vcs/blake3_hash.rs
+++ b/crates/prover/src/core/vcs/blake3_hash.rs
@@ -1,8 +1,9 @@
-use std::fmt;
+use core::fmt;
 
 use serde::{Deserialize, Serialize};
 
 use crate::core::vcs::hash::Hash;
+use crate::prelude::*;
 
 // Wrapper for the blake3 hash type.
 #[derive(Clone, Copy, PartialEq, Default, Eq, Serialize, Deserialize)]

--- a/crates/prover/src/core/vcs/hash.rs
+++ b/crates/prover/src/core/vcs/hash.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use core::fmt::{Debug, Display};
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/prover/src/core/vcs/mod.rs
+++ b/crates/prover/src/core/vcs/mod.rs
@@ -1,5 +1,4 @@
 //! Vector commitment scheme (VCS) module.
-
 pub mod blake2_hash;
 pub mod blake2_merkle;
 pub mod blake2s_ref;

--- a/crates/prover/src/core/vcs/ops.rs
+++ b/crates/prover/src/core/vcs/ops.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/prover/src/core/vcs/poseidon252_merkle.rs
+++ b/crates/prover/src/core/vcs/poseidon252_merkle.rs
@@ -7,6 +7,7 @@ use super::ops::MerkleHasher;
 use crate::core::channel::{MerkleChannel, Poseidon252Channel};
 use crate::core::fields::m31::BaseField;
 use crate::core::vcs::hash::Hash;
+use crate::prelude::*;
 
 const ELEMENTS_IN_BLOCK: usize = 8;
 
@@ -32,7 +33,7 @@ impl MerkleHasher for Poseidon252MerkleHasher {
         let padded_values = column_values
             .iter()
             .copied()
-            .chain(std::iter::repeat(BaseField::zero()).take(padding_length));
+            .chain(core::iter::repeat(BaseField::zero()).take(padding_length));
         for chunk in padded_values.array_chunks::<ELEMENTS_IN_BLOCK>() {
             let mut word = FieldElement252::default();
             for x in chunk {

--- a/crates/prover/src/core/vcs/prover.rs
+++ b/crates/prover/src/core/vcs/prover.rs
@@ -1,14 +1,15 @@
-use std::cmp::Reverse;
-use std::collections::BTreeMap;
+use core::cmp::Reverse;
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::ops::{MerkleHasher, MerkleOps};
 use super::utils::{next_decommitment_node, option_flatten_peekable};
+use crate::collections::BTreeMap;
 use crate::core::backend::{Col, Column};
 use crate::core::fields::m31::BaseField;
 use crate::core::utils::PeekableExt;
+use crate::prelude::*;
 
 pub struct MerkleProver<B: MerkleOps<H>, H: MerkleHasher> {
     /// Layers of the Merkle tree.
@@ -55,7 +56,7 @@ impl<B: MerkleOps<H>, H: MerkleHasher> MerkleProver<B, H> {
             // Take columns of the current log_size.
             let layer_columns = columns
                 .peek_take_while(|column| column.len().ilog2() == log_size)
-                .collect_vec();
+                .collect::<Vec<_>>();
 
             layers.push(B::commit_on_layer(log_size, layers.last(), &layer_columns));
         }
@@ -102,7 +103,7 @@ impl<B: MerkleOps<H>, H: MerkleHasher> MerkleProver<B, H> {
             // Prepare the relevant columns and previous layer hashes to read from.
             let layer_columns = columns_by_layer
                 .peek_take_while(|column| column.len().ilog2() == layer_log_size)
-                .collect_vec();
+                .collect::<Vec<_>>();
             let previous_layer_hashes = self.layers.get(layer_log_size as usize + 1);
 
             // Queries to this layer come from queried node in the previous layer and queried

--- a/crates/prover/src/core/vcs/test_utils.rs
+++ b/crates/prover/src/core/vcs/test_utils.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -7,9 +5,11 @@ use rand::{Rng, SeedableRng};
 use super::ops::{MerkleHasher, MerkleOps};
 use super::prover::MerkleDecommitment;
 use super::verifier::MerkleVerifier;
+use crate::collections::BTreeMap;
 use crate::core::backend::CpuBackend;
 use crate::core::fields::m31::BaseField;
 use crate::core::vcs::prover::MerkleProver;
+use crate::prelude::*;
 
 pub type TestData<H> = (
     BTreeMap<u32, Vec<usize>>,
@@ -29,16 +29,16 @@ where
     let mut rng = SmallRng::seed_from_u64(0);
     let log_sizes = (0..N_COLS)
         .map(|_| rng.gen_range(log_size_range.clone()))
-        .collect_vec();
+        .collect::<Vec<_>>();
     let cols = log_sizes
         .iter()
         .map(|&log_size| {
             (0..(1 << log_size))
                 .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
-                .collect_vec()
+                .collect::<Vec<_>>()
         })
-        .collect_vec();
-    let merkle = MerkleProver::<CpuBackend, H>::commit(cols.iter().collect_vec());
+        .collect::<Vec<_>>();
+    let merkle = MerkleProver::<CpuBackend, H>::commit(cols.iter().collect());
 
     let mut queries = BTreeMap::<u32, Vec<usize>>::new();
     for log_size in log_size_range.rev() {
@@ -46,11 +46,11 @@ where
             .map(|_| rng.gen_range(0..(1 << log_size)))
             .sorted()
             .dedup()
-            .collect_vec();
+            .collect::<Vec<_>>();
         queries.insert(log_size, layer_queries);
     }
 
-    let (values, decommitment) = merkle.decommit(&queries, cols.iter().collect_vec());
+    let (values, decommitment) = merkle.decommit(&queries, cols.iter().collect::<Vec<_>>());
 
     let verifier = MerkleVerifier::new(merkle.root(), log_sizes);
     (queries, decommitment, values, verifier)

--- a/crates/prover/src/core/vcs/utils.rs
+++ b/crates/prover/src/core/vcs/utils.rs
@@ -1,4 +1,4 @@
-use std::iter::Peekable;
+use core::iter::Peekable;
 
 /// Fetches the next node that needs to be decommited in the current Merkle layer.
 pub fn next_decommitment_node(
@@ -15,6 +15,6 @@ pub fn next_decommitment_node(
 
 pub fn option_flatten_peekable<'a, I: IntoIterator<Item = &'a usize>>(
     a: Option<I>,
-) -> Peekable<std::iter::Copied<std::iter::Flatten<<Option<I> as IntoIterator>::IntoIter>>> {
+) -> Peekable<core::iter::Copied<core::iter::Flatten<<Option<I> as IntoIterator>::IntoIter>>> {
     a.into_iter().flatten().copied().peekable()
 }

--- a/crates/prover/src/core/vcs/verifier.rs
+++ b/crates/prover/src/core/vcs/verifier.rs
@@ -1,13 +1,12 @@
-use std::collections::BTreeMap;
-
-use itertools::Itertools;
 use thiserror::Error;
 
 use super::ops::MerkleHasher;
 use super::prover::MerkleDecommitment;
 use super::utils::{next_decommitment_node, option_flatten_peekable};
+use crate::collections::BTreeMap;
 use crate::core::fields::m31::BaseField;
 use crate::core::utils::PeekableExt;
+use crate::prelude::*;
 
 pub struct MerkleVerifier<H: MerkleHasher> {
     pub root: H::Hash,
@@ -84,7 +83,7 @@ impl<H: MerkleHasher> MerkleVerifier<H> {
                 .iter()
                 .flatten()
                 .map(|(q, _)| *q)
-                .collect_vec()
+                .collect::<Vec<_>>()
                 .into_iter()
                 .peekable();
             let mut prev_layer_hashes = last_layer_hashes.as_ref().map(|x| x.iter().peekable());
@@ -140,7 +139,9 @@ impl<H: MerkleHasher> MerkleVerifier<H> {
                     ),
                 };
 
-                let node_values = node_values_iter.take(n_columns_in_layer).collect_vec();
+                let node_values = node_values_iter
+                    .take(n_columns_in_layer)
+                    .collect::<Vec<_>>();
                 if node_values.len() != n_columns_in_layer {
                     return Err(err);
                 }

--- a/crates/prover/src/examples/blake/air.rs
+++ b/crates/prover/src/examples/blake/air.rs
@@ -1,6 +1,6 @@
-use std::simd::u32x16;
+use core::simd::u32x16;
 
-use itertools::{chain, multiunzip, Itertools};
+use itertools::{chain, multiunzip};
 use num_traits::Zero;
 use serde::Serialize;
 use tracing::{span, Level};
@@ -26,6 +26,7 @@ use crate::examples::blake::scheduler::{self, blake_scheduler_info, BlakeElement
 use crate::examples::blake::{
     round, xor_table, BlakeXorElements, XorAccums, N_ROUNDS, ROUND_LOG_SPLIT,
 };
+use crate::prelude::*;
 
 fn preprocessed_xor_columns() -> [PreProcessedColumnId; 20] {
     [
@@ -116,7 +117,7 @@ impl BlakeStatement0 {
             blake_round_is_first_column_log_sizes,
             preprocessed_xor_columns_log_sizes(),
         )
-        .collect_vec();
+        .collect::<Vec<_>>();
 
         log_sizes
     }
@@ -163,7 +164,7 @@ impl BlakeStatement1 {
                 ],
                 self.round_claimed_sums.clone()
             ]
-            .collect_vec(),
+            .collect::<Vec<_>>(),
         )
     }
 }
@@ -191,7 +192,7 @@ impl BlakeComponents {
         let blake_round_is_first_columns_iter: Vec<PreProcessedColumnId> = ROUND_LOG_SPLIT
             .iter()
             .map(|l| IsFirst::new(log_size + l).id())
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         let tree_span_provider = &mut TraceLocationAllocator::new_with_preproccessed_columns(
             &chain!(
@@ -199,7 +200,7 @@ impl BlakeComponents {
                 blake_round_is_first_columns_iter,
                 preprocessed_xor_columns(),
             )
-            .collect_vec()[..],
+            .collect::<Vec<_>>()[..],
         );
 
         Self {
@@ -330,11 +331,11 @@ where
     // Prepare inputs.
     let blake_inputs = (0..(1 << (log_size - LOG_N_LANES)))
         .map(|i| {
-            let v = [u32x16::from_array(std::array::from_fn(|j| (i + 2 * j) as u32)); 16];
-            let m = [u32x16::from_array(std::array::from_fn(|j| (i + 2 * j + 1) as u32)); 16];
+            let v = [u32x16::from_array(core::array::from_fn(|j| (i + 2 * j) as u32)); 16];
+            let m = [u32x16::from_array(core::array::from_fn(|j| (i + 2 * j + 1) as u32)); 16];
             BlakeInput { v, m }
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     // Setup protocol.
     let channel = &mut MC::C::default();
@@ -356,7 +357,7 @@ where
             XorTable::new(7, 2, 0).generate_constant_trace(),
             XorTable::new(4, 0, 0).generate_constant_trace(),
         ]
-        .collect_vec(),
+        .collect::<Vec<_>>(),
     );
     tree_builder.commit(channel);
     span.exit();
@@ -401,7 +402,7 @@ where
             xor_trace7,
             xor_trace4,
         ]
-        .collect_vec(),
+        .collect::<Vec<_>>(),
     );
     tree_builder.commit(channel);
     span.exit();
@@ -464,7 +465,7 @@ where
             xor_trace7,
             xor_trace4,
         ]
-        .collect_vec(),
+        .collect::<Vec<_>>(),
     );
 
     // Statement1.

--- a/crates/prover/src/examples/blake/mod.rs
+++ b/crates/prover/src/examples/blake/mod.rs
@@ -1,9 +1,9 @@
 //! AIR for blake2s and blake3.
 //! See <https://en.wikipedia.org/wiki/BLAKE_(hash_function)>
 
-use std::fmt::Debug;
-use std::ops::{Add, AddAssign, Mul, Sub};
-use std::simd::u32x16;
+use core::fmt::Debug;
+use core::ops::{Add, AddAssign, Mul, Sub};
+use core::simd::u32x16;
 
 use num_traits::One;
 use xor_table::{xor12, xor4, xor7, xor8, xor9};

--- a/crates/prover/src/examples/blake/preprocessed_columns.rs
+++ b/crates/prover/src/examples/blake/preprocessed_columns.rs
@@ -7,6 +7,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// A preprocessed table for the xor operation of 2 n_bits numbers.
 /// n_expand_bits is an optimization parameter reducing the table's cloumns' length to

--- a/crates/prover/src/examples/blake/round/constraints.rs
+++ b/crates/prover/src/examples/blake/round/constraints.rs
@@ -1,4 +1,4 @@
-use itertools::{chain, Itertools};
+use itertools::chain;
 use num_traits::One;
 
 use super::{BlakeXorElements, RoundElements};
@@ -6,6 +6,7 @@ use crate::constraint_framework::{EvalAtRow, RelationEntry};
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::examples::blake::{Fu32, STATE_SIZE};
+use crate::prelude::*;
 
 const INV16: BaseField = BaseField::from_u32_unchecked(1 << 15);
 const TWO: BaseField = BaseField::from_u32_unchecked(2);
@@ -20,9 +21,9 @@ pub struct BlakeRoundEval<'a, E: EvalAtRow> {
 }
 impl<E: EvalAtRow> BlakeRoundEval<'_, E> {
     pub fn eval(mut self) -> E {
-        let mut v: [Fu32<E::F>; STATE_SIZE] = std::array::from_fn(|_| self.next_u32());
+        let mut v: [Fu32<E::F>; STATE_SIZE] = core::array::from_fn(|_| self.next_u32());
         let input_v = v.clone();
-        let m: [Fu32<E::F>; STATE_SIZE] = std::array::from_fn(|_| self.next_u32());
+        let m: [Fu32<E::F>; STATE_SIZE] = core::array::from_fn(|_| self.next_u32());
 
         self.g(
             v.get_many_mut([0, 4, 8, 12]).unwrap(),
@@ -74,7 +75,7 @@ impl<E: EvalAtRow> BlakeRoundEval<'_, E> {
                 v.iter().cloned().flat_map(Fu32::into_felts),
                 m.iter().cloned().flat_map(Fu32::into_felts)
             ]
-            .collect_vec(),
+            .collect::<Vec<_>>(),
         ));
 
         self.eval.finalize_logup_in_pairs();

--- a/crates/prover/src/examples/blake/round/gen.rs
+++ b/crates/prover/src/examples/blake/round/gen.rs
@@ -1,7 +1,6 @@
-use std::simd::u32x16;
-use std::vec;
+use core::simd::u32x16;
 
-use itertools::{chain, Itertools};
+use itertools::chain;
 use num_traits::One;
 use tracing::{span, Level};
 
@@ -20,6 +19,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
 use crate::examples::blake::round::blake_round_info;
 use crate::examples::blake::{to_felts, XorAccums, N_ROUND_INPUT_FELTS, STATE_SIZE};
+use crate::prelude::*;
 
 pub struct BlakeRoundLookupData {
     /// A vector of (w, [a_col, b_col, c_col]) for each xor lookup.
@@ -40,12 +40,12 @@ impl TraceGenerator {
         assert!(log_size >= LOG_N_LANES);
         let trace = (0..blake_round_info().mask_offsets[ORIGINAL_TRACE_IDX].len())
             .map(|_| unsafe { Col::<SimdBackend, BaseField>::uninitialized(1 << log_size) })
-            .collect_vec();
+            .collect::<Vec<_>>();
         Self {
             log_size,
             trace,
             xor_lookups: vec![],
-            round_lookup: std::array::from_fn(|_| unsafe {
+            round_lookup: core::array::from_fn(|_| unsafe {
                 BaseColumn::uninitialized(1 << log_size)
             }),
         }
@@ -183,7 +183,7 @@ impl TraceGeneratorRow<'_> {
         if self.gen.xor_lookups.len() <= self.xor_lookups_index {
             self.gen.xor_lookups.push((
                 w,
-                std::array::from_fn(|_| unsafe {
+                core::array::from_fn(|_| unsafe {
                     BaseColumn::uninitialized(1 << self.gen.log_size)
                 }),
             ));

--- a/crates/prover/src/examples/blake/round/mod.rs
+++ b/crates/prover/src/examples/blake/round/mod.rs
@@ -52,9 +52,7 @@ pub fn blake_round_info() -> InfoEvaluator {
 
 #[cfg(test)]
 mod tests {
-    use std::simd::Simd;
-
-    use itertools::Itertools;
+    use core::simd::Simd;
 
     use crate::constraint_framework::preprocessed_columns::IsFirst;
     use crate::constraint_framework::FrameworkEval;
@@ -76,10 +74,10 @@ mod tests {
             LOG_SIZE,
             &(0..(1 << LOG_SIZE))
                 .map(|_| BlakeRoundInput {
-                    v: std::array::from_fn(|i| Simd::splat(i as u32)),
-                    m: std::array::from_fn(|i| Simd::splat((i + 1) as u32)),
+                    v: core::array::from_fn(|i| Simd::splat(i as u32)),
+                    m: core::array::from_fn(|i| Simd::splat((i + 1) as u32)),
                 })
-                .collect_vec(),
+                .collect::<Vec<_>>(),
             &mut xor_accum,
         );
 
@@ -105,7 +103,7 @@ mod tests {
             round_lookup_elements,
             claimed_sum,
         };
-        crate::constraint_framework::assert_constraints_on_polys(
+        crate::constraint_framework::assert_constraints(
             &trace_polys,
             CanonicCoset::new(LOG_SIZE),
             |eval| {

--- a/crates/prover/src/examples/blake/scheduler/constraints.rs
+++ b/crates/prover/src/examples/blake/scheduler/constraints.rs
@@ -1,4 +1,4 @@
-use itertools::{chain, Itertools};
+use itertools::chain;
 use num_traits::{One, Zero};
 
 use super::BlakeElements;
@@ -6,15 +6,16 @@ use crate::constraint_framework::{EvalAtRow, RelationEntry};
 use crate::core::vcs::blake2s_ref::SIGMA;
 use crate::examples::blake::round::RoundElements;
 use crate::examples::blake::{Fu32, N_ROUNDS, STATE_SIZE};
+use crate::prelude::*;
 
 pub fn eval_blake_scheduler_constraints<E: EvalAtRow>(
     eval: &mut E,
     blake_lookup_elements: &BlakeElements,
     round_lookup_elements: &RoundElements,
 ) {
-    let messages: [Fu32<E::F>; STATE_SIZE] = std::array::from_fn(|_| eval_next_u32(eval));
+    let messages: [Fu32<E::F>; STATE_SIZE] = core::array::from_fn(|_| eval_next_u32(eval));
     let states: [[Fu32<E::F>; STATE_SIZE]; N_ROUNDS + 1] =
-        std::array::from_fn(|_| std::array::from_fn(|_| eval_next_u32(eval)));
+        core::array::from_fn(|_| core::array::from_fn(|_| eval_next_u32(eval)));
 
     // Schedule.
     for [i, j] in (0..N_ROUNDS).array_chunks::<2>() {
@@ -28,7 +29,7 @@ pub fn eval_blake_scheduler_constraints<E: EvalAtRow>(
                 output_state.iter().cloned().flat_map(Fu32::into_felts),
                 round_messages.iter().cloned().flat_map(Fu32::into_felts)
             ]
-            .collect_vec()
+            .collect::<Vec<_>>()
         });
         eval.add_to_relation(RelationEntry::new(
             round_lookup_elements,
@@ -54,7 +55,7 @@ pub fn eval_blake_scheduler_constraints<E: EvalAtRow>(
             output_state.iter().cloned().flat_map(Fu32::into_felts),
             messages.iter().cloned().flat_map(Fu32::into_felts)
         ]
-        .collect_vec(),
+        .collect::<Vec<_>>(),
     ));
 
     eval.finalize_logup_in_pairs();

--- a/crates/prover/src/examples/blake/scheduler/gen.rs
+++ b/crates/prover/src/examples/blake/scheduler/gen.rs
@@ -1,6 +1,6 @@
-use std::simd::u32x16;
+use core::simd::u32x16;
 
-use itertools::{chain, Itertools};
+use itertools::chain;
 use num_traits::Zero;
 use tracing::{span, Level};
 
@@ -19,6 +19,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
 use crate::examples::blake::round::{BlakeRoundInput, RoundElements};
 use crate::examples::blake::{to_felts, N_ROUNDS, N_ROUND_INPUT_FELTS, STATE_SIZE};
+use crate::prelude::*;
 
 #[derive(Copy, Clone, Default)]
 pub struct BlakeInput {
@@ -33,10 +34,10 @@ pub struct BlakeSchedulerLookupData {
 impl BlakeSchedulerLookupData {
     fn new(log_size: u32) -> Self {
         Self {
-            round_lookups: std::array::from_fn(|_| {
-                std::array::from_fn(|_| unsafe { BaseColumn::uninitialized(1 << log_size) })
+            round_lookups: core::array::from_fn(|_| {
+                core::array::from_fn(|_| unsafe { BaseColumn::uninitialized(1 << log_size) })
             }),
-            blake_lookups: std::array::from_fn(|_| unsafe {
+            blake_lookups: core::array::from_fn(|_| unsafe {
                 BaseColumn::uninitialized(1 << log_size)
             }),
         }
@@ -57,7 +58,7 @@ pub fn gen_trace(
 
     let mut trace = (0..blake_scheduler_info().mask_offsets[ORIGINAL_TRACE_IDX].len())
         .map(|_| unsafe { BaseColumn::uninitialized(1 << log_size) })
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
         let mut col_index = 0;

--- a/crates/prover/src/examples/blake/scheduler/mod.rs
+++ b/crates/prover/src/examples/blake/scheduler/mod.rs
@@ -53,13 +53,11 @@ pub fn blake_scheduler_info() -> InfoEvaluator {
 
 #[cfg(test)]
 mod tests {
-    use std::simd::Simd;
-
-    use itertools::Itertools;
+    use core::simd::Simd;
 
     use crate::constraint_framework::preprocessed_columns::IsFirst;
     use crate::constraint_framework::FrameworkEval;
-    use crate::core::backend::Column;
+    use crate::core::poly::circle::CanonicCoset;
     use crate::examples::blake::round::RoundElements;
     use crate::examples::blake::scheduler::r#gen::{gen_interaction_trace, gen_trace, BlakeInput};
     use crate::examples::blake::scheduler::{BlakeElements, BlakeSchedulerEval};
@@ -74,10 +72,10 @@ mod tests {
             LOG_SIZE,
             &(0..(1 << LOG_SIZE))
                 .map(|_| BlakeInput {
-                    v: std::array::from_fn(|i| Simd::splat(i as u32)),
-                    m: std::array::from_fn(|i| Simd::splat((i + 1) as u32)),
+                    v: core::array::from_fn(|i| Simd::splat(i as u32)),
+                    m: core::array::from_fn(|i| Simd::splat((i + 1) as u32)),
                 })
-                .collect_vec(),
+                .collect::<Vec<_>>(),
         );
 
         let round_lookup_elements = RoundElements::dummy();
@@ -90,15 +88,11 @@ mod tests {
         );
 
         let trace = TreeVec::new(vec![
-            vec![IsFirst::new(LOG_SIZE).gen_column_simd().values.to_cpu()],
-            trace.into_iter().map(|x| x.values.to_cpu()).collect(),
-            interaction_trace
-                .into_iter()
-                .map(|x| x.values.to_cpu())
-                .collect(),
+            vec![IsFirst::new(LOG_SIZE).gen_column_simd()],
+            trace,
+            interaction_trace,
         ]);
-        let trace = &trace.as_ref();
-        let trace = trace.into();
+        let trace_polys = trace.map_cols(|c| c.interpolate());
 
         let component = BlakeSchedulerEval {
             log_size: LOG_SIZE,
@@ -106,9 +100,9 @@ mod tests {
             round_lookup_elements,
             claimed_sum,
         };
-        crate::constraint_framework::assert_constraints_on_trace(
-            &trace,
-            LOG_SIZE,
+        crate::constraint_framework::assert_constraints(
+            &trace_polys,
+            CanonicCoset::new(LOG_SIZE),
             |eval| {
                 component.evaluate(eval);
             },

--- a/crates/prover/src/examples/blake/xor_table/constraints.rs
+++ b/crates/prover/src/examples/blake/xor_table/constraints.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 #[macro_export]
 macro_rules! xor_table_eval {
     ($modname:tt, $elements:tt, $elem_bits:literal, $expand_bits:literal) => {

--- a/crates/prover/src/examples/blake/xor_table/gen.rs
+++ b/crates/prover/src/examples/blake/xor_table/gen.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 #[macro_export]
 macro_rules! xor_table_gen {
     ($modname:tt, $elements:tt, $elem_bits:literal, $expand_bits:literal) => {
@@ -24,7 +26,7 @@ macro_rules! xor_table_gen {
                             mult.clone(),
                         )
                     })
-                    .collect_vec(),
+                    .collect::<Vec<_>>(),
                 XorTableLookupData { xor_accum },
             )
         }
@@ -45,7 +47,7 @@ macro_rules! xor_table_gen {
         ) {
             let limb_bits = XorTable::new(ELEM_BITS, EXPAND_BITS, 0).limb_bits();
             let _span = span!(Level::INFO, "Xor interaction trace").entered();
-            let offsets_vec = u32x16::from_array(std::array::from_fn(|i| i as u32));
+            let offsets_vec = u32x16::from_array(core::array::from_fn(|i| i as u32));
             let mut logup_gen =
                 LogupTraceGenerator::new(XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits());
 
@@ -103,7 +105,7 @@ macro_rules! xor_table_gen {
 
             // If there is an odd number of lookup expressions, handle the last one.
             if let Some(rem) = iter.into_remainder() {
-                if let Some((i, mults)) = rem.collect_vec().pop() {
+                if let Some((i, mults)) = rem.collect::<Vec<_>>().pop() {
                     let mut col_gen = logup_gen.new_col();
                     let ah = i as u32 >> EXPAND_BITS;
                     let bh = i as u32 & ((1 << EXPAND_BITS) - 1);

--- a/crates/prover/src/examples/blake/xor_table/mod.rs
+++ b/crates/prover/src/examples/blake/xor_table/mod.rs
@@ -10,10 +10,12 @@
 //! xors: (a_l, b_l, a_l^b_l).
 //! The rest of the lookups are computed based on these constant columns.
 
+use crate::prelude::*;
+
 mod constraints;
 mod gen;
 
-use std::simd::u32x16;
+use core::simd::u32x16;
 
 use itertools::Itertools;
 use num_traits::Zero;
@@ -73,7 +75,7 @@ macro_rules! xor_table_component {
                                 1 << XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits(),
                             )
                         })
-                        .collect_vec(),
+                        .collect::<Vec<_>>(),
                 }
             }
         }
@@ -153,10 +155,10 @@ define_xor_table!(xor4, XorElements4, 4, 0);
 
 #[cfg(test)]
 mod tests {
-    use std::simd::u32x16;
+    use core::simd::u32x16;
 
     use crate::constraint_framework::logup::LookupElements;
-    use crate::constraint_framework::{assert_constraints_on_polys, FrameworkEval};
+    use crate::constraint_framework::{assert_constraints, FrameworkEval};
     use crate::core::poly::circle::CanonicCoset;
     use crate::examples::blake::preprocessed_columns::XorTable;
     use crate::examples::blake::xor_table::xor12::{
@@ -186,7 +188,7 @@ mod tests {
             lookup_elements,
             claimed_sum,
         };
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             CanonicCoset::new(XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits()),
             |eval| {

--- a/crates/prover/src/examples/plonk/mod.rs
+++ b/crates/prover/src/examples/plonk/mod.rs
@@ -1,12 +1,11 @@
-use itertools::Itertools;
 use num_traits::One;
 use tracing::{span, Level};
 
 use crate::constraint_framework::logup::{LogupTraceGenerator, LookupElements};
 use crate::constraint_framework::preprocessed_columns::PreProcessedColumnId;
 use crate::constraint_framework::{
-    assert_constraints_on_polys, relation, EvalAtRow, FrameworkComponent, FrameworkEval,
-    RelationEntry, TraceLocationAllocator,
+    assert_constraints, relation, EvalAtRow, FrameworkComponent, FrameworkEval, RelationEntry,
+    TraceLocationAllocator,
 };
 use crate::core::backend::simd::column::BaseColumn;
 use crate::core::backend::simd::m31::LOG_N_LANES;
@@ -22,6 +21,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::prover::{prove, StarkProof};
 use crate::core::vcs::blake2_merkle::{Blake2sMerkleChannel, Blake2sMerkleHasher};
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 pub type PlonkComponent = FrameworkComponent<PlonkEval>;
 
@@ -205,7 +205,7 @@ pub fn prove_fibonacci_plonk(
             col,
         )
     })
-    .collect_vec();
+    .collect::<Vec<_>>();
     let constants_trace_location = tree_builder.extend_evals(constant_trace);
     tree_builder.commit(channel);
     span.exit();
@@ -246,13 +246,12 @@ pub fn prove_fibonacci_plonk(
     let trace_polys = commitment_scheme
         .trees
         .as_ref()
-        .map(|t| t.polynomials.iter().cloned().collect_vec());
-    let component_eval = component.clone();
-    assert_constraints_on_polys(
+        .map(|t| t.polynomials.iter().cloned().collect::<Vec<_>>());
+    assert_constraints(
         &trace_polys,
         CanonicCoset::new(log_n_rows),
-        |assert_eval| {
-            component_eval.evaluate(assert_eval);
+        |mut eval| {
+            component.evaluate(eval);
         },
         claimed_sum,
     );

--- a/crates/prover/src/examples/poseidon/mod.rs
+++ b/crates/prover/src/examples/poseidon/mod.rs
@@ -1,8 +1,6 @@
 //! AIR for Poseidon2 hash function from <https://eprint.iacr.org/2023/323.pdf>.
+use core::ops::{Add, AddAssign, Mul, Sub};
 
-use std::ops::{Add, AddAssign, Mul, Sub};
-
-use itertools::Itertools;
 use num_traits::One;
 use tracing::{info, span, Level};
 
@@ -26,6 +24,7 @@ use crate::core::poly::BitReversedOrder;
 use crate::core::prover::{prove, StarkProof};
 use crate::core::vcs::blake2_merkle::{Blake2sMerkleChannel, Blake2sMerkleHasher};
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 const N_LOG_INSTANCES_PER_ROW: usize = 3;
 const N_INSTANCES_PER_ROW: usize = 1 << N_LOG_INSTANCES_PER_ROW;
@@ -140,7 +139,7 @@ fn pow5<F: FieldExpOps>(x: F) -> F {
 
 pub fn eval_poseidon_constraints<E: EvalAtRow>(eval: &mut E, lookup_elements: &PoseidonElements) {
     for _ in 0..N_INSTANCES_PER_ROW {
-        let mut state: [_; N_STATE] = std::array::from_fn(|_| eval.next_trace_mask());
+        let mut state: [_; N_STATE] = core::array::from_fn(|_| eval.next_trace_mask());
 
         // Require state lookup.
         let initial_state = state.clone();
@@ -152,7 +151,7 @@ pub fn eval_poseidon_constraints<E: EvalAtRow>(eval: &mut E, lookup_elements: &P
             });
             apply_external_round_matrix(&mut state);
             // TODO(andrew) Apply round matrix after the pow5, as is the order in the paper.
-            state = std::array::from_fn(|i| pow5(state[i].clone()));
+            state = core::array::from_fn(|i| pow5(state[i].clone()));
             state.iter_mut().for_each(|s| {
                 let m = eval.next_trace_mask();
                 eval.add_constraint(s.clone() - m.clone());
@@ -176,7 +175,7 @@ pub fn eval_poseidon_constraints<E: EvalAtRow>(eval: &mut E, lookup_elements: &P
                 state[i] += EXTERNAL_ROUND_CONSTS[round + N_HALF_FULL_ROUNDS][i];
             });
             apply_external_round_matrix(&mut state);
-            state = std::array::from_fn(|i| pow5(state[i].clone()));
+            state = core::array::from_fn(|i| pow5(state[i].clone()));
             state.iter_mut().for_each(|s| {
                 let m = eval.next_trace_mask();
                 eval.add_constraint(s.clone() - m.clone());
@@ -210,13 +209,13 @@ pub fn gen_trace(
     assert!(log_size >= LOG_N_LANES);
     let mut trace = (0..N_COLUMNS)
         .map(|_| Col::<SimdBackend, BaseField>::zeros(1 << log_size))
-        .collect_vec();
+        .collect::<Vec<_>>();
     let mut lookup_data = LookupData {
-        initial_state: std::array::from_fn(|_| {
-            std::array::from_fn(|_| BaseColumn::zeros(1 << log_size))
+        initial_state: core::array::from_fn(|_| {
+            core::array::from_fn(|_| BaseColumn::zeros(1 << log_size))
         }),
-        final_state: std::array::from_fn(|_| {
-            std::array::from_fn(|_| BaseColumn::zeros(1 << log_size))
+        final_state: core::array::from_fn(|_| {
+            core::array::from_fn(|_| BaseColumn::zeros(1 << log_size))
         }),
     };
 
@@ -224,8 +223,8 @@ pub fn gen_trace(
         // Initial state.
         let mut col_index = 0;
         for rep_i in 0..N_INSTANCES_PER_ROW {
-            let mut state: [_; N_STATE] = std::array::from_fn(|state_i| {
-                PackedBaseField::from_array(std::array::from_fn(|i| {
+            let mut state: [_; N_STATE] = core::array::from_fn(|state_i| {
+                PackedBaseField::from_array(core::array::from_fn(|i| {
                     BaseField::from_u32_unchecked((vec_index * 16 + i + state_i + rep_i) as u32)
                 }))
             });
@@ -244,7 +243,7 @@ pub fn gen_trace(
                     state[i] += PackedBaseField::broadcast(EXTERNAL_ROUND_CONSTS[round][i]);
                 });
                 apply_external_round_matrix(&mut state);
-                state = std::array::from_fn(|i| pow5(state[i]));
+                state = core::array::from_fn(|i| pow5(state[i]));
                 state.iter().copied().for_each(|s| {
                     trace[col_index].data[vec_index] = s;
                     col_index += 1;
@@ -268,7 +267,7 @@ pub fn gen_trace(
                     );
                 });
                 apply_external_round_matrix(&mut state);
-                state = std::array::from_fn(|i| pow5(state[i]));
+                state = core::array::from_fn(|i| pow5(state[i]));
                 state.iter().copied().for_each(|s| {
                     trace[col_index].data[vec_index] = s;
                     col_index += 1;
@@ -392,10 +391,9 @@ pub fn prove_poseidon(
 mod tests {
     use std::env;
 
-    use itertools::Itertools;
     use num_traits::One;
 
-    use crate::constraint_framework::assert_constraints_on_polys;
+    use crate::constraint_framework::assert_constraints;
     use crate::core::air::Component;
     use crate::core::channel::Blake2sChannel;
     use crate::core::fields::m31::BaseField;
@@ -429,11 +427,11 @@ mod tests {
             [5, 7, 1, 3, 4, 6, 1, 1, 1, 3, 5, 7, 1, 1, 4, 6]
                 .map(BaseField::from_u32_unchecked)
                 .into_iter()
-                .collect_vec(),
+                .collect::<Vec<_>>(),
         );
         let state = (0..4)
             .map(BaseField::from_u32_unchecked)
-            .collect_vec()
+            .collect::<Vec<_>>()
             .try_into()
             .unwrap();
 
@@ -444,7 +442,7 @@ mod tests {
     fn test_apply_internal() {
         let mut state: [BaseField; 16] = (0..16)
             .map(|i| BaseField::from_u32_unchecked(i * 3 + 187))
-            .collect_vec()
+            .collect::<Vec<_>>()
             .try_into()
             .unwrap();
         let mut internal_matrix = [[BaseField::one(); 16]; 16];
@@ -471,9 +469,13 @@ mod tests {
             gen_interaction_trace(LOG_N_ROWS, interaction_data, &lookup_elements);
 
         let traces = TreeVec::new(vec![vec![], trace0, trace1]);
-        let trace_polys =
-            traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect_vec());
-        assert_constraints_on_polys(
+        let trace_polys = traces.map(|trace| {
+            trace
+                .into_iter()
+                .map(|c| c.interpolate())
+                .collect::<Vec<_>>()
+        });
+        assert_constraints(
             &trace_polys,
             CanonicCoset::new(LOG_N_ROWS),
             |mut eval| {

--- a/crates/prover/src/examples/state_machine/components.rs
+++ b/crates/prover/src/examples/state_machine/components.rs
@@ -17,6 +17,7 @@ use crate::core::poly::circle::CircleEvaluation;
 use crate::core::poly::BitReversedOrder;
 use crate::core::prover::StarkProof;
 use crate::core::vcs::ops::MerkleHasher;
+use crate::prelude::*;
 
 const LOG_CONSTRAINT_DEGREE: u32 = 1;
 pub const STATE_SIZE: usize = 2;
@@ -45,7 +46,7 @@ impl<const COORDINATE: usize> FrameworkEval for StateTransitionEval<COORDINATE> 
         self.log_n_rows + LOG_CONSTRAINT_DEGREE
     }
     fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
-        let input_state: [_; STATE_SIZE] = std::array::from_fn(|_| eval.next_trace_mask());
+        let input_state: [_; STATE_SIZE] = core::array::from_fn(|_| eval.next_trace_mask());
 
         let mut output_state = input_state.clone();
         output_state[COORDINATE] += E::F::one();

--- a/crates/prover/src/examples/state_machine/gen.rs
+++ b/crates/prover/src/examples/state_machine/gen.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use num_traits::{One, Zero};
 
 use super::components::{State, StateMachineElements, STATE_SIZE};
@@ -14,6 +13,7 @@ use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::{bit_reverse_index, coset_index_to_circle_domain_index};
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 // Given `initial state`, generate a trace that row `i` is the initial state plus `i` in the
 // `inc_index` dimension.
@@ -26,7 +26,7 @@ pub fn gen_trace(
     let domain = CanonicCoset::new(log_size).circle_domain();
     let mut trace = (0..STATE_SIZE)
         .map(|_| vec![M31::zero(); 1 << log_size])
-        .collect_vec();
+        .collect::<Vec<_>>();
     let mut curr_state = initial_state;
 
     // Add the states in bit reversed circle domain order.
@@ -48,7 +48,7 @@ pub fn gen_trace(
                 BaseColumn::from_iter(col),
             )
         })
-        .collect_vec()
+        .collect::<Vec<_>>()
 }
 
 pub fn gen_interaction_trace(
@@ -69,7 +69,7 @@ pub fn gen_interaction_trace(
         let mut packed_state: [PackedM31; STATE_SIZE] = trace
             .iter()
             .map(|col| col.data[vec_row])
-            .collect_vec()
+            .collect::<Vec<_>>()
             .try_into()
             .unwrap();
         let input_denom: PackedQM31 = lookup_elements.combine(&packed_state);

--- a/crates/prover/src/examples/state_machine/mod.rs
+++ b/crates/prover/src/examples/state_machine/mod.rs
@@ -1,5 +1,6 @@
 use crate::constraint_framework::relation_tracker::RelationSummary;
 use crate::constraint_framework::Relation;
+use crate::prelude::*;
 pub mod components;
 pub mod gen;
 
@@ -9,7 +10,7 @@ use components::{
     StateMachineStatement1, StateTransitionEval,
 };
 use gen::{gen_interaction_trace, gen_trace};
-use itertools::{chain, Itertools};
+use itertools::chain;
 
 use crate::constraint_framework::TraceLocationAllocator;
 use crate::core::backend::simd::m31::LOG_N_LANES;
@@ -57,7 +58,7 @@ pub fn prove_state_machine(
     let trace_op0 = gen_trace(x_axis_log_rows, initial_state, 0);
     let trace_op1 = gen_trace(y_axis_log_rows, intermediate_state, 1);
 
-    let trace = chain![trace_op0.clone(), trace_op1.clone()].collect_vec();
+    let trace = chain![trace_op0.clone(), trace_op1.clone()].collect::<Vec<_>>();
 
     let relation_summary = match track_relations {
         false => None,
@@ -100,7 +101,8 @@ pub fn prove_state_machine(
     stmt1.mix_into(channel);
 
     let mut tree_builder = commitment_scheme.tree_builder();
-    tree_builder.extend_evals(chain![interaction_trace_op0, interaction_trace_op1].collect_vec());
+    tree_builder
+        .extend_evals(chain![interaction_trace_op0, interaction_trace_op1].collect::<Vec<_>>());
     tree_builder.commit(channel);
 
     // Prove constraints.
@@ -189,7 +191,7 @@ mod tests {
     use super::{prove_state_machine, verify_state_machine};
     use crate::constraint_framework::expr::ExprEvaluator;
     use crate::constraint_framework::{
-        assert_constraints_on_polys, FrameworkEval, Relation, TraceLocationAllocator,
+        assert_constraints, FrameworkEval, Relation, TraceLocationAllocator,
     };
     use crate::core::channel::Blake2sChannel;
     use crate::core::fields::m31::M31;
@@ -221,12 +223,11 @@ mod tests {
 
         let trace = TreeVec::new(vec![vec![], trace, interaction_trace]);
         let trace_polys = trace.map_cols(|c| c.interpolate());
-        let component_eval = component.clone();
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             CanonicCoset::new(log_n_rows),
-            |assert_eval| {
-                component_eval.evaluate(assert_eval);
+            |eval| {
+                component.evaluate(eval);
             },
             claimed_sum,
         );

--- a/crates/prover/src/examples/wide_fibonacci/mod.rs
+++ b/crates/prover/src/examples/wide_fibonacci/mod.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::constraint_framework::{EvalAtRow, FrameworkComponent, FrameworkEval};
 use crate::core::backend::simd::m31::PackedBaseField;
 use crate::core::backend::simd::SimdBackend;
@@ -9,6 +7,7 @@ use crate::core::fields::FieldExpOps;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 pub type WideFibonacciComponent<const N: usize> = FrameworkComponent<WideFibonacciEval<N>>;
 
@@ -49,7 +48,7 @@ pub fn generate_trace<const N: usize>(
 ) -> ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> {
     let mut trace = (0..N)
         .map(|_| Col::<SimdBackend, BaseField>::zeros(1 << log_size))
-        .collect_vec();
+        .collect::<Vec<_>>();
     for (vec_index, input) in inputs.iter().enumerate() {
         let mut a = input.a;
         let mut b = input.b;
@@ -64,17 +63,16 @@ pub fn generate_trace<const N: usize>(
     trace
         .into_iter()
         .map(|eval| CircleEvaluation::<SimdBackend, _, BitReversedOrder>::new(domain, eval))
-        .collect_vec()
+        .collect::<Vec<_>>()
 }
 
 #[cfg(test)]
 mod tests {
-    use itertools::Itertools;
     use num_traits::{One, Zero};
 
     use super::WideFibonacciEval;
     use crate::constraint_framework::{
-        assert_constraints_on_polys, AssertEvaluator, FrameworkEval, TraceLocationAllocator,
+        assert_constraints, AssertEvaluator, FrameworkEval, TraceLocationAllocator,
     };
     use crate::core::air::Component;
     use crate::core::backend::simd::m31::{PackedBaseField, LOG_N_LANES};
@@ -103,14 +101,14 @@ mod tests {
         if log_n_instances < LOG_N_LANES {
             let n_instances = 1 << log_n_instances;
             let inputs = vec![FibInput {
-                a: PackedBaseField::from_array(std::array::from_fn(|j| {
+                a: PackedBaseField::from_array(core::array::from_fn(|j| {
                     if j < n_instances {
                         BaseField::one()
                     } else {
                         BaseField::zero()
                     }
                 })),
-                b: PackedBaseField::from_array(std::array::from_fn(|j| {
+                b: PackedBaseField::from_array(core::array::from_fn(|j| {
                     if j < n_instances {
                         BaseField::from_u32_unchecked((j) as u32)
                     } else {
@@ -123,11 +121,11 @@ mod tests {
         let inputs = (0..(1 << (log_n_instances - LOG_N_LANES)))
             .map(|i| FibInput {
                 a: PackedBaseField::one(),
-                b: PackedBaseField::from_array(std::array::from_fn(|j| {
+                b: PackedBaseField::from_array(core::array::from_fn(|j| {
                     BaseField::from_u32_unchecked((i * 16 + j) as u32)
                 })),
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
         generate_trace::<FIB_SEQUENCE_LENGTH>(log_n_instances, &inputs)
     }
 
@@ -139,10 +137,14 @@ mod tests {
     fn test_wide_fibonacci_constraints() {
         const LOG_N_INSTANCES: u32 = 6;
         let traces = TreeVec::new(vec![vec![], generate_test_trace(LOG_N_INSTANCES)]);
-        let trace_polys =
-            traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect_vec());
+        let trace_polys = traces.map(|trace| {
+            trace
+                .into_iter()
+                .map(|c| c.interpolate())
+                .collect::<Vec<_>>()
+        });
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             CanonicCoset::new(LOG_N_INSTANCES),
             fibonacci_constraint_evaluator::<LOG_N_INSTANCES>,
@@ -159,10 +161,14 @@ mod tests {
         // Modify the trace such that a constraint fail.
         trace[17].values.set(2, BaseField::one());
         let traces = TreeVec::new(vec![vec![], trace]);
-        let trace_polys =
-            traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect_vec());
+        let trace_polys = traces.map(|trace| {
+            trace
+                .into_iter()
+                .map(|c| c.interpolate())
+                .collect::<Vec<_>>()
+        });
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             CanonicCoset::new(LOG_N_INSTANCES),
             fibonacci_constraint_evaluator::<LOG_N_INSTANCES>,

--- a/crates/prover/src/examples/xor/gkr_lookups/accumulation.rs
+++ b/crates/prover/src/examples/xor/gkr_lookups/accumulation.rs
@@ -1,5 +1,5 @@
-use std::iter::zip;
-use std::ops::{AddAssign, Mul};
+use core::iter::zip;
+use core::ops::{AddAssign, Mul};
 
 use educe::Educe;
 use num_traits::One;
@@ -11,6 +11,7 @@ use crate::core::circle::M31_CIRCLE_LOG_ORDER;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::lookups::mle::Mle;
+use crate::prelude::*;
 
 pub const MIN_LOG_BLOWUP_FACTOR: u32 = 1;
 
@@ -136,7 +137,7 @@ impl DynMle<SimdBackend> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::repeat;
+    use core::iter::repeat;
 
     use num_traits::Zero;
 

--- a/crates/prover/src/examples/xor/gkr_lookups/mle_eval.rs
+++ b/crates/prover/src/examples/xor/gkr_lookups/mle_eval.rs
@@ -2,9 +2,9 @@
 // TODO(andrew): Remove in downstream PR.
 #![allow(dead_code)]
 
-use std::iter::zip;
+use core::iter::zip;
 
-use itertools::{chain, zip_eq, Itertools};
+use itertools::{chain, zip_eq};
 use num_traits::{One, Zero};
 use tracing::{span, Level};
 
@@ -39,6 +39,7 @@ use crate::core::poly::twiddles::TwiddleTree;
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::{bit_reverse_index, coset_index_to_circle_domain_index};
 use crate::core::ColumnVec;
+use crate::prelude::*;
 
 /// Prover component that carries out a univariate IOP for multilinear eval at point.
 ///
@@ -228,7 +229,7 @@ impl<O: MleCoeffColumnOracle> ComponentProver<SimdBackend> for MleEvalProverComp
         let log_expand = eval_domain.log_size() - trace_domain.log_size();
         let mut denom_inv = (0..1 << log_expand)
             .map(|i| coset_vanishing(trace_domain.coset(), eval_domain.at(i)).inverse())
-            .collect_vec();
+            .collect::<Vec<_>>();
         bit_reverse(&mut denom_inv);
 
         // Accumulator.
@@ -684,7 +685,7 @@ fn eval_step_selector(coset: Coset, log_step: u32, p: CirclePoint<SecureField>) 
             *p = p.double();
             Some(res.y)
         })
-        .collect_vec();
+        .collect::<Vec<_>>();
     vanish_at_log_step.reverse();
     // We only need the first `log_step` many values.
     vanish_at_log_step.truncate(log_step as usize);
@@ -730,10 +731,10 @@ fn hadamard_product(
 
 #[cfg(test)]
 mod tests {
-    use std::array;
-    use std::iter::{repeat, zip};
+    use core::array;
+    use core::iter::{repeat, zip};
 
-    use itertools::{chain, Itertools};
+    use itertools::chain;
     use mle_coeff_column::{MleCoeffColumnComponent, MleCoeffColumnEval};
     use num_traits::{One, Zero};
     use rand::rngs::SmallRng;
@@ -745,9 +746,7 @@ mod tests {
         MleEvalVerifierComponent,
     };
     use crate::constraint_framework::preprocessed_columns::IsFirst;
-    use crate::constraint_framework::{
-        assert_constraints_on_polys, EvalAtRow, TraceLocationAllocator,
-    };
+    use crate::constraint_framework::{assert_constraints, EvalAtRow, TraceLocationAllocator};
     use crate::core::air::{Component, ComponentProver, Components};
     use crate::core::backend::cpu::bit_reverse;
     use crate::core::backend::simd::prefix_sum::inclusive_prefix_sum;
@@ -959,7 +958,7 @@ mod tests {
         let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
         let trace_domain = CanonicCoset::new(log_size);
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             trace_domain,
             |mut eval| {
@@ -1001,7 +1000,7 @@ mod tests {
         let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
         let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             trace_domain,
             |mut eval| {
@@ -1038,7 +1037,7 @@ mod tests {
         let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
         let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             trace_domain,
             |mut eval| {
@@ -1075,7 +1074,7 @@ mod tests {
         let trace_polys = traces.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
         let trace_domain = CanonicCoset::new(N_VARIABLES as u32);
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             trace_domain,
             |mut eval| {
@@ -1099,14 +1098,14 @@ mod tests {
     fn inclusive_prefix_sum_constraints_with_log_size_5() {
         const LOG_SIZE: u32 = 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let vals = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let vals = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect::<Vec<_>>();
         let cumulative_sum = vals.iter().sum::<SecureField>();
         let cumulative_sum_shift = cumulative_sum / BaseField::from(vals.len());
         let trace = TreeVec::new(vec![gen_prefix_sum_trace(vals)]);
         let trace_polys = trace.map(|trace| trace.into_iter().map(|c| c.interpolate()).collect());
         let trace_domain = CanonicCoset::new(LOG_SIZE);
 
-        assert_constraints_on_polys(
+        assert_constraints(
             &trace_polys,
             trace_domain,
             |mut eval| {

--- a/crates/prover/src/examples/xor/gkr_lookups/preprocessed_columns.rs
+++ b/crates/prover/src/examples/xor/gkr_lookups/preprocessed_columns.rs
@@ -7,6 +7,7 @@ use crate::core::fields::m31::BaseField;
 use crate::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use crate::core::poly::BitReversedOrder;
 use crate::core::utils::{bit_reverse_index, coset_index_to_circle_domain_index};
+use crate::prelude::*;
 
 /// A column with `1` at every `2^log_step` positions, `0` elsewhere, shifted by offset.
 #[derive(Debug)]

--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(incomplete_features)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     all(target_arch = "x86_64", target_feature = "avx512f"),
     feature(stdarch_x86_avx512)
@@ -16,6 +17,46 @@
     slice_ptr_get,
     trait_upcasting
 )]
+
+// Re-export common alloc types and macros for no_std
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+mod prelude {
+    #[cfg(not(feature = "std"))]
+    pub use alloc::{
+        borrow::ToOwned, boxed::Box, format, string::String, string::ToString, vec, vec::Vec,
+    };
+    #[cfg(feature = "std")]
+    pub use std::{
+        borrow::ToOwned, boxed::Box, format, string::String, string::ToString, vec, vec::Vec,
+    };
+}
+
+pub mod collections {
+    #[cfg(not(feature = "std"))]
+    pub use alloc::collections::btree_map;
+    #[cfg(not(feature = "std"))]
+    pub use alloc::collections::btree_map::BTreeMap;
+    #[cfg(not(feature = "std"))]
+    pub use alloc::collections::btree_set;
+    #[cfg(not(feature = "std"))]
+    pub use alloc::collections::btree_set::BTreeSet;
+    #[cfg(feature = "std")]
+    pub use std::collections::*;
+
+    #[cfg(not(feature = "std"))]
+    pub use hashbrown::hash_map;
+    #[cfg(not(feature = "std"))]
+    pub use hashbrown::hash_map::HashMap;
+    #[cfg(not(feature = "std"))]
+    pub use hashbrown::hash_set;
+    #[cfg(not(feature = "std"))]
+    pub use hashbrown::hash_set::HashSet;
+}
+
+pub use prelude::*;
+
 pub mod constraint_framework;
 pub mod core;
 pub mod examples;

--- a/crates/prover/src/math/matrix.rs
+++ b/crates/prover/src/math/matrix.rs
@@ -1,5 +1,6 @@
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::ExtensionOf;
+use crate::prelude::*;
 
 pub trait SquareMatrix<F: ExtensionOf<BaseField> + Copy, const N: usize> {
     fn get_at(&self, i: usize, j: usize) -> F;


### PR DESCRIPTION
Preview of no-std support for Stwo.

This is a preliminary attempt at making stwo no-std compatible in order to allow proof generation and verification within polkadot pallets, embedded systems, and arbtirary (zk-)VMs.

Work in progress.