### PR TITLE
log compoisition polynomial degree bound

### DIFF
--- a/crates/examples/src/xor/gkr_lookups/mle_eval.rs
+++ b/crates/examples/src/xor/gkr_lookups/mle_eval.rs
@@ -846,6 +846,7 @@ mod tests {
         let components = Components {
             components: components.iter().map(|&c| c as &dyn Component).collect(),
             n_preprocessed_columns: 0,
+            all_preprocessed_columns: false,
         };
 
         let log_sizes = components.column_log_sizes();
@@ -937,6 +938,7 @@ mod tests {
         let components = Components {
             components: vec![&mle_coeffs_col_component, &mle_eval_component],
             n_preprocessed_columns: 0,
+            all_preprocessed_columns: false,
         };
 
         let log_sizes = components.column_log_sizes();

--- a/crates/stwo/src/core/air/components.rs
+++ b/crates/stwo/src/core/air/components.rs
@@ -13,6 +13,8 @@ use crate::core::ColumnVec;
 pub struct Components<'a> {
     pub components: Vec<&'a dyn Component>,
     pub n_preprocessed_columns: usize,
+    /// Whether `maks_points` should include all preprocessed columns, regardles of usage.
+    pub all_preprocessed_columns: bool,
 }
 
 impl Components<'_> {
@@ -36,11 +38,14 @@ impl Components<'_> {
         );
 
         let preprocessed_mask_points = &mut mask_points[PREPROCESSED_TRACE_IDX];
