### PR TITLE
fix: replace unsafe zeroed() with MaybeUninit in split_at

### DIFF
--- a/crates/air-utils-derive/src/iterable_field.rs
+++ b/crates/air-utils-derive/src/iterable_field.rs
@@ -260,15 +260,15 @@ impl IterableField {
                 let tail = format_ident!("{}_tail", name);
                 let array_size = &array_of_vecs.outer_array_size;
                 quote! {
-                    let (
-                        mut #head,
-                        mut #tail
-                    ):([_; #array_size],[_; #array_size])  = unsafe { (std::mem::zeroed(), std::mem::zeroed()) };
+                    let mut #head: [std::mem::MaybeUninit<_>; #array_size] = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+                    let mut #tail: [std::mem::MaybeUninit<_>; #array_size] = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
                     self.#name.into_iter().enumerate().for_each(|(i, v)| {
-                        let (head, tail) = v.split_at_mut(#index);
-                        #head[i] = head;
-                        #tail[i] = tail;
+                        let (head_val, tail_val) = v.split_at_mut(#index);
+                        #head[i].write(head_val);
+                        #tail[i].write(tail_val);
                     });
+                    let #head = unsafe { std::mem::MaybeUninit::array_assume_init(#head) };
+                    let #tail = unsafe { std::mem::MaybeUninit::array_assume_init(#tail) };
                 }
             }
         }

--- a/crates/air-utils-derive/src/par_iter.rs
+++ b/crates/air-utils-derive/src/par_iter.rs
@@ -69,7 +69,6 @@ fn generate_row_producer(
             type Item = #mut_chunk_name<#lifetime>;
             type IntoIter = #iter_mut_name<#lifetime>;
 
-            #[allow(invalid_value)]
             fn split_at(self, index: usize) -> (Self, Self) {
                 #(#split_at)*
                 (


### PR DESCRIPTION
Replace std::mem::zeroed() with MaybeUninit for safe array initialization in ArrayOfVecs split_at method. 
References don't have a zero representation, so zeroed() was creating invalid values leading to potential UB.

The fix uses MaybeUninit arrays that are safely initialized element by element before being converted to initialized arrays via array_assume_init().
Also removed the #[allow(invalid_value)] attribute that's no longer needed.