### PR TITLE
fix: use prefixed_digest in non-parallel poseidon grind path

### DIFF
--- a/crates/stwo/src/prover/backend/simd/grind.rs
+++ b/crates/stwo/src/prover/backend/simd/grind.rs
@@ -146,7 +146,7 @@ pub mod poseidon252 {
             ]);
             #[cfg(not(feature = "parallel"))]
             let res = (0..)
-                .find_map(|hi| grind_poseidon(digest, hi, pow_bits))
+                .find_map(|hi| grind_poseidon(prefixed_digest, hi, pow_bits))
                 .expect("Grind failed to find a solution.");
 
             #[cfg(feature = "parallel")]


### PR DESCRIPTION
Fixes #1216

The non-parallel path in `grind` for `Poseidon252Channel` was using `digest` instead of `prefixed_digest`, causing the test to fail and triggering an unused variable warning.

Changed line 149 to use `prefixed_digest` to match the parallel path and the `verify_pow_nonce` logic.