### PR TITLE
dev: update rand crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -887,7 +887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -897,7 +906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -905,6 +914,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
 name = "rawpointer"
@@ -1161,7 +1176,7 @@ dependencies = [
  "indexmap",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "serde",
  "starknet-crypto",
@@ -1202,7 +1217,7 @@ dependencies = [
  "hashbrown",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "std-shims",
  "stwo",
@@ -1218,7 +1233,7 @@ dependencies = [
  "itertools 0.12.1",
  "ndarray",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "serde",
  "stwo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytemuck = { version = "1.14.3", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
 rayon = { version = "1.10.0", optional = false }
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9.2", default-features = false, features = ["small_rng"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 hashbrown = ">=0.15.2"
 std-shims = { path = "crates/std-shims", default-features = false }

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -175,9 +175,9 @@ mod tests {
 
         let mut rng = SmallRng::seed_from_u64(0);
         let columns: HashMap<(usize, usize, isize), BaseField> =
-            HashMap::from([((1, 0, 0), rng.gen()), ((1, 1, 0), rng.gen())]);
-        let vars: HashMap<String, BaseField> = HashMap::from([("a".to_string(), rng.gen())]);
-        let ext_vars: HashMap<String, SecureField> = HashMap::from([("b".to_string(), rng.gen())]);
+            HashMap::from([((1, 0, 0), rng.random()), ((1, 1, 0), rng.random())]);
+        let vars: HashMap<String, BaseField> = HashMap::from([("a".to_string(), rng.random())]);
+        let ext_vars: HashMap<String, SecureField> = HashMap::from([("b".to_string(), rng.random())]);
 
         let base_expr = (((zero.clone() + c0.clone()) + (a.clone() + zero.clone()))
             * ((-c1.clone()) + (-c0.clone()))

--- a/crates/examples/src/xor/gkr_lookups/mle_eval.rs
+++ b/crates/examples/src/xor/gkr_lookups/mle_eval.rs
@@ -782,9 +782,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         // Setup protocol.
         let twiddles = SimdBackend::precompute_twiddles(
@@ -858,9 +858,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         // Setup protocol.
         let twiddles = SimdBackend::precompute_twiddles(
@@ -947,9 +947,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let mle_eval_trace = build_trace(&mle, &eval_point, claim);
@@ -994,7 +994,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1031,7 +1031,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1068,7 +1068,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1102,7 +1102,7 @@ mod tests {
     fn inclusive_prefix_sum_constraints_with_log_size_5() {
         const LOG_SIZE: u32 = 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let vals = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let vals = (0..1 << LOG_SIZE).map(|_| rng.random()).collect_vec();
         let cumulative_sum = vals.iter().sum::<SecureField>();
         let cumulative_sum_shift = cumulative_sum / BaseField::from(vals.len());
         let trace = TreeVec::new(vec![gen_prefix_sum_trace(vals)]);
@@ -1139,7 +1139,7 @@ mod tests {
     fn eval_carry_quotient_col_works() {
         const N_VARIABLES: usize = 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let col_eval = gen_carry_quotient_col(&eval_point);
         let twiddles = SimdBackend::precompute_twiddles(col_eval.domain.half_coset);

--- a/crates/stwo/benches/eval_at_point.rs
+++ b/crates/stwo/benches/eval_at_point.rs
@@ -12,8 +12,8 @@ const LOG_SIZE: u32 = 20;
 fn bench_eval_at_secure_point<B: PolyOps>(c: &mut Criterion, id: &str) {
     let poly = CirclePoly::new((0..1 << LOG_SIZE).map(BaseField::from).collect());
     let mut rng = SmallRng::seed_from_u64(0);
-    let x = rng.gen();
-    let y = rng.gen();
+    let x = rng.random();
+    let y = rng.random();
     let point = CirclePoint { x, y };
     c.bench_function(
         &format!("{id} eval_at_secure_field_point 2^{LOG_SIZE}"),

--- a/crates/stwo/benches/field.rs
+++ b/crates/stwo/benches/field.rs
@@ -12,8 +12,8 @@ pub const N_STATE_ELEMENTS: usize = 8;
 
 pub fn m31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<M31> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [M31; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<M31> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [M31; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("M31 mul", |b| {
         b.iter(|| {
@@ -42,8 +42,8 @@ pub fn m31_operations_bench(c: &mut Criterion) {
 
 pub fn cm31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<CM31> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [CM31; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<CM31> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [CM31; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("CM31 mul", |b| {
         b.iter(|| {
@@ -72,8 +72,8 @@ pub fn cm31_operations_bench(c: &mut Criterion) {
 
 pub fn qm31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<SecureField> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [SecureField; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<SecureField> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [SecureField; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("SecureField mul", |b| {
         b.iter(|| {
@@ -102,7 +102,7 @@ pub fn qm31_operations_bench(c: &mut Criterion) {
 
 pub fn simd_m31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<PackedBaseField> = (0..N_ELEMENTS / N_LANES).map(|_| rng.gen()).collect();
+    let elements: Vec<PackedBaseField> = (0..N_ELEMENTS / N_LANES).map(|_| rng.random()).collect();
     let mut states = vec![PackedBaseField::broadcast(BaseField::one()); N_STATE_ELEMENTS];
 
     c.bench_function("mul_simd", |b| {
@@ -145,6 +145,6 @@ pub fn simd_m31_operations_bench(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = m31_operations_bench, cm31_operations_bench, qm31_operations_bench, 
+    targets = m31_operations_bench, cm31_operations_bench, qm31_operations_bench,
         simd_m31_operations_bench);
 criterion_main!(benches);

--- a/crates/stwo/benches/lookups.rs
+++ b/crates/stwo/benches/lookups.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use stwo::core::channel::Blake2sChannel;
@@ -83,9 +83,9 @@ fn bench_gkr_logup_singles<B: GkrOps>(c: &mut Criterion, id: &str) {
 /// Generates a random multilinear polynomial.
 fn gen_random_mle<B: MleOps<F>, F: Field>(rng: &mut impl Rng, n_variables: u32) -> Mle<B, F>
 where
-    Standard: Distribution<F>,
+    StandardUniform: Distribution<F>,
 {
-    Mle::new((0..1 << n_variables).map(|_| rng.gen()).collect())
+    Mle::new((0..1 << n_variables).map(|_| rng.random()).collect())
 }
 
 fn gkr_lookup_benches(c: &mut Criterion) {

--- a/crates/stwo/benches/pcs.rs
+++ b/crates/stwo/benches/pcs.rs
@@ -46,7 +46,7 @@ fn bench_pcs<B: BackendForChannel<Blake2sMerkleChannel>>(c: &mut Criterion, id: 
     let evals: Vec<CircleEvaluation<B, BaseField, BitReversedOrder>> = iter::repeat_with(|| {
         CircleEvaluation::new(
             small_domain.circle_domain(),
-            (0..1 << LOG_COSET_SIZE).map(|_| rng.gen()).collect(),
+            (0..1 << LOG_COSET_SIZE).map(|_| rng.random()).collect(),
         )
     })
     .take(N_POLYS)

--- a/crates/stwo/src/core/air/accumulation.rs
+++ b/crates/stwo/src/core/air/accumulation.rs
@@ -53,13 +53,13 @@ mod tests {
         const MAX_LOG_SIZE: u32 = 10;
         const MASK: u32 = P;
         let log_sizes = (0..100)
-            .map(|_| rng.gen_range(4..MAX_LOG_SIZE))
+            .map(|_| rng.random_range(4..MAX_LOG_SIZE))
             .collect::<Vec<_>>();
 
         // Generate random evaluations.
         let evaluations = log_sizes
             .iter()
-            .map(|_| M31::from_u32_unchecked(rng.gen::<u32>() & MASK))
+            .map(|_| M31::from_u32_unchecked(rng.random::<u32>() & MASK))
             .collect::<Vec<_>>();
         let alpha = qm31!(2, 3, 4, 5);
 

--- a/crates/stwo/src/core/fields/m31.rs
+++ b/crates/stwo/src/core/fields/m31.rs
@@ -4,7 +4,7 @@ use core::ops::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
 use super::{ComplexConjugate, FieldExpOps};
@@ -166,10 +166,10 @@ impl From<i32> for M31 {
     }
 }
 
-impl Distribution<M31> for Standard {
+impl Distribution<M31> for StandardUniform {
     // Not intended for cryptographic use. Should only be used in tests and benchmarks.
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> M31 {
-        M31(rng.gen_range(0..P))
+        M31(rng.random_range(0..P))
     }
 }
 
@@ -239,8 +239,8 @@ mod tests {
     fn test_basic_ops() {
         let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..10000 {
-            let x: u32 = rng.gen::<u32>() % P;
-            let y: u32 = rng.gen::<u32>() % P;
+            let x: u32 = rng.random::<u32>() % P;
+            let y: u32 = rng.random::<u32>() % P;
             assert_eq!(m31!(add_p(x, y)), m31!(x) + m31!(y));
             assert_eq!(m31!(mul_p(x, y)), m31!(x) * m31!(y));
             assert_eq!(m31!(neg_p(x)), -m31!(x));

--- a/crates/stwo/src/core/fields/mod.rs
+++ b/crates/stwo/src/core/fields/mod.rs
@@ -290,7 +290,7 @@ macro_rules! impl_field {
 #[macro_export]
 macro_rules! impl_extension_field {
     ($field_name: ident, $extended_field_name: ty) => {
-        use rand::distributions::{Distribution, Standard};
+        use rand::distr::{Distribution, StandardUniform};
         use $crate::core::fields::ExtensionOf;
 
         impl ExtensionOf<M31> for $field_name {
@@ -462,10 +462,10 @@ macro_rules! impl_extension_field {
             }
         }
 
-        impl Distribution<$field_name> for Standard {
+        impl Distribution<$field_name> for StandardUniform {
             // Not intended for cryptographic use. Should only be used in tests and benchmarks.
             fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $field_name {
-                $field_name(rng.gen(), rng.gen())
+                $field_name(rng.random(), rng.random())
             }
         }
     };
@@ -486,7 +486,7 @@ mod tests {
     #[test]
     fn test_batch_inverse() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let expected = elements.iter().map(|e| e.inverse()).collect::<Vec<_>>();
 
         let actual = batch_inverse(&elements);
@@ -498,7 +498,7 @@ mod tests {
     #[should_panic]
     fn test_slice_batch_inverse_wrong_dst_size() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let mut dst = [M31::zero(); 15];
 
         batch_inverse_in_place(&elements, &mut dst);
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn test_batch_inverse_chunked() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let chunk_size = 4;
         let expected = batch_inverse(&elements);
 

--- a/crates/stwo/src/core/vcs/poseidon252_merkle.rs
+++ b/crates/stwo/src/core/vcs/poseidon252_merkle.rs
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn test_construct_word() {
         let mut rng = SmallRng::seed_from_u64(1638);
-        let random_values = (0..8 * 1000 + 5).map(|_| rng.gen::<M31>()).collect_vec();
+        let random_values = (0..8 * 1000 + 5).map(|_| rng.random::<M31>()).collect_vec();
 
         let expected = random_values
             .chunks(ELEMENTS_IN_BLOCK)

--- a/crates/stwo/src/core/vcs/test_utils.rs
+++ b/crates/stwo/src/core/vcs/test_utils.rs
@@ -28,13 +28,13 @@ where
 
     let mut rng = SmallRng::seed_from_u64(0);
     let log_sizes = (0..N_COLS)
-        .map(|_| rng.gen_range(log_size_range.clone()))
+        .map(|_| rng.random_range(log_size_range.clone()))
         .collect_vec();
     let cols = log_sizes
         .iter()
         .map(|&log_size| {
             (0..(1 << log_size))
-                .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
+                .map(|_| BaseField::from(rng.random_range(0..(1 << 30))))
                 .collect_vec()
         })
         .collect_vec();
@@ -43,7 +43,7 @@ where
     let mut queries = BTreeMap::<u32, Vec<usize>>::new();
     for log_size in log_size_range.rev() {
         let layer_queries = (0..N_QUERIES)
-            .map(|_| rng.gen_range(0..(1 << log_size)))
+            .map(|_| rng.random_range(0..(1 << log_size)))
             .sorted()
             .dedup()
             .collect_vec();

--- a/crates/stwo/src/prover/air/accumulation.rs
+++ b/crates/stwo/src/prover/air/accumulation.rs
@@ -168,7 +168,7 @@ mod tests {
         const LOG_SIZE_BOUND: u32 = 10;
         const MASK: u32 = P;
         let mut log_sizes = (0..100)
-            .map(|_| rng.gen_range(LOG_SIZE_MIN..LOG_SIZE_BOUND))
+            .map(|_| rng.random_range(LOG_SIZE_MIN..LOG_SIZE_BOUND))
             .collect::<Vec<_>>();
         log_sizes.sort();
 
@@ -177,7 +177,7 @@ mod tests {
             .iter()
             .map(|log_size| {
                 (0..(1 << *log_size))
-                    .map(|_| M31::from_u32_unchecked(rng.gen::<u32>() & MASK))
+                    .map(|_| M31::from_u32_unchecked(rng.random::<u32>() & MASK))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();

--- a/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
@@ -343,8 +343,8 @@ mod tests {
     fn logup_with_generic_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerator_values, &denominator_values)
             .map(|(&n, &d)| Fraction::new(n, d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -382,7 +382,7 @@ mod tests {
     fn logup_with_singles_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = denominator_values
             .iter()
             .map(|&d| Fraction::new(SecureField::one(), d))
@@ -416,8 +416,8 @@ mod tests {
     fn logup_with_multiplicities_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerator_values = (0..N).map(|_| rng.gen()).collect::<Vec<BaseField>>();
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerator_values = (0..N).map(|_| rng.random()).collect::<Vec<BaseField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerator_values, &denominator_values)
             .map(|(&n, &d)| Fraction::new(n.into(), d))
             .sum::<Fraction<SecureField, SecureField>>();

--- a/crates/stwo/src/prover/backend/cpu/mod.rs
+++ b/crates/stwo/src/prover/backend/cpu/mod.rs
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn batch_inverse_in_place_test() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let column = rng.gen::<[QM31; 16]>().to_vec();
+        let column = rng.random::<[QM31; 16]>().to_vec();
         let expected = column.iter().map(|e| e.inverse()).collect_vec();
         let mut dst = Vec::zeros(column.len());
 

--- a/crates/stwo/src/prover/backend/simd/blake2s.rs
+++ b/crates/stwo/src/prover/backend/simd/blake2s.rs
@@ -492,7 +492,7 @@ mod tests {
     #[test]
     fn hash_16_works() {
         let mut rng = SmallRng::seed_from_u64(1055);
-        let msgs: [[u32; 16]; 16] = array::from_fn(|_| rng.gen::<[u32; 16]>());
+        let msgs: [[u32; 16]; 16] = array::from_fn(|_| rng.random::<[u32; 16]>());
         let expected: [[u8; 32]; 16] = array::from_fn(|i| {
             let state = msgs[i];
             let mut hasher = Blake2sHasher::new();

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -510,8 +510,8 @@ mod tests {
                 (0..1 << log_size).map(BaseField::from).collect(),
             );
             let poly = evaluation.bit_reverse().interpolate();
-            let x = rng.gen();
-            let y = rng.gen();
+            let x = rng.random();
+            let y = rng.random();
             let p = CirclePoint { x, y };
 
             let eval = PolyOps::eval_at_point(&poly, p);

--- a/crates/stwo/src/prover/backend/simd/cm31.rs
+++ b/crates/stwo/src/prover/backend/simd/cm31.rs
@@ -189,8 +189,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -202,8 +202,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -215,8 +215,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -228,7 +228,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedCM31::from_array(values);
 
         let res = -packed_values;

--- a/crates/stwo/src/prover/backend/simd/column.rs
+++ b/crates/stwo/src/prover/backend/simd/column.rs
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     fn secure_field_vec_from_iter_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [SecureField; 30] = rng.gen();
+        let values: [SecureField; 30] = rng.random();
 
         let res = values.into_iter().collect::<SecureColumn>();
 
@@ -775,8 +775,8 @@ mod tests {
         };
 
         let mut rng = SmallRng::seed_from_u64(0);
-        let rand0 = PackedQM31::from_array(rng.gen());
-        let rand1 = PackedQM31::from_array(rng.gen());
+        let rand0 = PackedQM31::from_array(rng.random());
+        let rand1 = PackedQM31::from_array(rng.random());
 
         const CHUNK_SIZE: usize = 4;
         let mut chunks: Vec<_> = col.chunks_mut(CHUNK_SIZE).collect();

--- a/crates/stwo/src/prover/backend/simd/conversion.rs
+++ b/crates/stwo/src/prover/backend/simd/conversion.rs
@@ -98,13 +98,13 @@ mod tests {
         type MyType = (M31, [M31; 3], [M31; 15]);
         let mut rand_input = || -> MyType {
             (
-                M31::from(rng.gen::<u32>()),
+                M31::from(rng.random::<u32>()),
                 [
-                    M31::from(rng.gen::<u32>()),
-                    M31::from(rng.gen::<u32>()),
-                    M31::from(rng.gen::<u32>()),
+                    M31::from(rng.random::<u32>()),
+                    M31::from(rng.random::<u32>()),
+                    M31::from(rng.random::<u32>()),
                 ],
-                std::array::from_fn(|_| M31::from(rng.gen::<u32>())),
+                std::array::from_fn(|_| M31::from(rng.random::<u32>())),
             )
         };
         let inputs: [_; N_LANES] = std::array::from_fn(|_| rand_input());

--- a/crates/stwo/src/prover/backend/simd/fft/ifft.rs
+++ b/crates/stwo/src/prover/backend/simd/fft/ifft.rs
@@ -568,9 +568,9 @@ mod tests {
     #[test]
     fn test_ibutterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let mut v0: [BaseField; N_LANES] = rng.gen();
-        let mut v1: [BaseField; N_LANES] = rng.gen();
-        let twiddle: [BaseField; N_LANES] = rng.gen();
+        let mut v0: [BaseField; N_LANES] = rng.random();
+        let mut v1: [BaseField; N_LANES] = rng.random();
+        let twiddle: [BaseField; N_LANES] = rng.random();
         let twiddle_dbl = twiddle.map(|v| v.0 * 2);
 
         let (r0, r1) = simd_ibutterfly(v0.into(), v1.into(), twiddle_dbl.into());
@@ -586,10 +586,10 @@ mod tests {
     #[test]
     fn test_ifft3() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
-        let twiddles0: [BaseField; 4] = rng.gen();
-        let twiddles1: [BaseField; 2] = rng.gen();
-        let twiddles2: [BaseField; 1] = rng.gen();
+        let values = rng.random::<[BaseField; 8]>().map(PackedBaseField::broadcast);
+        let twiddles0: [BaseField; 4] = rng.random();
+        let twiddles1: [BaseField; 2] = rng.random();
+        let twiddles2: [BaseField; 1] = rng.random();
         let twiddles0_dbl = twiddles0.map(|v| v.0 * 2);
         let twiddles1_dbl = twiddles1.map(|v| v.0 * 2);
         let twiddles2_dbl = twiddles2.map(|v| v.0 * 2);
@@ -649,7 +649,7 @@ mod tests {
         let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
         assert_eq!(twiddle_dbls.len(), 4);
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [[BaseField; 16]; 2] = rng.gen();
+        let values: [[BaseField; 16]; 2] = rng.random();
 
         let res = {
             let (val0, val1) = vecwise_ibutterflies(
@@ -671,7 +671,7 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -693,7 +693,7 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();

--- a/crates/stwo/src/prover/backend/simd/fft/rfft.rs
+++ b/crates/stwo/src/prover/backend/simd/fft/rfft.rs
@@ -595,9 +595,9 @@ mod tests {
     #[test]
     fn test_butterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let mut v0: [BaseField; N_LANES] = rng.gen();
-        let mut v1: [BaseField; N_LANES] = rng.gen();
-        let twiddle: [BaseField; N_LANES] = rng.gen();
+        let mut v0: [BaseField; N_LANES] = rng.random();
+        let mut v1: [BaseField; N_LANES] = rng.random();
+        let twiddle: [BaseField; N_LANES] = rng.random();
         let twiddle_dbl = twiddle.map(|v| v.0 * 2);
 
         let (r0, r1) = simd_butterfly(v0.into(), v1.into(), twiddle_dbl.into());
@@ -613,10 +613,10 @@ mod tests {
     #[test]
     fn test_fft3() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
-        let twiddles0: [BaseField; 4] = rng.gen();
-        let twiddles1: [BaseField; 2] = rng.gen();
-        let twiddles2: [BaseField; 1] = rng.gen();
+        let values = rng.random::<[BaseField; 8]>().map(PackedBaseField::broadcast);
+        let twiddles0: [BaseField; 4] = rng.random();
+        let twiddles1: [BaseField; 2] = rng.random();
+        let twiddles2: [BaseField; 1] = rng.random();
         let twiddles0_dbl = twiddles0.map(|v| v.0 * 2);
         let twiddles1_dbl = twiddles1.map(|v| v.0 * 2);
         let twiddles2_dbl = twiddles2.map(|v| v.0 * 2);
@@ -677,7 +677,7 @@ mod tests {
         let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
         assert_eq!(twiddle_dbls.len(), 4);
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [[BaseField; 16]; 2] = rng.gen();
+        let values: [[BaseField; 16]; 2] = rng.random();
 
         let res = {
             let (val0, val1) = simd_butterfly(
@@ -703,7 +703,7 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -726,7 +726,7 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();

--- a/crates/stwo/src/prover/backend/simd/fri.rs
+++ b/crates/stwo/src/prover/backend/simd/fri.rs
@@ -190,7 +190,7 @@ mod tests {
     fn test_fold_line() {
         const LOG_SIZE: u32 = 7;
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let values = (0..1 << LOG_SIZE).map(|_| rng.random()).collect_vec();
         let alpha = qm31!(1, 3, 5, 7);
         let domain = LineDomain::new(CanonicCoset::new(LOG_SIZE + 1).half_coset());
         let cpu_fold = CpuBackend::fold_line(

--- a/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
@@ -581,8 +581,8 @@ mod tests {
     fn logup_with_generic_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerators, &denominators)
             .map(|(&n, &d)| Fraction::new(n, d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -620,8 +620,8 @@ mod tests {
     fn logup_with_multiplicities_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerators = (0..N).map(|_| rng.gen()).collect::<Vec<BaseField>>();
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerators = (0..N).map(|_| rng.random()).collect::<Vec<BaseField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerators, &denominators)
             .map(|(&n, &d)| Fraction::new(n.into(), d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -659,7 +659,7 @@ mod tests {
     fn logup_with_singles_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = denominators
             .iter()
             .map(|&d| Fraction::new(SecureField::one(), d))

--- a/crates/stwo/src/prover/backend/simd/m31.rs
+++ b/crates/stwo/src/prover/backend/simd/m31.rs
@@ -7,7 +7,7 @@ use std::simd::{u32x16, Simd};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 
 use super::qm31::PackedQM31;
 use super::PACKED_M31_BATCH_INVERSE_CHUNK_SIZE;
@@ -281,9 +281,9 @@ impl From<BaseField> for PackedM31 {
     }
 }
 
-impl Distribution<PackedM31> for Standard {
+impl Distribution<PackedM31> for StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedM31 {
-        PackedM31::from_array(rng.gen())
+        PackedM31::from_array(rng.random())
     }
 }
 
@@ -603,8 +603,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -616,8 +616,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -629,8 +629,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -642,7 +642,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedM31::from_array(values);
 
         let res = -packed_values;
@@ -672,7 +672,7 @@ mod tests {
     #[test]
     fn inverse_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedM31::from_array(values);
 
         let res = packed_values.inverse();

--- a/crates/stwo/src/prover/backend/simd/prefix_sum.rs
+++ b/crates/stwo/src/prover/backend/simd/prefix_sum.rs
@@ -154,7 +154,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_3_works() {
         const LOG_N: u32 = 3;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);
@@ -166,7 +166,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_6_works() {
         const LOG_N: u32 = 6;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);
@@ -178,7 +178,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_8_works() {
         const LOG_N: u32 = 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);

--- a/crates/stwo/src/prover/backend/simd/qm31.rs
+++ b/crates/stwo/src/prover/backend/simd/qm31.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 
 use super::cm31::PackedCM31;
 use super::m31::{PackedM31, N_LANES};
@@ -305,9 +305,9 @@ impl Neg for PackedQM31 {
     }
 }
 
-impl Distribution<PackedQM31> for Standard {
+impl Distribution<PackedQM31> for StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedQM31 {
-        PackedQM31::from_array(rng.gen())
+        PackedQM31::from_array(rng.random())
     }
 }
 
@@ -340,8 +340,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -353,8 +353,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -366,8 +366,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedQM31::from_array(values);
 
         let res = -packed_values;

--- a/crates/stwo/src/prover/channel/logging_channel.rs
+++ b/crates/stwo/src/prover/channel/logging_channel.rs
@@ -134,14 +134,14 @@ mod tests {
         let mut regular_channel = Blake2sChannel::default();
 
         let felts = vec![
-            rng.gen::<SecureField>(),
-            rng.gen::<SecureField>(),
-            rng.gen::<SecureField>(),
+            rng.random::<SecureField>(),
+            rng.random::<SecureField>(),
+            rng.random::<SecureField>(),
         ];
         logging_channel.mix_felts(&felts);
         regular_channel.mix_felts(&felts);
 
-        let value = rng.gen::<u64>();
+        let value = rng.random::<u64>();
         logging_channel.mix_u64(value);
         regular_channel.mix_u64(value);
 
@@ -149,7 +149,7 @@ mod tests {
         let felt2 = regular_channel.draw_secure_felt();
         assert_eq!(felt1, felt2);
 
-        let n_felts = rng.gen_range(1..10);
+        let n_felts = rng.random_range(1..10);
         let felts1 = logging_channel.draw_secure_felts(n_felts);
         let felts2 = regular_channel.draw_secure_felts(n_felts);
         assert_eq!(felts1, felts2);


### PR DESCRIPTION
This PR upgrades the `rand` crate to `0.9.2`, updating the APIs properly following some changes:

- Rename module rand::distributions to rand::distr (https://github.com/rust-random/rand/pull/1470)
- Rename distribution Standard to StandardUniform (https://github.com/rust-random/rand/pull/1526)
- Rename fn Rng::gen to random to avoid conflict with the new gen keyword in Rust 2024 (https://github.com/rust-random/rand/pull/1438)

The motivation for this PR is to allow updating Stwo to use the 2024 Rust edition going forward.