### PR TITLE
fix(simd): Prevent integer underflow in compute_coset_twiddles

### DIFF
--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -558,6 +558,8 @@ fn compute_small_coset_twiddles(coset: Coset) -> TwiddleTree<SimdBackend> {
 
 /// Computes the twiddles of the coset in bit-reversed order. Optimized for SIMD.
 fn compute_coset_twiddles(coset: Coset, twiddles: &mut Vec<PackedM31>) {
+    let coset_log_size = coset.log_size();
+    assert!(coset_log_size > 0);
     let log_size = coset.log_size() - 1;
     assert!(log_size >= LOG_N_LANES);
 


### PR DESCRIPTION
Hello! I found a little problem - If coset.log_size() returns 0, integer underflow will occur before the assertion is executed.