-        *preprocessed_mask_points = vec![vec![]; self.n_preprocessed_columns];
-
-        for component in &self.components {
-            for idx in component.preprocessed_column_indices() {
-                preprocessed_mask_points[idx] = vec![point];
+        if self.all_preprocessed_columns {
+            *preprocessed_mask_points = vec![vec![point]; self.n_preprocessed_columns];
+        } else {
+            *preprocessed_mask_points = vec![vec![]; self.n_preprocessed_columns];
+            for component in &self.components {
+                for idx in component.preprocessed_column_indices() {
+                    preprocessed_mask_points[idx] = vec![point];
+                }
             }
         }
 

--- a/crates/stwo/src/core/verifier.rs
+++ b/crates/stwo/src/core/verifier.rs
@@ -28,6 +28,7 @@ pub fn verify<MC: MerkleChannel>(
     let components = Components {
         components: components.to_vec(),
         n_preprocessed_columns,
+        all_preprocessed_columns: false,
     };
     let composition_log_size = components.composition_log_degree_bound();
     tracing::info!(

--- a/crates/stwo/src/prover/air/component_prover.rs
+++ b/crates/stwo/src/prover/air/component_prover.rs
@@ -93,6 +93,7 @@ impl<B: Backend> ComponentProvers<'_, B> {
                 .map(|c| *c as &dyn Component)
                 .collect_vec(),
             n_preprocessed_columns: self.n_preprocessed_columns,
+            all_preprocessed_columns: false,
         }
     }
     pub fn compute_composition_polynomial(


### PR DESCRIPTION
log compoisition polynomial degree bound

renamed stwo-prover to stwo

removed artifacts from bad rebase

removed mask module

hashbrown instead of std hashmap

stwo-air-utils to take stwo with prover feature

downgrade hashbrown version

no std verifier

Add remainder length to poseidon hash_node (#1166)

stop using assert_matches

no longet using is_empty on ExactSizedIterators

stop using array windows unstable feature

no longer using iter_array_chunks in non-prover builds

stop using unstable remove_try_from_fn_array

feature flagged porable_imd in constraint-framework

stable rust ci tests for no-prover tests

relaxed cargo lint denies

rfft throughput benchmark

fixed pow performance bug

fixed pow bug

fixed doc for MekleProver 'commit'

added typos check in CI

Bump_rust_toolchain (#1187)

Rename preproccessed into preprocessed (#1189)

Update pow_bits in default PcsConfig (#1192)

Use poseidon_hash2. (#1194)

Add length pad to poseidon mix_u32s.

Length Padding Function

Domain Seperation in Blake

domain separation in poseidon252 channel (#1199)

Split PoW verification from nonce mixing. (#1197)

Remove ChannelTime. (#1200)

Change n_draws from usize to u32. (#1202)

Simplify accumulate_row_quotients. (#1201)

Add domain separation to Blake2sMerkleHasher. (#1203)

Add draw_u32s and remove draw_random_bytes. (#1204)

Add zeros in the middle for blake pow verification. (#1205)

Add split_at_mid to Column (#1208)

grind(): Make fields inside hash 16-byte aligned. (#1215)

Add CirclePoly split_at_mid (#1223)

SecurePoly split_at_mid (#1224)

Split composition poly into 2 (#1225)

Add unsorted_query_locations to prover output. (#1226)

Add Blake2sM31Channel. (#1219)

Add ExtendedFriProof with a map of all FRI values involved in the proof. (#1228)

commit-id:aaae180e

Add traits for lifted vcs. (#1220)

Implement MerkleHasherLifted for Blake. (#1221)

Add Merkle prover in bit reverse. (#1227)

Add Merkle tree node infromation to the proof. (#1229)

commit-id:9e162d13

Evaluation By Folding

Evaluation by Folding Bench

Poly Struct for Storing Trace Polynomials

change variable name (#1239)

Store Trace Polys in Poly Struct

Rename CirclePoly -> CircleCoefficients

Skip layers with no samples. (#1236)

Boxed Air Utils

Boxed Air Utils Derive

Barycentric Evaluation

Remove unneccesary feature cfg. (#1265)

Calculate Barycentric Weights Only When Necessary (#1279)

Change alerting target. (#1268)

Fix non-parallel bug and modify CI. (#1290)

Currently the CI misses the stwo tests with feature prover enabled but
without parallel.

Made clippy script more extensive + fixed issue (#1295)

Turns out a per-crate clippy catches issues that are not caught with a workspace level clippy (due to features sets differences)

Cleaned up some clippy allows (#1298)

Add column log size print (#1303)

Parallelize fft over columns (#1304)

Parallel denominator_inverses in simd quotients (#1305)

Removed unused file (#1299)

Parallelize OOD evaluation. (#1306)

Merge lifted into dev. (#1307)

* Add lifted Merkle verifier. (#1234)

* Add SIMD MerkleOpsLifted. (#1235)

* Add auxiliary structs to vcs_lifted. (#1247)

* Add generic blake for lifted vcs. (#1252)

* Change queries from vec to slice. (#1250)

* Add lift_and_accumulate. (#1245)

* Modify finalize of DomainEvaluationAccumulator. (#1246)

* Add skeleton of lifted quotient ops. (#1248)

All the code related to the previous architecture of quotient ops has
been removed.

* Add empty poseidon merkle hasher lifted. (#1253)

* Change channel's assoc type to MerkleHasherLifted. (#1254)

* Add CPU QuotientOps impl. (#1249)

* Make pcs prove lifted values. (#1251)

* Add pcs verifier lifted. (#1255)

* Modify trace step in masks and eval at point. (#1257)

* Add CpuBackend impl to ComponentProver. (#1258)

* Add mixed wide fibonacci test. (#1259)

* Add m31 blake hasher to simd. (#1260)

* Allow small traces with cpu, fix bug. (#1261)

* Add lift and accumulate in simd. (#1262)

* Add simd impl of accumulate_numerators. (#1263)

* Add `compute_quotients_and_combine`. (#1266)

* Change fri decommit to return a vec of query positions. (#1269)

* Commit to a single column in fri. (#1270)

* Update docs and rename. (#1271)

* Remove iterations in fri verifier decommit. (#1272)

* Remove unneeded structure. (#1273)

* Update docs. (#1274)

* Add poseidon hasher. (#1283)

* Add SIMD implementation of poseidon MerkleOpsLifted. (#1280)

* Adapt the queries for the preprocessed trees. (#1281)

Co-authored-by: Alon F <alonf@starkware.co>

* Fix non-parallel bugs. (#1287)

* Adapt barycentric weights to the lifted protocol. (#1288)

* Change order of the alphas to the samples order. (#1292)

* Change queried values layout. (#1293)

* Add periodicity samples. (#1294)

* Improve performance of cpu merkle. (#1284)

* Fix lifting size in fri_answers and add test. (#1296)

* Optimize blake simd merkle lifted. (#1291)

* Add maximal size periodicity checks. (#1301)

* Add dummy serde and reexport MerkleHasherLifted. (#1297)

These changes make it easier to integrate with stwo_cairo_prover.

---------

Co-authored-by: Alon F <alonf@starkware.co>

Fix names in test. (#1309)

Add FrameworkComponent.is_enabled. (#1308)

Add serde for auxialiary proof types. (#1310)

Updated documentation. (#1313)

Bump version to 2.0.0. (#1314)

Fix workspace deps. (#1315)

Add crates description. (#1316)

Update LookupElements::dummy. (#1319)

make BaseColumn::from_cpu run without taking ownership over input (#1318)

Change pcs config mixing (#1320)

Add an option to include all the preprocessed columns in the proof.