### PR TITLE
Add CommitmentSchemeProver::commit_tree for pre-built trees

### DIFF
--- a/crates/stwo/benches/pcs.rs
+++ b/crates/stwo/benches/pcs.rs
@@ -3,7 +3,6 @@ use std::iter;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use stwo::core::channel::Blake2sChannel;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::poly::circle::CanonicCoset;
 use stwo::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
@@ -21,7 +20,6 @@ const N_POLYS: usize = 16;
 
 fn benched_fn<B: BackendForChannel<Blake2sMerkleChannel>>(
     evals: Vec<CircleEvaluation<B, BaseField, BitReversedOrder>>,
-    channel: &mut Blake2sChannel,
     twiddles: &TwiddleTree<B>,
 ) {
     let polys = evals
@@ -32,7 +30,6 @@ fn benched_fn<B: BackendForChannel<Blake2sMerkleChannel>>(
     CommitmentTreeProver::<B, Blake2sMerkleChannel>::new(
         polys,
         LOG_BLOWUP_FACTOR,
-        channel,
         twiddles,
         false,
         None,
@@ -44,7 +41,6 @@ fn bench_pcs<B: BackendForChannel<Blake2sMerkleChannel>>(c: &mut Criterion, id: 
     let small_domain = CanonicCoset::new(LOG_COSET_SIZE);
     let big_domain = CanonicCoset::new(LOG_COSET_SIZE + LOG_BLOWUP_FACTOR);
     let twiddles = B::precompute_twiddles(big_domain.half_coset());
-    let mut channel = Blake2sChannel::default();
     let mut rng = SmallRng::seed_from_u64(0);
 
     let evals: Vec<CircleEvaluation<B, BaseField, BitReversedOrder>> = iter::repeat_with(|| {
@@ -61,13 +57,7 @@ fn bench_pcs<B: BackendForChannel<Blake2sMerkleChannel>>(c: &mut Criterion, id: 
         |b| {
             b.iter_batched(
                 || evals.clone(),
-                |evals| {
-                    benched_fn::<B>(
-                        black_box(evals),
-                        black_box(&mut channel),
-                        black_box(&twiddles),
-                    )
-                },
+                |evals| benched_fn::<B>(black_box(evals), black_box(&twiddles)),
                 BatchSize::LargeInput,
             );
         },

--- a/crates/stwo/src/prover/pcs/mod.rs
+++ b/crates/stwo/src/prover/pcs/mod.rs
@@ -32,7 +32,7 @@ pub mod quotient_ops;
 
 /// The prover side of a FRI polynomial commitment scheme. See [super].
 pub struct CommitmentSchemeProver<'a, B: BackendForChannel<MC>, MC: MerkleChannel> {
-    pub trees: TreeVec<CommitmentTreeProver<B, MC>>,
+    pub trees: TreeVec<MaybeOwned<'a, CommitmentTreeProver<B, MC>>>,
     pub config: PcsConfig,
     twiddles: &'a TwiddleTree<B>,
     pub store_polynomials_coefficients: bool,
@@ -72,17 +72,30 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
         self.store_polynomials_coefficients = true;
     }
 
+    /// Evaluates the given polynomials, commits them into a Merkle tree, mixes the root into
+    /// the channel, and appends the resulting tree to the scheme.
     fn commit(&mut self, polynomials: ColumnVec<CircleCoefficients<B>>, channel: &mut MC::C) {
         let _span = span!(Level::INFO, "Commitment").entered();
         let tree = CommitmentTreeProver::new(
             polynomials,
             self.config.fri_config.log_blowup_factor,
-            channel,
             self.twiddles,
             self.store_polynomials_coefficients,
             self.config.lifting_log_size,
             &self.base_column_pool,
         );
+        MC::mix_root(channel, tree.commitment.root());
+        self.trees.push(MaybeOwned::Owned(tree));
+    }
+
+    /// Appends an externally constructed [`CommitmentTreeProver`] to the scheme and mixes its
+    /// Merkle root into the channel. Accepts both owned and borrowed trees.
+    pub fn commit_tree(
+        &mut self,
+        tree: MaybeOwned<'a, CommitmentTreeProver<B, MC>>,
+        channel: &mut MC::C,
+    ) {
+        MC::mix_root(channel, tree.commitment.root());
         self.trees.push(tree);
     }
 
@@ -268,11 +281,13 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
             .map(|(v, x)| (v, x.decommitment, x.aux))
             .multiunzip();
 
-        // Return evaluation buffers to the memory pool for reuse.
+        // Return evaluation buffers to the memory pool for reuse (owned trees only).
         for tree in &mut self.trees.0 {
-            for poly in tree.polynomials.drain(..) {
-                let log_size = poly.evals.domain.log_size();
-                self.base_column_pool.give_back(log_size, poly.evals.values);
+            if let MaybeOwned::Owned(tree) = tree {
+                for poly in tree.polynomials.drain(..) {
+                    let log_size = poly.evals.domain.log_size();
+                    self.base_column_pool.give_back(log_size, poly.evals.values);
+                }
             }
         }
 
@@ -344,7 +359,6 @@ impl<B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentTreeProver<B, MC> {
     pub fn new(
         polynomials: ColumnVec<CircleCoefficients<B>>,
         log_blowup_factor: u32,
-        channel: &mut MC::C,
         twiddles: &TwiddleTree<B>,
         store_polynomials_coefficients: bool,
         lifting_log_size: Option<u32>,
@@ -374,7 +388,6 @@ impl<B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentTreeProver<B, MC> {
                 .collect(),
             lifting_log_size,
         );
-        MC::mix_root(channel, tree.root());
 
         CommitmentTreeProver {
             polynomials,


### PR DESCRIPTION
Move MC::mix_root out of CommitmentTreeProver::new so that trees can be constructed independently of the Fiat-Shamir channel. The root is now mixed in by CommitmentSchemeProver::commit (internal) and the new public commit_tree method, which accepts an externally built CommitmentTreeProver.