### PR TITLE
fix: remove redundant clone in ArrayOfVecs construction

### DIFF
--- a/crates/air-utils-derive/src/iterable_field.rs
+++ b/crates/air-utils-derive/src/iterable_field.rs
@@ -41,7 +41,7 @@ impl IterableField {
                     vis: field.vis.clone(),
                     name: field.ident.clone().unwrap(),
                     outer_array_size: outer_array.len.clone(),
-                    inner_type: inner_type.clone(),
+                    inner_type,
                 }))
             }
             // Case that type is Vec<T>.


### PR DESCRIPTION
Removed unnecessary .clone() call on inner_type variable in iterable_field.rs. The value is moved into the struct and not used afterwards, so cloning wastes resources. 

All tests passed.