### PR TITLE
Fix denom_inv bug

### DIFF
--- a/crates/constraint-framework/src/prover/component_prover.rs
+++ b/crates/constraint-framework/src/prover/component_prover.rs
@@ -72,9 +72,13 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
 
         // Denom inverses.
         let log_expand = eval_domain.log_size() - trace_domain.log_size();
-        let mut denom_inv = (0..1 << log_expand)
-            .map(|i| coset_vanishing(trace_domain.coset(), eval_domain.at(i)).inverse())
-            .collect_vec();
+        let mut denom_inv = if log_expand > 0 {
+            (0..1 << log_expand)
+                .map(|i| coset_vanishing(trace_domain.coset(), eval_domain.at(i)).inverse())
+                .collect_vec()
+        } else {
+            vec![BaseField::one()]
+        };
         bit_reverse(&mut denom_inv);
 
         // Accumulator.


### PR DESCRIPTION
Issue: panics when trace_domain and eval_domain have the same log size (when AIR has only addition gates) and `coset_vanishing` returns 0, and the program tries to call `inverse()` on it.

This change fallbacks to using 1 as `denom_inv` when trace_domain and eval_domain have the same log size