### PR TITLE
Reduce Expression memory usage with rc

### DIFF
--- a/crates/constraint-framework/src/expr/degree.rs
+++ b/crates/constraint-framework/src/expr/degree.rs
@@ -57,7 +57,7 @@ impl BaseExpr {
             BaseExpr::Mul(a, b) => a.degree_bound(named_exprs) + b.degree_bound(named_exprs),
             BaseExpr::Neg(a) => a.degree_bound(named_exprs),
             // TODO(alont): Consider handling this in the type system.
-            BaseExpr::Inv(expr) => match *expr.clone() {
+            BaseExpr::Inv(expr) => match expr.as_ref() {
                 BaseExpr::Param(name) if named_exprs.degree_bound(name.clone()).is_zero() => 0,
                 BaseExpr::Const(_) => 0,
                 _ => panic!("Cannot compute the degree of an inverse"),

--- a/crates/constraint-framework/src/expr/degree.rs
+++ b/crates/constraint-framework/src/expr/degree.rs
@@ -7,7 +7,7 @@
 ///        simplification.
 ///     2. If expressions p and q cancel out under some operation, this will not be accounted
 ///        for, so that (x^2 + 1) - (x^2 + x) will return degree 2.
-use std::{collections::HashMap, ops::Deref};
+use std::collections::HashMap;
 
 use num_traits::Zero;
 
@@ -57,7 +57,7 @@ impl BaseExpr {
             BaseExpr::Mul(a, b) => a.degree_bound(named_exprs) + b.degree_bound(named_exprs),
             BaseExpr::Neg(a) => a.degree_bound(named_exprs),
             // TODO(alont): Consider handling this in the type system.
-            BaseExpr::Inv(expr) => match expr.deref() {
+            BaseExpr::Inv(expr) => match expr.as_ref() {
                 BaseExpr::Param(name) if named_exprs.degree_bound(name.clone()).is_zero() => 0,
                 BaseExpr::Const(_) => 0,
                 _ => panic!("Cannot compute the degree of an inverse"),

--- a/crates/constraint-framework/src/expr/degree.rs
+++ b/crates/constraint-framework/src/expr/degree.rs
@@ -7,7 +7,7 @@
 ///        simplification.
 ///     2. If expressions p and q cancel out under some operation, this will not be accounted
 ///        for, so that (x^2 + 1) - (x^2 + x) will return degree 2.
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Deref};
 
 use num_traits::Zero;
 
@@ -57,7 +57,7 @@ impl BaseExpr {
             BaseExpr::Mul(a, b) => a.degree_bound(named_exprs) + b.degree_bound(named_exprs),
             BaseExpr::Neg(a) => a.degree_bound(named_exprs),
             // TODO(alont): Consider handling this in the type system.
-            BaseExpr::Inv(expr) => match expr.as_ref() {
+            BaseExpr::Inv(expr) => match expr.deref() {
                 BaseExpr::Param(name) if named_exprs.degree_bound(name.clone()).is_zero() => 0,
                 BaseExpr::Const(_) => 0,
                 _ => panic!("Cannot compute the degree of an inverse"),

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use num_traits::Zero;
 use stwo::core::Fraction;
@@ -33,7 +32,7 @@ impl FormalLogupAtRow {
             is_finalized: true,
             is_first: BaseExpr::zero(),
             cumsum_shift: ExtExpr::Param(claimed_sum_name)
-                * BaseExpr::Inv(Rc::new(BaseExpr::Param(column_size_name))),
+                * BaseExpr::Inv(BaseExpr::Param(column_size_name).into()),
         }
     }
 }
@@ -228,10 +227,10 @@ impl EvalAtRow for ExprEvaluator {
 
     fn combine_ef(values: [Self::F; 4]) -> Self::EF {
         ExtExpr::SecureCol([
-            Rc::new(values[0].clone()),
-            Rc::new(values[1].clone()),
-            Rc::new(values[2].clone()),
-            Rc::new(values[3].clone()),
+            values[0].clone().into(),
+            values[1].clone().into(),
+            values[2].clone().into(),
+            values[3].clone().into(),
         ])
     }
 

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -33,7 +33,7 @@ impl FormalLogupAtRow {
             is_finalized: true,
             is_first: BaseExpr::zero(),
             cumsum_shift: ExtExpr::Param(claimed_sum_name)
-                * BaseExpr::Inv(BaseExpr::Param(column_size_name).into()),
+                * BaseExpr::Inv(Rc::new(BaseExpr::Param(column_size_name))),
         }
     }
 }

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -292,10 +292,12 @@ impl EvalAtRow for ExprEvaluator {
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use num_traits::One;
     use stwo::core::fields::FieldExpOps;
 
-    use crate::expr::{ExprEvaluator, ExtExpr};
+    use crate::expr::{BaseExpr, BaseExprInner, ExprEvaluator, ExtExpr};
     use crate::{relation, EvalAtRow, FrameworkEval, RelationEntry};
 
     #[test]
@@ -350,19 +352,33 @@ mod tests {
     }
 
     #[test]
-    fn hash_stress_rounds_100_passes() {
-        let rounds = 5;
+    fn base_expr_shares_subexpressions() {
+        // (x)               leaf
+        // (x + x)           shared once
+        // (x + x) * (x + x) shared twice
+        let leaf = BaseExprInner(Rc::new(BaseExpr::Param("x".into())));
+        let shared = BaseExprInner(Rc::new(BaseExpr::Add(leaf.clone(), leaf.clone())));
+        let expr = BaseExprInner(Rc::new(BaseExpr::Mul(shared.clone(), shared.clone())));
+
+        // leaf: in scope 1 + in Add left 1 + in Add right 1 = 3
+        assert_eq!(Rc::strong_count(&leaf.0), 3);
+
+        // shared: variable 1 + in Mul left 1 + in Mul right 1 = 3
+        assert_eq!(Rc::strong_count(&shared.0), 3);
+
+        // expr itself should have exactly 1 owner here
+        assert_eq!(Rc::strong_count(&expr.0), 1);
+    }
+
+    #[test]
+    fn hash_stress_rounds_1000_passes() {
+        let rounds = 1000;
         let stress = HashStressEval { rounds };
         let eval = stress.evaluate(ExprEvaluator::new());
 
-        // print variables
-        // println!("{:?}", eval.format_constraints());
-        // print number of constraints
-        println!("constraints: {}", eval.constraints.len());
-        // print first 10 constraints
-        for (i, c) in eval.constraints.iter().enumerate() {
-            println!("constraint {}: {}", i, c.format_expr());
-        }
+        let _ = eval.random_assignment();
+
+        assert_eq!(eval.constraints.len(), rounds + 1);
     }
 
     #[test]
@@ -476,23 +492,24 @@ mod tests {
         fn max_constraint_log_degree_bound(&self) -> u32 {
             0
         }
+
         fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
             let mut acc = eval.next_trace_mask();
             let initial_acc = acc.clone();
 
-            for _ in 0..self.rounds {
-                let l = eval.next_trace_mask();
-                let r = eval.next_trace_mask();
+            for _round in 0..self.rounds {
+                let w = eval.next_trace_mask();
 
-                let s1 = eval.add_intermediate(acc.clone() + l.clone()); // (acc + l)
-                let s2 = eval.add_intermediate(r.clone() + E::F::one()); // (r + 1)
+                // (acc + w)
+                let acc_plus_w = eval.add_intermediate(acc.clone() + w.clone());
 
-                let round_out = eval.add_intermediate(s1 * s2); // (acc + l)*(r + 1)
+                // new_acc = (acc + w)^2
+                let new_acc = eval.add_intermediate(acc_plus_w.clone() * acc_plus_w);
 
-                let m = eval.next_trace_mask();
-                eval.add_constraint(round_out.clone() - m.clone()); // round_out == m
+                let next_acc = eval.next_trace_mask();
+                eval.add_constraint(new_acc - next_acc.clone());
 
-                acc = m;
+                acc = next_acc;
             }
 
             eval.add_to_relation(RelationEntry::new(

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use num_traits::Zero;
 use stwo::core::Fraction;
@@ -227,10 +228,10 @@ impl EvalAtRow for ExprEvaluator {
 
     fn combine_ef(values: [Self::F; 4]) -> Self::EF {
         ExtExpr::SecureCol([
-            values[0].clone().into(),
-            values[1].clone().into(),
-            values[2].clone().into(),
-            values[3].clone().into(),
+            Rc::new(values[0].clone()),
+            Rc::new(values[1].clone()),
+            Rc::new(values[2].clone()),
+            Rc::new(values[3].clone()),
         ])
     }
 

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use num_traits::Zero;
 use stwo::core::Fraction;
@@ -32,7 +33,7 @@ impl FormalLogupAtRow {
             is_finalized: true,
             is_first: BaseExpr::zero(),
             cumsum_shift: ExtExpr::Param(claimed_sum_name)
-                * BaseExpr::Inv(Box::new(BaseExpr::Param(column_size_name))),
+                * BaseExpr::Inv(Rc::new(BaseExpr::Param(column_size_name))),
         }
     }
 }
@@ -227,10 +228,10 @@ impl EvalAtRow for ExprEvaluator {
 
     fn combine_ef(values: [Self::F; 4]) -> Self::EF {
         ExtExpr::SecureCol([
-            Box::new(values[0].clone()),
-            Box::new(values[1].clone()),
-            Box::new(values[2].clone()),
-            Box::new(values[3].clone()),
+            Rc::new(values[0].clone()),
+            Rc::new(values[1].clone()),
+            Rc::new(values[2].clone()),
+            Rc::new(values[3].clone()),
         ])
     }
 

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -297,7 +297,7 @@ mod tests {
     use num_traits::One;
     use stwo::core::fields::FieldExpOps;
 
-    use crate::expr::{BaseExpr, BaseExprInner, ExprEvaluator, ExtExpr};
+    use crate::expr::{BaseExpr, ExprEvaluator, ExtExpr};
     use crate::{relation, EvalAtRow, FrameworkEval, RelationEntry};
 
     #[test]
@@ -356,18 +356,18 @@ mod tests {
         // (x)               leaf
         // (x + x)           shared once
         // (x + x) * (x + x) shared twice
-        let leaf = BaseExprInner(Rc::new(BaseExpr::Param("x".into())));
-        let shared = BaseExprInner(Rc::new(BaseExpr::Add(leaf.clone(), leaf.clone())));
-        let expr = BaseExprInner(Rc::new(BaseExpr::Mul(shared.clone(), shared.clone())));
+        let leaf = Rc::new(BaseExpr::Param("x".into()));
+        let shared = Rc::new(BaseExpr::Add(leaf.clone(), leaf.clone()));
+        let expr = Rc::new(BaseExpr::Mul(shared.clone(), shared.clone()));
 
         // leaf: in scope 1 + in Add left 1 + in Add right 1 = 3
-        assert_eq!(Rc::strong_count(&leaf.0), 3);
+        assert_eq!(Rc::strong_count(&leaf), 3);
 
         // shared: variable 1 + in Mul left 1 + in Mul right 1 = 3
-        assert_eq!(Rc::strong_count(&shared.0), 3);
+        assert_eq!(Rc::strong_count(&shared), 3);
 
         // expr itself should have exactly 1 owner here
-        assert_eq!(Rc::strong_count(&expr.0), 1);
+        assert_eq!(Rc::strong_count(&expr), 1);
     }
 
     #[test]

--- a/crates/constraint-framework/src/expr/evaluator.rs
+++ b/crates/constraint-framework/src/expr/evaluator.rs
@@ -350,6 +350,22 @@ mod tests {
     }
 
     #[test]
+    fn hash_stress_rounds_100_passes() {
+        let rounds = 5;
+        let stress = HashStressEval { rounds };
+        let eval = stress.evaluate(ExprEvaluator::new());
+
+        // print variables
+        // println!("{:?}", eval.format_constraints());
+        // print number of constraints
+        println!("constraints: {}", eval.constraints.len());
+        // print first 10 constraints
+        for (i, c) in eval.constraints.iter().enumerate() {
+            println!("constraint {}: {}", i, c.format_expr());
+        }
+    }
+
+    #[test]
     #[should_panic]
     fn test_constraint_regression_fails() {
         let test_struct = TestStruct {};
@@ -446,6 +462,51 @@ mod tests {
                 &[x0, x1, x2],
             ));
             eval.finalize_logup();
+            eval
+        }
+    }
+
+    pub struct HashStressEval {
+        pub rounds: usize,
+    }
+    impl FrameworkEval for HashStressEval {
+        fn log_size(&self) -> u32 {
+            0
+        }
+        fn max_constraint_log_degree_bound(&self) -> u32 {
+            0
+        }
+        fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
+            let mut acc = eval.next_trace_mask();
+            let initial_acc = acc.clone();
+
+            for _ in 0..self.rounds {
+                let l = eval.next_trace_mask();
+                let r = eval.next_trace_mask();
+
+                let s1 = eval.add_intermediate(acc.clone() + l.clone()); // (acc + l)
+                let s2 = eval.add_intermediate(r.clone() + E::F::one()); // (r + 1)
+
+                let round_out = eval.add_intermediate(s1 * s2); // (acc + l)*(r + 1)
+
+                let m = eval.next_trace_mask();
+                eval.add_constraint(round_out.clone() - m.clone()); // round_out == m
+
+                acc = m;
+            }
+
+            eval.add_to_relation(RelationEntry::new(
+                &TestRelation::dummy(),
+                E::EF::one(),
+                &[initial_acc],
+            ));
+            eval.add_to_relation(RelationEntry::new(
+                &TestRelation::dummy(),
+                -E::EF::one(),
+                &[acc],
+            ));
+
+            eval.finalize_logup_in_pairs();
             eval
         }
     }

--- a/crates/constraint-framework/src/expr/format.rs
+++ b/crates/constraint-framework/src/expr/format.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use num_traits::Zero;
 
 use super::{BaseExpr, ColumnExpr, ExtExpr};
@@ -37,9 +39,9 @@ impl ExtExpr {
             ExtExpr::SecureCol([a, b, c, d]) => {
                 // If the expression's non-base components are all constant zeroes, return the base
                 // field representation of its first part.
-                if *b.as_ref() == BaseExpr::zero()
-                    && *c.as_ref() == BaseExpr::zero()
-                    && *d.as_ref() == BaseExpr::zero()
+                if matches!(*b.deref(), BaseExpr::Const(c) if c.is_zero())
+                    && matches!(*c.deref(), BaseExpr::Const(c) if c.is_zero())
+                    && matches!(*d.deref(), BaseExpr::Const(c) if c.is_zero())
                 {
                     a.format_expr()
                 } else {

--- a/crates/constraint-framework/src/expr/format.rs
+++ b/crates/constraint-framework/src/expr/format.rs
@@ -37,7 +37,10 @@ impl ExtExpr {
             ExtExpr::SecureCol([a, b, c, d]) => {
                 // If the expression's non-base components are all constant zeroes, return the base
                 // field representation of its first part.
-                if **b == BaseExpr::zero() && **c == BaseExpr::zero() && **d == BaseExpr::zero() {
+                if *b.as_ref() == BaseExpr::zero()
+                    && *c.as_ref() == BaseExpr::zero()
+                    && *d.as_ref() == BaseExpr::zero()
+                {
                     a.format_expr()
                 } else {
                     format!(

--- a/crates/constraint-framework/src/expr/format.rs
+++ b/crates/constraint-framework/src/expr/format.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use num_traits::Zero;
 
 use super::{BaseExpr, ColumnExpr, ExtExpr};
@@ -39,9 +37,9 @@ impl ExtExpr {
             ExtExpr::SecureCol([a, b, c, d]) => {
                 // If the expression's non-base components are all constant zeroes, return the base
                 // field representation of its first part.
-                if matches!(*b.deref(), BaseExpr::Const(c) if c.is_zero())
-                    && matches!(*c.deref(), BaseExpr::Const(c) if c.is_zero())
-                    && matches!(*d.deref(), BaseExpr::Const(c) if c.is_zero())
+                if matches!(*b.as_ref(), BaseExpr::Const(c) if c.is_zero())
+                    && matches!(*c.as_ref(), BaseExpr::Const(c) if c.is_zero())
+                    && matches!(*d.as_ref(), BaseExpr::Const(c) if c.is_zero())
                 {
                     a.format_expr()
                 } else {

--- a/crates/constraint-framework/src/expr/mod.rs
+++ b/crates/constraint-framework/src/expr/mod.rs
@@ -33,15 +33,6 @@ impl From<(usize, usize, isize)> for ColumnExpr {
     }
 }
 
-/// An expression representing a base field value. Can be either:
-///     * A column indexed by a `ColumnExpr`.
-///     * A base field constant.
-///     * A formal parameter to the AIR.
-///     * A sum, difference, or product of two base field expressions.
-///     * A negation or inverse of a base field expression.
-///
-/// This type is meant to be used as an F associated type for EvalAtRow and interacts with
-/// `ExtExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
 pub struct BaseExprInner(Rc<BaseExpr>);
 
@@ -52,6 +43,15 @@ impl Deref for BaseExprInner {
     }
 }
 
+/// An expression representing a base field value. Can be either:
+///     * A column indexed by a `ColumnExpr`.
+///     * A base field constant.
+///     * A formal parameter to the AIR.
+///     * A sum, difference, or product of two base field expressions.
+///     * A negation or inverse of a base field expression.
+///
+/// This type is meant to be used as an F associated type for EvalAtRow and interacts with
+/// `ExtExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
 pub enum BaseExpr {
     Col(ColumnExpr),
@@ -65,15 +65,6 @@ pub enum BaseExpr {
     Inv(BaseExprInner),
 }
 
-/// An expression representing a secure field value. Can be either:
-///     * A secure column constructed from 4 base field expressions.
-///     * A secure field constant.
-///     * A formal parameter to the AIR.
-///     * A sum, difference, or product of two secure field expressions.
-///     * A negation of a secure field expression.
-///
-/// This type is meant to be used as an EF associated type for EvalAtRow and interacts with
-/// `BaseExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExtExprInner(Rc<ExtExpr>);
 
@@ -84,6 +75,15 @@ impl Deref for ExtExprInner {
     }
 }
 
+/// An expression representing a secure field value. Can be either:
+///     * A secure column constructed from 4 base field expressions.
+///     * A secure field constant.
+///     * A formal parameter to the AIR.
+///     * A sum, difference, or product of two secure field expressions.
+///     * A negation of a secure field expression.
+///
+/// This type is meant to be used as an EF associated type for EvalAtRow and interacts with
+/// `BaseExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExtExpr {
     /// An atomic secure column constructed from 4 expressions.

--- a/crates/constraint-framework/src/expr/mod.rs
+++ b/crates/constraint-framework/src/expr/mod.rs
@@ -90,10 +90,10 @@ impl From<BaseField> for BaseExpr {
 impl From<BaseField> for ExtExpr {
     fn from(val: BaseField) -> Self {
         ExtExpr::SecureCol([
-            BaseExpr::from(val).into(),
-            BaseExpr::zero().into(),
-            BaseExpr::zero().into(),
-            BaseExpr::zero().into(),
+            Rc::new(BaseExpr::from(val)),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
         ])
     }
 }
@@ -101,10 +101,10 @@ impl From<BaseField> for ExtExpr {
 impl From<SecureField> for ExtExpr {
     fn from(QM31(CM31(a, b), CM31(c, d)): SecureField) -> Self {
         ExtExpr::SecureCol([
-            BaseExpr::from(a).into(),
-            BaseExpr::from(b).into(),
-            BaseExpr::from(c).into(),
-            BaseExpr::from(d).into(),
+            Rc::new(BaseExpr::from(a)),
+            Rc::new(BaseExpr::from(b)),
+            Rc::new(BaseExpr::from(c)),
+            Rc::new(BaseExpr::from(d)),
         ])
     }
 }
@@ -112,10 +112,10 @@ impl From<SecureField> for ExtExpr {
 impl From<BaseExpr> for ExtExpr {
     fn from(expr: BaseExpr) -> Self {
         ExtExpr::SecureCol([
-            expr.clone().into(),
-            BaseExpr::zero().into(),
-            BaseExpr::zero().into(),
-            BaseExpr::zero().into(),
+            Rc::new(expr.clone()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
         ])
     }
 }
@@ -123,21 +123,21 @@ impl From<BaseExpr> for ExtExpr {
 impl Add for BaseExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        BaseExpr::Add(self.into(), rhs.into()).into()
+        BaseExpr::Add(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Sub for BaseExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        BaseExpr::Sub(self.into(), rhs.into()).into()
+        BaseExpr::Sub(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Mul for BaseExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        BaseExpr::Mul(self.into(), rhs.into()).into()
+        BaseExpr::Mul(Rc::new(self), Rc::new(rhs))
     }
 }
 
@@ -156,28 +156,28 @@ impl MulAssign for BaseExpr {
 impl Neg for BaseExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        BaseExpr::Neg(self.into()).into()
+        BaseExpr::Neg(Rc::new(self))
     }
 }
 
 impl Add for ExtExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        ExtExpr::Add(self.into(), rhs.into()).into()
+        ExtExpr::Add(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Sub for ExtExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        ExtExpr::Sub(self.into(), rhs.into()).into()
+        ExtExpr::Sub(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Mul for ExtExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        ExtExpr::Mul(self.into(), rhs.into()).into()
+        ExtExpr::Mul(Rc::new(self), Rc::new(rhs))
     }
 }
 
@@ -196,7 +196,7 @@ impl MulAssign for ExtExpr {
 impl Neg for ExtExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        ExtExpr::Neg(self.into()).into()
+        ExtExpr::Neg(Rc::new(self))
     }
 }
 
@@ -236,7 +236,7 @@ impl One for ExtExpr {
 
 impl FieldExpOps for BaseExpr {
     fn inverse(&self) -> Self {
-        BaseExpr::Inv(self.clone().into()).into()
+        BaseExpr::Inv(Rc::new(self.clone()))
     }
 }
 

--- a/crates/constraint-framework/src/expr/mod.rs
+++ b/crates/constraint-framework/src/expr/mod.rs
@@ -5,7 +5,7 @@ pub mod format;
 pub mod simplify;
 pub mod utils;
 
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use std::ops::{Add, AddAssign, Deref, Mul, MulAssign, Neg, Sub};
 use std::rc::Rc;
 
 pub use evaluator::ExprEvaluator;
@@ -43,19 +43,26 @@ impl From<(usize, usize, isize)> for ColumnExpr {
 /// This type is meant to be used as an F associated type for EvalAtRow and interacts with
 /// `ExtExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
-pub struct BaseExpr(Rc<BaseExprInner>);
+pub struct BaseExprInner(Rc<BaseExpr>);
+
+impl Deref for BaseExprInner {
+    type Target = BaseExpr;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum BaseExprInner {
+pub enum BaseExpr {
     Col(ColumnExpr),
     Const(BaseField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(BaseExpr, BaseExpr),
-    Sub(BaseExpr, BaseExpr),
-    Mul(BaseExpr, BaseExpr),
-    Neg(BaseExpr),
-    Inv(BaseExpr),
+    Add(BaseExprInner, BaseExprInner),
+    Sub(BaseExprInner, BaseExprInner),
+    Mul(BaseExprInner, BaseExprInner),
+    Neg(BaseExprInner),
+    Inv(BaseExprInner),
 }
 
 /// An expression representing a secure field value. Can be either:
@@ -68,41 +75,57 @@ pub enum BaseExprInner {
 /// This type is meant to be used as an EF associated type for EvalAtRow and interacts with
 /// `BaseExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
+pub struct ExtExprInner(Rc<ExtExpr>);
+
+impl Deref for ExtExprInner {
+    type Target = ExtExpr;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum ExtExpr {
     /// An atomic secure column constructed from 4 expressions.
     /// Expressions on the secure column are not reduced, i.e,
     /// if `a = SecureCol(a0, a1, a2, a3)`, `b = SecureCol(b0, b1, b2, b3)` then
     /// `a + b` evaluates to `Add(a, b)` rather than
     /// `SecureCol(Add(a0, b0), Add(a1, b1), Add(a2, b2), Add(a3, b3))`
-    SecureCol([Rc<BaseExpr>; 4]),
+    SecureCol([BaseExprInner; 4]),
     Const(SecureField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(Rc<ExtExpr>, Rc<ExtExpr>),
-    Sub(Rc<ExtExpr>, Rc<ExtExpr>),
-    Mul(Rc<ExtExpr>, Rc<ExtExpr>),
-    Neg(Rc<ExtExpr>),
+    Add(ExtExprInner, ExtExprInner),
+    Sub(ExtExprInner, ExtExprInner),
+    Mul(ExtExprInner, ExtExprInner),
+    Neg(ExtExprInner),
 }
 
-impl Into<BaseExpr> for BaseExprInner {
-    fn into(self) -> BaseExpr {
-        BaseExpr(Rc::new(self))
+impl Into<BaseExprInner> for BaseExpr {
+    fn into(self) -> BaseExprInner {
+        BaseExprInner(Rc::new(self))
     }
 }
 
 impl From<BaseField> for BaseExpr {
     fn from(val: BaseField) -> Self {
-        BaseExprInner::Const(val).into()
+        BaseExpr::Const(val)
+    }
+}
+
+impl Into<ExtExprInner> for ExtExpr {
+    fn into(self) -> ExtExprInner {
+        ExtExprInner(Rc::new(self))
     }
 }
 
 impl From<BaseField> for ExtExpr {
     fn from(val: BaseField) -> Self {
         ExtExpr::SecureCol([
-            Rc::new(BaseExpr::from(val)),
-            Rc::new(BaseExpr::zero()),
-            Rc::new(BaseExpr::zero()),
-            Rc::new(BaseExpr::zero()),
+            BaseExpr::from(val).into(),
+            BaseExpr::zero().into(),
+            BaseExpr::zero().into(),
+            BaseExpr::zero().into(),
         ])
     }
 }
@@ -110,10 +133,10 @@ impl From<BaseField> for ExtExpr {
 impl From<SecureField> for ExtExpr {
     fn from(QM31(CM31(a, b), CM31(c, d)): SecureField) -> Self {
         ExtExpr::SecureCol([
-            Rc::new(BaseExpr::from(a)),
-            Rc::new(BaseExpr::from(b)),
-            Rc::new(BaseExpr::from(c)),
-            Rc::new(BaseExpr::from(d)),
+            BaseExpr::from(a).into(),
+            BaseExpr::from(b).into(),
+            BaseExpr::from(c).into(),
+            BaseExpr::from(d).into(),
         ])
     }
 }
@@ -121,10 +144,10 @@ impl From<SecureField> for ExtExpr {
 impl From<BaseExpr> for ExtExpr {
     fn from(expr: BaseExpr) -> Self {
         ExtExpr::SecureCol([
-            Rc::new(expr.clone()),
-            Rc::new(BaseExpr::zero()),
-            Rc::new(BaseExpr::zero()),
-            Rc::new(BaseExpr::zero()),
+            expr.clone().into(),
+            BaseExpr::zero().into(),
+            BaseExpr::zero().into(),
+            BaseExpr::zero().into(),
         ])
     }
 }
@@ -132,21 +155,21 @@ impl From<BaseExpr> for ExtExpr {
 impl Add for BaseExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        BaseExprInner::Add(self, rhs).into()
+        BaseExpr::Add(self.into(), rhs.into()).into()
     }
 }
 
 impl Sub for BaseExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        BaseExprInner::Sub(self, rhs).into()
+        BaseExpr::Sub(self.into(), rhs.into()).into()
     }
 }
 
 impl Mul for BaseExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        BaseExprInner::Mul(self, rhs).into()
+        BaseExpr::Mul(self.into(), rhs.into()).into()
     }
 }
 
@@ -165,28 +188,28 @@ impl MulAssign for BaseExpr {
 impl Neg for BaseExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        BaseExprInner::Neg(self).into()
+        BaseExpr::Neg(self.into()).into()
     }
 }
 
 impl Add for ExtExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        ExtExpr::Add(Rc::new(self), Rc::new(rhs))
+        ExtExpr::Add(self.into(), rhs.into()).into()
     }
 }
 
 impl Sub for ExtExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        ExtExpr::Sub(Rc::new(self), Rc::new(rhs))
+        ExtExpr::Sub(self.into(), rhs.into()).into()
     }
 }
 
 impl Mul for ExtExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        ExtExpr::Mul(Rc::new(self), Rc::new(rhs))
+        ExtExpr::Mul(self.into(), rhs.into()).into()
     }
 }
 
@@ -205,7 +228,7 @@ impl MulAssign for ExtExpr {
 impl Neg for ExtExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        ExtExpr::Neg(Rc::new(self))
+        ExtExpr::Neg(self.into()).into()
     }
 }
 
@@ -245,7 +268,7 @@ impl One for ExtExpr {
 
 impl FieldExpOps for BaseExpr {
     fn inverse(&self) -> Self {
-        BaseExprInner::Inv(self.clone()).into()
+        BaseExpr::Inv(self.clone().into()).into()
     }
 }
 

--- a/crates/constraint-framework/src/expr/mod.rs
+++ b/crates/constraint-framework/src/expr/mod.rs
@@ -6,6 +6,7 @@ pub mod simplify;
 pub mod utils;
 
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use std::rc::Rc;
 
 pub use evaluator::ExprEvaluator;
 use num_traits::{One, Zero};
@@ -42,16 +43,19 @@ impl From<(usize, usize, isize)> for ColumnExpr {
 /// This type is meant to be used as an F associated type for EvalAtRow and interacts with
 /// `ExtExpr`, `BaseField` and `SecureField` as expected.
 #[derive(Clone, Debug, PartialEq)]
-pub enum BaseExpr {
+pub struct BaseExpr(Rc<BaseExprInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum BaseExprInner {
     Col(ColumnExpr),
     Const(BaseField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(Box<BaseExpr>, Box<BaseExpr>),
-    Sub(Box<BaseExpr>, Box<BaseExpr>),
-    Mul(Box<BaseExpr>, Box<BaseExpr>),
-    Neg(Box<BaseExpr>),
-    Inv(Box<BaseExpr>),
+    Add(BaseExpr, BaseExpr),
+    Sub(BaseExpr, BaseExpr),
+    Mul(BaseExpr, BaseExpr),
+    Neg(BaseExpr),
+    Inv(BaseExpr),
 }
 
 /// An expression representing a secure field value. Can be either:
@@ -70,29 +74,35 @@ pub enum ExtExpr {
     /// if `a = SecureCol(a0, a1, a2, a3)`, `b = SecureCol(b0, b1, b2, b3)` then
     /// `a + b` evaluates to `Add(a, b)` rather than
     /// `SecureCol(Add(a0, b0), Add(a1, b1), Add(a2, b2), Add(a3, b3))`
-    SecureCol([Box<BaseExpr>; 4]),
+    SecureCol([Rc<BaseExpr>; 4]),
     Const(SecureField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(Box<ExtExpr>, Box<ExtExpr>),
-    Sub(Box<ExtExpr>, Box<ExtExpr>),
-    Mul(Box<ExtExpr>, Box<ExtExpr>),
-    Neg(Box<ExtExpr>),
+    Add(Rc<ExtExpr>, Rc<ExtExpr>),
+    Sub(Rc<ExtExpr>, Rc<ExtExpr>),
+    Mul(Rc<ExtExpr>, Rc<ExtExpr>),
+    Neg(Rc<ExtExpr>),
+}
+
+impl Into<BaseExpr> for BaseExprInner {
+    fn into(self) -> BaseExpr {
+        BaseExpr(Rc::new(self))
+    }
 }
 
 impl From<BaseField> for BaseExpr {
     fn from(val: BaseField) -> Self {
-        BaseExpr::Const(val)
+        BaseExprInner::Const(val).into()
     }
 }
 
 impl From<BaseField> for ExtExpr {
     fn from(val: BaseField) -> Self {
         ExtExpr::SecureCol([
-            Box::new(BaseExpr::from(val)),
-            Box::new(BaseExpr::zero()),
-            Box::new(BaseExpr::zero()),
-            Box::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::from(val)),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
         ])
     }
 }
@@ -100,10 +110,10 @@ impl From<BaseField> for ExtExpr {
 impl From<SecureField> for ExtExpr {
     fn from(QM31(CM31(a, b), CM31(c, d)): SecureField) -> Self {
         ExtExpr::SecureCol([
-            Box::new(BaseExpr::from(a)),
-            Box::new(BaseExpr::from(b)),
-            Box::new(BaseExpr::from(c)),
-            Box::new(BaseExpr::from(d)),
+            Rc::new(BaseExpr::from(a)),
+            Rc::new(BaseExpr::from(b)),
+            Rc::new(BaseExpr::from(c)),
+            Rc::new(BaseExpr::from(d)),
         ])
     }
 }
@@ -111,10 +121,10 @@ impl From<SecureField> for ExtExpr {
 impl From<BaseExpr> for ExtExpr {
     fn from(expr: BaseExpr) -> Self {
         ExtExpr::SecureCol([
-            Box::new(expr.clone()),
-            Box::new(BaseExpr::zero()),
-            Box::new(BaseExpr::zero()),
-            Box::new(BaseExpr::zero()),
+            Rc::new(expr.clone()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
+            Rc::new(BaseExpr::zero()),
         ])
     }
 }
@@ -122,21 +132,21 @@ impl From<BaseExpr> for ExtExpr {
 impl Add for BaseExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        BaseExpr::Add(Box::new(self), Box::new(rhs))
+        BaseExprInner::Add(self, rhs).into()
     }
 }
 
 impl Sub for BaseExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        BaseExpr::Sub(Box::new(self), Box::new(rhs))
+        BaseExprInner::Sub(self, rhs).into()
     }
 }
 
 impl Mul for BaseExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        BaseExpr::Mul(Box::new(self), Box::new(rhs))
+        BaseExprInner::Mul(self, rhs).into()
     }
 }
 
@@ -155,28 +165,28 @@ impl MulAssign for BaseExpr {
 impl Neg for BaseExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        BaseExpr::Neg(Box::new(self))
+        BaseExprInner::Neg(self).into()
     }
 }
 
 impl Add for ExtExpr {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
-        ExtExpr::Add(Box::new(self), Box::new(rhs))
+        ExtExpr::Add(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Sub for ExtExpr {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
-        ExtExpr::Sub(Box::new(self), Box::new(rhs))
+        ExtExpr::Sub(Rc::new(self), Rc::new(rhs))
     }
 }
 
 impl Mul for ExtExpr {
     type Output = Self;
     fn mul(self, rhs: Self) -> Self {
-        ExtExpr::Mul(Box::new(self), Box::new(rhs))
+        ExtExpr::Mul(Rc::new(self), Rc::new(rhs))
     }
 }
 
@@ -195,7 +205,7 @@ impl MulAssign for ExtExpr {
 impl Neg for ExtExpr {
     type Output = Self;
     fn neg(self) -> Self {
-        ExtExpr::Neg(Box::new(self))
+        ExtExpr::Neg(Rc::new(self))
     }
 }
 
@@ -235,7 +245,7 @@ impl One for ExtExpr {
 
 impl FieldExpOps for BaseExpr {
     fn inverse(&self) -> Self {
-        BaseExpr::Inv(Box::new(self.clone()))
+        BaseExprInner::Inv(self.clone()).into()
     }
 }
 

--- a/crates/constraint-framework/src/expr/mod.rs
+++ b/crates/constraint-framework/src/expr/mod.rs
@@ -5,7 +5,7 @@ pub mod format;
 pub mod simplify;
 pub mod utils;
 
-use std::ops::{Add, AddAssign, Deref, Mul, MulAssign, Neg, Sub};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
 use std::rc::Rc;
 
 pub use evaluator::ExprEvaluator;
@@ -33,16 +33,6 @@ impl From<(usize, usize, isize)> for ColumnExpr {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct BaseExprInner(Rc<BaseExpr>);
-
-impl Deref for BaseExprInner {
-    type Target = BaseExpr;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// An expression representing a base field value. Can be either:
 ///     * A column indexed by a `ColumnExpr`.
 ///     * A base field constant.
@@ -58,21 +48,11 @@ pub enum BaseExpr {
     Const(BaseField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(BaseExprInner, BaseExprInner),
-    Sub(BaseExprInner, BaseExprInner),
-    Mul(BaseExprInner, BaseExprInner),
-    Neg(BaseExprInner),
-    Inv(BaseExprInner),
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExtExprInner(Rc<ExtExpr>);
-
-impl Deref for ExtExprInner {
-    type Target = ExtExpr;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+    Add(Rc<BaseExpr>, Rc<BaseExpr>),
+    Sub(Rc<BaseExpr>, Rc<BaseExpr>),
+    Mul(Rc<BaseExpr>, Rc<BaseExpr>),
+    Neg(Rc<BaseExpr>),
+    Inv(Rc<BaseExpr>),
 }
 
 /// An expression representing a secure field value. Can be either:
@@ -91,31 +71,19 @@ pub enum ExtExpr {
     /// if `a = SecureCol(a0, a1, a2, a3)`, `b = SecureCol(b0, b1, b2, b3)` then
     /// `a + b` evaluates to `Add(a, b)` rather than
     /// `SecureCol(Add(a0, b0), Add(a1, b1), Add(a2, b2), Add(a3, b3))`
-    SecureCol([BaseExprInner; 4]),
+    SecureCol([Rc<BaseExpr>; 4]),
     Const(SecureField),
     /// Formal parameter to the AIR, for example the interaction elements of a relation.
     Param(String),
-    Add(ExtExprInner, ExtExprInner),
-    Sub(ExtExprInner, ExtExprInner),
-    Mul(ExtExprInner, ExtExprInner),
-    Neg(ExtExprInner),
-}
-
-impl Into<BaseExprInner> for BaseExpr {
-    fn into(self) -> BaseExprInner {
-        BaseExprInner(Rc::new(self))
-    }
+    Add(Rc<ExtExpr>, Rc<ExtExpr>),
+    Sub(Rc<ExtExpr>, Rc<ExtExpr>),
+    Mul(Rc<ExtExpr>, Rc<ExtExpr>),
+    Neg(Rc<ExtExpr>),
 }
 
 impl From<BaseField> for BaseExpr {
     fn from(val: BaseField) -> Self {
         BaseExpr::Const(val)
-    }
-}
-
-impl Into<ExtExprInner> for ExtExpr {
-    fn into(self) -> ExtExprInner {
-        ExtExprInner(Rc::new(self))
     }
 }
 

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -1,10 +1,7 @@
-use std::rc::Rc;
-
 use num_traits::{One, Zero};
 use stwo::core::fields::qm31::SecureField;
 
 use super::{BaseExpr, ExtExpr};
-use crate::expr::rcbox_base;
 
 /// Applies simplifications to arithmetic expressions that can be used both for `BaseExpr` and for
 /// `ExtExpr`.
@@ -21,9 +18,11 @@ macro_rules! simplify_arithmetic {
                     (_, Self::Const(b_val)) if b_val.is_zero() => a, // a + 0 = a
                     // Simplify Negs.
                     // (-a + -b) = -(a + b)
-                    (Self::Neg(minus_a), Self::Neg(minus_b)) => -(*minus_a + *minus_b),
-                    (Self::Neg(minus_a), _) => b - *minus_a, // -a + b = b - a
-                    (_, Self::Neg(minus_b)) => a - *minus_b, // a + -b = a - b
+                    (Self::Neg(minus_a), Self::Neg(minus_b)) => {
+                        -((*minus_a).clone() + (*minus_b).clone())
+                    }
+                    (Self::Neg(minus_a), _) => b - (*minus_a).clone(), // -a + b = b - a
+                    (_, Self::Neg(minus_b)) => a - (*minus_b).clone(), // a + -b = a - b
                     // No simplification.
                     _ => a + b,
                 }
@@ -38,9 +37,11 @@ macro_rules! simplify_arithmetic {
                     (_, Self::Const(b_val)) if b_val.is_zero() => a,        // a - 0 = a
                     // Simplify Negs.
                     // (-a - -b) = b - a
-                    (Self::Neg(minus_a), Self::Neg(minus_b)) => *minus_b - *minus_a,
-                    (Self::Neg(minus_a), _) => -(*minus_a + b), // -a - b = -(a + b)
-                    (_, Self::Neg(minus_b)) => a + *minus_b,    // a + -b = a - b
+                    (Self::Neg(minus_a), Self::Neg(minus_b)) => {
+                        (*minus_b).clone() - (*minus_a).clone()
+                    }
+                    (Self::Neg(minus_a), _) => -((*minus_a).clone() + b), // -a - b = -(a + b)
+                    (_, Self::Neg(minus_b)) => a + (*minus_b).clone(),    // a + -b = a - b
                     // No Simplification.
                     _ => a - b,
                 }
@@ -59,9 +60,11 @@ macro_rules! simplify_arithmetic {
                     (_, Self::Const(b_val)) if -b_val == One::one() => -a,      // a * -1 = -a
                     // Simplify Negs.
                     // (-a) * (-b) = a * b
-                    (Self::Neg(minus_a), Self::Neg(minus_b)) => *minus_a * *minus_b,
-                    (Self::Neg(minus_a), _) => -(*minus_a * b), // (-a) * b = -(a * b)
-                    (_, Self::Neg(minus_b)) => -(a * *minus_b), // a * (-b) = -(a * b)
+                    (Self::Neg(minus_a), Self::Neg(minus_b)) => {
+                        (*minus_a).clone() * (*minus_b).clone()
+                    }
+                    (Self::Neg(minus_a), _) => -((*minus_a).clone() * b), // (-a) * b = -(a * b)
+                    (_, Self::Neg(minus_b)) => -((a).clone() * (*minus_b).clone()), // a * (-b) = -(a * b)
                     // No simplification.
                     _ => a * b,
                 }
@@ -70,9 +73,9 @@ macro_rules! simplify_arithmetic {
                 let a = a.simplify();
                 match a {
                     Self::Const(c) => Self::Const(-c),
-                    Self::Neg(minus_a) => *minus_a,     // -(-a) = a
-                    Self::Sub(a, b) => Self::Sub(b, a), // -(a - b) = b - a
-                    _ => -a,                            // No simplification.
+                    Self::Neg(minus_a) => (*minus_a).clone(), // -(-a) = a
+                    Self::Sub(a, b) => Self::Sub(b, a),      // -(a - b) = b - a
+                    _ => -a,                                  // No simplification.
                 }
             }
             other => other, // No simplification.
@@ -90,9 +93,9 @@ impl BaseExpr {
             Self::Inv(a) => {
                 let a = a.unchecked_simplify();
                 match a {
-                    Self::Inv(inv_a) => inv_a.clone(), // 1 / (1 / a) = a
+                    Self::Inv(inv_a) => (*inv_a).clone(),
                     Self::Const(c) => Self::Const(c.inverse()),
-                    _ => Self::Inv(rcbox_base(a)),
+                    _ => Self::Inv(a.into()),
                 }
             }
             other => other,
@@ -131,12 +134,7 @@ impl ExtExpr {
                         BaseExpr::Const(c_val),
                         BaseExpr::Const(d_val),
                     ) => ExtExpr::Const(SecureField::from_m31_array([a_val, b_val, c_val, d_val])),
-                    _ => Self::SecureCol([
-                        Rc::new(Box::new(a)),
-                        Rc::new(Box::new(b)),
-                        Rc::new(Box::new(c)),
-                        Rc::new(Box::new(d)),
-                    ]),
+                    _ => Self::SecureCol([a.into(), b.into(), c.into(), d.into()]),
                 }
             }
             other => other,

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -1,7 +1,10 @@
+use std::rc::Rc;
+
 use num_traits::{One, Zero};
 use stwo::core::fields::qm31::SecureField;
 
 use super::{BaseExpr, ExtExpr};
+use crate::expr::rcbox_base;
 
 /// Applies simplifications to arithmetic expressions that can be used both for `BaseExpr` and for
 /// `ExtExpr`.
@@ -87,9 +90,9 @@ impl BaseExpr {
             Self::Inv(a) => {
                 let a = a.unchecked_simplify();
                 match a {
-                    Self::Inv(inv_a) => *inv_a, // 1 / (1 / a) = a
+                    Self::Inv(inv_a) => inv_a.clone(), // 1 / (1 / a) = a
                     Self::Const(c) => Self::Const(c.inverse()),
-                    _ => Self::Inv(Box::new(a)),
+                    _ => Self::Inv(rcbox_base(a)),
                 }
             }
             other => other,
@@ -128,7 +131,12 @@ impl ExtExpr {
                         BaseExpr::Const(c_val),
                         BaseExpr::Const(d_val),
                     ) => ExtExpr::Const(SecureField::from_m31_array([a_val, b_val, c_val, d_val])),
-                    _ => Self::SecureCol([Box::new(a), Box::new(b), Box::new(c), Box::new(d)]),
+                    _ => Self::SecureCol([
+                        Rc::new(Box::new(a)),
+                        Rc::new(Box::new(b)),
+                        Rc::new(Box::new(c)),
+                        Rc::new(Box::new(d)),
+                    ]),
                 }
             }
             other => other,

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -97,7 +97,7 @@ impl BaseExpr {
                 match a {
                     Self::Inv(inv_a) => (*inv_a).clone(),
                     Self::Const(c) => Self::Const(c.inverse()),
-                    _ => Self::Inv(a.into()),
+                    _ => Self::Inv(Rc::new(a)),
                 }
             }
             other => other,

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use num_traits::{One, Zero};
 use stwo::core::fields::qm31::SecureField;
 
@@ -64,7 +66,7 @@ macro_rules! simplify_arithmetic {
                         (*minus_a).clone() * (*minus_b).clone()
                     }
                     (Self::Neg(minus_a), _) => -((*minus_a).clone() * b), // (-a) * b = -(a * b)
-                    (_, Self::Neg(minus_b)) => -((a).clone() * (*minus_b).clone()), // a * (-b) = -(a * b)
+                    (_, Self::Neg(minus_b)) => -(a.clone() * (*minus_b).clone()), // a * (-b) = -(a * b)
                     // No simplification.
                     _ => a * b,
                 }
@@ -73,9 +75,9 @@ macro_rules! simplify_arithmetic {
                 let a = a.simplify();
                 match a {
                     Self::Const(c) => Self::Const(-c),
-                    Self::Neg(minus_a) => (*minus_a).clone(), // -(-a) = a
-                    Self::Sub(a, b) => Self::Sub(b, a),      // -(a - b) = b - a
-                    _ => -a,                                  // No simplification.
+                    Self::Neg(minus_a) => (*minus_a).clone(),   // -(-a) = a
+                    Self::Sub(a, b) => Self::Sub(b, a),         // -(a - b) = b - a
+                    _ => -a,                                    // No simplification.
                 }
             }
             other => other, // No simplification.
@@ -134,7 +136,7 @@ impl ExtExpr {
                         BaseExpr::Const(c_val),
                         BaseExpr::Const(d_val),
                     ) => ExtExpr::Const(SecureField::from_m31_array([a_val, b_val, c_val, d_val])),
-                    _ => Self::SecureCol([a.into(), b.into(), c.into(), d.into()]),
+                    _ => Self::SecureCol([Rc::new(a), Rc::new(b), Rc::new(c), Rc::new(d)]),
                 }
             }
             other => other,

--- a/crates/constraint-framework/src/expr/utils.rs
+++ b/crates/constraint-framework/src/expr/utils.rs
@@ -1,7 +1,12 @@
 #[cfg(test)]
 macro_rules! secure_col {
     ($a:expr, $b:expr, $c:expr, $d:expr) => {
-        crate::expr::ExtExpr::SecureCol([$a.into(), $b.into(), $c.into(), $d.into()])
+        crate::expr::ExtExpr::SecureCol([
+            std::rc::Rc::new($a.into()),
+            std::rc::Rc::new($b.into()),
+            std::rc::Rc::new($c.into()),
+            std::rc::Rc::new($d.into()),
+        ])
     };
 }
 #[cfg(test)]

--- a/crates/constraint-framework/src/expr/utils.rs
+++ b/crates/constraint-framework/src/expr/utils.rs
@@ -1,12 +1,7 @@
 #[cfg(test)]
 macro_rules! secure_col {
     ($a:expr, $b:expr, $c:expr, $d:expr) => {
-        crate::expr::ExtExpr::SecureCol([
-            std::rc::Rc::new($a.into()),
-            std::rc::Rc::new($b.into()),
-            std::rc::Rc::new($c.into()),
-            std::rc::Rc::new($d.into()),
-        ])
+        crate::expr::ExtExpr::SecureCol([$a.into(), $b.into(), $c.into(), $d.into()])
     };
 }
 #[cfg(test)]

--- a/crates/constraint-framework/src/expr/utils.rs
+++ b/crates/constraint-framework/src/expr/utils.rs
@@ -2,10 +2,10 @@
 macro_rules! secure_col {
     ($a:expr, $b:expr, $c:expr, $d:expr) => {
         crate::expr::ExtExpr::SecureCol([
-            Box::new($a.into()),
-            Box::new($b.into()),
-            Box::new($c.into()),
-            Box::new($d.into()),
+            std::rc::Rc::new($a.into()),
+            std::rc::Rc::new($b.into()),
+            std::rc::Rc::new($c.into()),
+            std::rc::Rc::new($d.into()),
         ])
     };
 }


### PR DESCRIPTION
- Replace recursion in BaseExpr/ExtExpr with Rc‑backed BaseExprInner/ExtExprInner, slashing memory for deep trees.
- Add a minimal sharing test to assert Rc counts and a larger‑round smoke test.

Code changes 
  - expr/mod.rs — core enum change
  - expr/evaluator.rs — sharing test and hash stress refactor.