### PR TITLE
fix: clarify PointEvaluationAccumulator::accumulate comment

### DIFF
--- a/crates/stwo/src/core/air/accumulation.rs
+++ b/crates/stwo/src/core/air/accumulation.rs
@@ -25,7 +25,7 @@ impl PointEvaluationAccumulator {
         }
     }
 
-    /// Accumulates u_i(P0), a polynomial evaluation at a P0 in reverse order.
+    /// Accumulates u_i(P0), where the i-th evaluation is multiplied by alpha^(N-1-i).
     pub fn accumulate(&mut self, evaluation: SecureField) {
         self.accumulation = self.accumulation * self.random_coeff + evaluation;
     }


### PR DESCRIPTION
Fixed a confusing comment in `PointEvaluationAccumulator::accumulate`.

The comment said "in reverse order" which was ambiguous - it wasn't clear whether it meant the evaluations themselves or the alpha powers. 
After checking the implementation and the formula, I realized it's about the alpha powers being applied in reverse order relative to indices.

Updated the comment to be more explicit about what's actually happening, matching the documentation on line 11. Should make the code easier to understand.