### PR TITLE
Remove TODO as issue as been solved

### DIFF
--- a/crates/prover/src/constraint_framework/component.rs
+++ b/crates/prover/src/constraint_framework/component.rs
@@ -80,7 +80,7 @@ impl TraceLocationAllocator {
     }
 
     /// Create a new `TraceLocationAllocator` with fixed preprocessed columns setup.
-    pub fn new_with_preproccessed_columns(preprocessed_columns: &[PreProcessedColumnId]) -> Self {
+    pub fn new_with_preprocessed_columns(preprocessed_columns: &[PreProcessedColumnId]) -> Self {
         assert!(
             preprocessed_columns.iter().all_unique(),
             "Duplicate preprocessed columns are not allowed!"

--- a/crates/prover/src/core/circle.rs
+++ b/crates/prover/src/core/circle.rs
@@ -126,8 +126,7 @@ impl<F: Zero + Add<Output = F> + FieldExpOps + Sub<Output = F> + Neg<Output = F>
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        // TODO(ShaharS): Revert once Rust solves compiler [issue](https://github.com/rust-lang/rust/issues/134457).
-        let x = self.x.clone() * rhs.x.clone() + (-self.y.clone() * rhs.y.clone());
+        let x = self.x.clone() * rhs.x.clone() - self.y.clone() * rhs.y.clone();
         let y = self.x * rhs.y + self.y * rhs.x;
         Self { x, y }
     }

--- a/crates/prover/src/examples/blake/air.rs
+++ b/crates/prover/src/examples/blake/air.rs
@@ -193,7 +193,7 @@ impl BlakeComponents {
             .map(|l| IsFirst::new(log_size + l).id())
             .collect_vec();
 
-        let tree_span_provider = &mut TraceLocationAllocator::new_with_preproccessed_columns(
+        let tree_span_provider = &mut TraceLocationAllocator::new_with_preprocessed_columns(
             &chain!(
                 [scheduler_is_first_column],
                 blake_round_is_first_columns_iter,


### PR DESCRIPTION
I was reading through the codebase and noticed that the mentioned issue had been closed in decembre already.

Removed the patch and looks ok, see https://github.com/rust-lang/rust/issues/134457