### PR TITLE
Remove the IsFirst columns in all components used in Blake example

### DIFF
--- a/crates/prover/src/examples/blake/air.rs
+++ b/crates/prover/src/examples/blake/air.rs
@@ -9,7 +9,7 @@ use super::preprocessed_columns::XorTable;
 use super::round::{blake_round_info, BlakeRoundComponent, BlakeRoundEval};
 use super::scheduler::{BlakeSchedulerComponent, BlakeSchedulerEval};
 use super::xor_table::{xor12, xor4, xor7, xor8, xor9};
-use crate::constraint_framework::preprocessed_columns::{IsFirst, PreProcessedColumnId};
+use crate::constraint_framework::preprocessed_columns::PreProcessedColumnId;
 use crate::constraint_framework::{TraceLocationAllocator, PREPROCESSED_TRACE_IDX};
 use crate::core::air::{Component, ComponentProver};
 use crate::core::backend::simd::m31::LOG_N_LANES;
@@ -27,53 +27,43 @@ use crate::examples::blake::{
     round, xor_table, BlakeXorElements, XorAccums, N_ROUNDS, ROUND_LOG_SPLIT,
 };
 
-fn preprocessed_xor_columns() -> [PreProcessedColumnId; 20] {
+fn preprocessed_xor_columns() -> [PreProcessedColumnId; 15] {
     [
         XorTable::new(12, 4, 0).id(),
         XorTable::new(12, 4, 1).id(),
         XorTable::new(12, 4, 2).id(),
-        IsFirst::new(XorTable::new(12, 4, 0).column_bits()).id(),
         XorTable::new(9, 2, 0).id(),
         XorTable::new(9, 2, 1).id(),
         XorTable::new(9, 2, 2).id(),
-        IsFirst::new(XorTable::new(9, 2, 0).column_bits()).id(),
         XorTable::new(8, 2, 0).id(),
         XorTable::new(8, 2, 1).id(),
         XorTable::new(8, 2, 2).id(),
-        IsFirst::new(XorTable::new(8, 2, 0).column_bits()).id(),
         XorTable::new(7, 2, 0).id(),
         XorTable::new(7, 2, 1).id(),
         XorTable::new(7, 2, 2).id(),
-        IsFirst::new(XorTable::new(7, 2, 0).column_bits()).id(),
         XorTable::new(4, 0, 0).id(),
         XorTable::new(4, 0, 1).id(),
         XorTable::new(4, 0, 2).id(),
-        IsFirst::new(XorTable::new(4, 0, 0).column_bits()).id(),
     ]
 }
 
-const fn preprocessed_xor_columns_log_sizes() -> [u32; 20] {
+const fn preprocessed_xor_columns_log_sizes() -> [u32; 15] {
     [
         XorTable::new(12, 4, 0).column_bits(),
         XorTable::new(12, 4, 1).column_bits(),
         XorTable::new(12, 4, 2).column_bits(),
-        XorTable::new(12, 4, 0).column_bits(),
         XorTable::new(9, 2, 0).column_bits(),
         XorTable::new(9, 2, 1).column_bits(),
         XorTable::new(9, 2, 2).column_bits(),
-        XorTable::new(9, 2, 0).column_bits(),
         XorTable::new(8, 2, 0).column_bits(),
         XorTable::new(8, 2, 1).column_bits(),
         XorTable::new(8, 2, 2).column_bits(),
-        XorTable::new(8, 2, 0).column_bits(),
         XorTable::new(7, 2, 0).column_bits(),
         XorTable::new(7, 2, 1).column_bits(),
         XorTable::new(7, 2, 2).column_bits(),
-        XorTable::new(7, 2, 0).column_bits(),
         XorTable::new(4, 0, 0).column_bits(),
         XorTable::new(4, 0, 1).column_bits(),
         XorTable::new(4, 0, 2).column_bits(),
-        XorTable::new(4, 0, 0).column_bits(),
     ]
 }
 
@@ -105,19 +95,7 @@ impl BlakeStatement0 {
         sizes.push(xor_table::xor4::trace_sizes::<4, 0>());
 
         let mut log_sizes = TreeVec::concat_cols(sizes.into_iter());
-
-        let log_size = self.log_size;
-
-        let scheduler_is_first_column_log_size = log_size;
-        let blake_round_is_first_column_log_sizes = ROUND_LOG_SPLIT.iter().map(|l| log_size + l);
-
-        log_sizes[PREPROCESSED_TRACE_IDX] = chain!(
-            [scheduler_is_first_column_log_size],
-            blake_round_is_first_column_log_sizes,
-            preprocessed_xor_columns_log_sizes(),
-        )
-        .collect_vec();
-
+        log_sizes[PREPROCESSED_TRACE_IDX] = preprocessed_xor_columns_log_sizes().to_vec();
         log_sizes
     }
     fn mix_into(&self, channel: &mut impl Channel) {
@@ -185,21 +163,8 @@ pub struct BlakeComponents {
 }
 impl BlakeComponents {
     fn new(stmt0: &BlakeStatement0, all_elements: &AllElements, stmt1: &BlakeStatement1) -> Self {
-        let log_size = stmt0.log_size;
-
-        let scheduler_is_first_column = IsFirst::new(log_size).id();
-        let blake_round_is_first_columns_iter: Vec<PreProcessedColumnId> = ROUND_LOG_SPLIT
-            .iter()
-            .map(|l| IsFirst::new(log_size + l).id())
-            .collect_vec();
-
         let tree_span_provider = &mut TraceLocationAllocator::new_with_preproccessed_columns(
-            &chain!(
-                [scheduler_is_first_column],
-                blake_round_is_first_columns_iter,
-                preprocessed_xor_columns(),
-            )
-            .collect_vec()[..],
+            &preprocessed_xor_columns(),
         );
 
         Self {
@@ -346,10 +311,6 @@ where
     let mut tree_builder = commitment_scheme.tree_builder();
     tree_builder.extend_evals(
         chain![
-            vec![IsFirst::new(log_size).gen_column_simd()],
-            ROUND_LOG_SPLIT
-                .iter()
-                .map(|l| IsFirst::new(log_size + l).gen_column_simd()),
             XorTable::new(12, 4, 0).generate_constant_trace(),
             XorTable::new(9, 2, 0).generate_constant_trace(),
             XorTable::new(8, 2, 0).generate_constant_trace(),

--- a/crates/prover/src/examples/blake/preprocessed_columns.rs
+++ b/crates/prover/src/examples/blake/preprocessed_columns.rs
@@ -1,6 +1,6 @@
 use tracing::{span, Level};
 
-use crate::constraint_framework::preprocessed_columns::{IsFirst, PreProcessedColumnId};
+use crate::constraint_framework::preprocessed_columns::PreProcessedColumnId;
 use crate::core::backend::simd::column::BaseColumn;
 use crate::core::backend::simd::SimdBackend;
 use crate::core::fields::m31::BaseField;
@@ -70,13 +70,11 @@ impl XorTable {
             })
             .collect();
 
-        let mut constant_trace = [a_col, b_col, c_col]
+        let constant_trace = [a_col, b_col, c_col]
             .map(|x| {
                 CircleEvaluation::new(CanonicCoset::new(self.column_bits()).circle_domain(), x)
             })
             .to_vec();
-        // TODO!(ShaharS): Remove this line.
-        constant_trace.push(IsFirst::new(self.column_bits()).gen_column_simd());
         constant_trace
     }
 }

--- a/crates/prover/src/examples/blake/round/mod.rs
+++ b/crates/prover/src/examples/blake/round/mod.rs
@@ -56,7 +56,6 @@ mod tests {
 
     use itertools::Itertools;
 
-    use crate::constraint_framework::preprocessed_columns::IsFirst;
     use crate::constraint_framework::FrameworkEval;
     use crate::core::poly::circle::CanonicCoset;
     use crate::examples::blake::round::r#gen::{
@@ -92,11 +91,7 @@ mod tests {
             &round_lookup_elements,
         );
 
-        let trace = TreeVec::new(vec![
-            vec![IsFirst::new(LOG_SIZE).gen_column_simd()],
-            trace,
-            interaction_trace,
-        ]);
+        let trace = TreeVec::new(vec![vec![], trace, interaction_trace]);
         let trace_polys = trace.map_cols(|c| c.interpolate());
 
         let component = BlakeRoundEval {

--- a/crates/prover/src/examples/blake/scheduler/mod.rs
+++ b/crates/prover/src/examples/blake/scheduler/mod.rs
@@ -57,7 +57,6 @@ mod tests {
 
     use itertools::Itertools;
 
-    use crate::constraint_framework::preprocessed_columns::IsFirst;
     use crate::constraint_framework::FrameworkEval;
     use crate::core::backend::Column;
     use crate::examples::blake::round::RoundElements;
@@ -90,7 +89,7 @@ mod tests {
         );
 
         let trace = TreeVec::new(vec![
-            vec![IsFirst::new(LOG_SIZE).gen_column_simd().values.to_cpu()],
+            vec![],
             trace.into_iter().map(|x| x.values.to_cpu()).collect(),
             interaction_trace
                 .into_iter()

--- a/crates/prover/src/examples/blake/xor_table/mod.rs
+++ b/crates/prover/src/examples/blake/xor_table/mod.rs
@@ -21,7 +21,6 @@ use tracing::{span, Level};
 
 use super::preprocessed_columns::XorTable;
 use crate::constraint_framework::logup::{LogupAtRow, LogupTraceGenerator};
-use crate::constraint_framework::preprocessed_columns::IsFirst;
 use crate::constraint_framework::{
     relation, EvalAtRow, FrameworkComponent, FrameworkEval, InfoEvaluator, Relation, RelationEntry,
     INTERACTION_TRACE_IDX, PREPROCESSED_TRACE_IDX,


### PR DESCRIPTION
Currently, the Blake example can run with LOG_N_INSTANCES=6 but not other parameters, because the Scheduler, Round, and XOR table components may want to use IsFirst columns of the same size, but the framework prevents duplicated preprocessed columns, which consistently happens when LOG_N_INSTANCES is larger than 6.

This PR changes the existing example to reflect the recent changes to logUp sum by removing the use of IsFirst columns altogether across all components. Note that such removal is safe since these columns have already been "unused" by the proof system. 