### PR TITLE
fix(constraint-framework): remove duplicate code and fix AddAssign

### DIFF
--- a/crates/constraint-framework/src/expr/assignment.rs
+++ b/crates/constraint-framework/src/expr/assignment.rs
@@ -111,7 +111,7 @@ impl AddAssign for ExprVariables {
     fn add_assign(&mut self, rhs: Self) {
         self.cols = self.cols.union(&rhs.cols).cloned().collect();
         self.params = self.params.union(&rhs.params).cloned().collect();
-        self.cols = self.cols.union(&rhs.cols).cloned().collect();
+        self.ext_params = self.ext_params.union(&rhs.ext_params).cloned().collect();
     }
 }
 

--- a/crates/constraint-framework/src/lib.rs
+++ b/crates/constraint-framework/src/lib.rs
@@ -64,7 +64,6 @@ pub trait EvalAtRow {
         + Mul<BaseField, Output = Self::F>
         + Add<SecureField, Output = Self::EF>
         + Mul<SecureField, Output = Self::EF>
-        + Neg<Output = Self::F>
         + From<BaseField>;
 
     /// A field type representing the closure of `F` with multiplying by [SecureField]. Constraints


### PR DESCRIPTION
Removed duplicate Neg trait bound in EvalAtRow::F.

Fixed copy-paste bug in AddAssign for ExprVariables - ext_params field wasn't being merged, causing silent data loss.