### PR TITLE
fix: remove duplicate Neg trait bound in EvalAtRow::F

### DIFF
--- a/crates/constraint-framework/src/lib.rs
+++ b/crates/constraint-framework/src/lib.rs
@@ -64,7 +64,6 @@ pub trait EvalAtRow {
         + Mul<BaseField, Output = Self::F>
         + Add<SecureField, Output = Self::EF>
         + Mul<SecureField, Output = Self::EF>
-        + Neg<Output = Self::F>
         + From<BaseField>;
 
     /// A field type representing the closure of `F` with multiplying by [SecureField]. Constraints


### PR DESCRIPTION
remove duplicate Neg trait bound in EvalAtRow::F