### PR TITLE
Pass twiddles to DomainEvaluationAccumulator.finalize.

### DIFF
--- a/crates/stwo/src/prover/air/accumulation.rs
+++ b/crates/stwo/src/prover/air/accumulation.rs
@@ -12,6 +12,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::poly::circle::CanonicCoset;
 use crate::prover::backend::{Backend, Col, Column, ColumnOps, CpuBackend};
 use crate::prover::poly::circle::{CircleCoefficients, CircleEvaluation, SecureCirclePoly};
+use crate::prover::poly::twiddles::TwiddleTree;
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
 
@@ -86,7 +87,8 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
     }
 
     /// Computes f(P) as coefficients.
-    pub fn finalize(self) -> SecureCirclePoly<B> {
+    /// `twiddles` must be precomputed for the max-size canonical domain's half coset.
+    pub fn finalize(self, twiddles: &TwiddleTree<B>) -> SecureCirclePoly<B> {
         assert_eq!(
             self.random_coeff_powers.len(),
             0,
@@ -106,15 +108,12 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
         if let Some(eval) = lifted_accumulation {
             // `lifted_accumulation` must be of size `log_size`, i.e. there must at least one sub
             // accumulation of size `log_size`.
-            let twiddles =
-                B::precompute_twiddles(CanonicCoset::new(log_size).circle_domain().half_coset);
-
             SecureCirclePoly(eval.columns.map(|c| {
                 CircleEvaluation::<B, BaseField, BitReversedOrder>::new(
                     CanonicCoset::new(log_size).circle_domain(),
                     c,
                 )
-                .interpolate_with_twiddles(&twiddles)
+                .interpolate_with_twiddles(twiddles)
             }))
         } else {
             SecureCirclePoly(std::array::from_fn(|_| {
@@ -168,6 +167,7 @@ mod tests {
     use crate::core::circle::CirclePoint;
     use crate::core::fields::m31::M31;
     use crate::prover::backend::cpu::CpuCircleEvaluation;
+    use crate::prover::poly::circle::PolyOps;
     use crate::qm31;
 
     #[test]
@@ -229,7 +229,12 @@ mod tests {
             }
             eval_chunk_offset += n_cols;
         }
-        let accumulator_poly = accumulator.finalize();
+        let twiddles = CpuBackend::precompute_twiddles(
+            CanonicCoset::new(LOG_SIZE_BOUND - 1)
+                .circle_domain()
+                .half_coset,
+        );
+        let accumulator_poly = accumulator.finalize(&twiddles);
 
         // Pick an arbitrary sample point.
         let point = CirclePoint::<SecureField>::get_point(98989892);

--- a/crates/stwo/src/prover/air/component_prover.rs
+++ b/crates/stwo/src/prover/air/component_prover.rs
@@ -99,6 +99,7 @@ impl<B: Backend> ComponentProvers<'_, B> {
         &self,
         random_coeff: SecureField,
         trace: &Trace<'_, B>,
+        twiddles: &TwiddleTree<B>,
     ) -> SecureCirclePoly<B> {
         let total_constraints: usize = self.components.iter().map(|c| c.n_constraints()).sum();
         let mut accumulator = DomainEvaluationAccumulator::new(
@@ -109,6 +110,6 @@ impl<B: Backend> ComponentProvers<'_, B> {
         for component in &self.components {
             component.evaluate_constraint_quotients_on_domain(trace, &mut accumulator)
         }
-        accumulator.finalize()
+        accumulator.finalize(twiddles)
     }
 }

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -60,7 +60,12 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
         class = "CompositionPolynomialGeneration"
     )
     .entered();
-    let composition_poly = component_provers.compute_composition_polynomial(random_coeff, &trace);
+
+    let composition_poly = component_provers.compute_composition_polynomial(
+        random_coeff,
+        &trace,
+        commitment_scheme.twiddles,
+    );
     span1.exit();
 
     // Commit on the Composition Polynomial by splitting its coeffs to two polynomialsof degree

--- a/crates/stwo/src/prover/pcs/mod.rs
+++ b/crates/stwo/src/prover/pcs/mod.rs
@@ -34,7 +34,7 @@ pub mod quotient_ops;
 pub struct CommitmentSchemeProver<'a, B: BackendForChannel<MC>, MC: MerkleChannel> {
     pub trees: TreeVec<MaybeOwned<'a, CommitmentTreeProver<B, MC>>>,
     pub config: PcsConfig,
-    twiddles: &'a TwiddleTree<B>,
+    pub twiddles: &'a TwiddleTree<B>,
     pub store_polynomials_coefficients: bool,
     /// Pre-allocated base field column pool for polynomial evaluation during commit.
     pub base_column_pool: MaybeOwned<'a, BaseColumnPool<B>>,


### PR DESCRIPTION
`finalize()` was precomputing twiddles internally for interpolation, but the same twiddles are already available in `CommitmentSchemeProver`. Pass them in instead to avoid redundant precomputation.

- Add a `twiddles: &TwiddleTree<B>` parameter to `finalize()` and `compute_composition_polynomial()`.
- Make `CommitmentSchemeProver.twiddles` public so the caller in `prove_ex` can thread the existing twiddles through.