### PR TITLE
feat: common subdomain optimization for SIMD constraint evaluation

### DIFF
--- a/crates/constraint-framework/src/prover/component_prover.rs
+++ b/crates/constraint-framework/src/prover/component_prover.rs
@@ -8,7 +8,7 @@ use stwo::core::constraints::coset_vanishing;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::pcs::TreeVec;
-use stwo::core::poly::circle::CanonicCoset;
+use stwo::core::poly::circle::{CanonicCoset, CircleDomain};
 use stwo::core::utils::bit_reverse;
 use stwo::prover::backend::simd::column::VeryPackedSecureColumnByCoords;
 use stwo::prover::backend::simd::m31::LOG_N_LANES;
@@ -51,43 +51,43 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
             .map(|idx| &trace.polys[PREPROCESSED_TRACE_IDX][*idx])
             .collect();
 
-        // Extend trace if necessary.
-        // TODO: Don't extend when eval_size < committed_size. Instead, pick a good
-        // subdomain. (For larger blowup factors).
-        let need_to_extend = component_polys
-            .iter()
-            .flatten()
-            .any(|c| c.evals.domain.log_size() != eval_domain.log_size());
-        let trace: TreeVec<
-            Vec<Cow<'_, CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>>,
-        > = if need_to_extend {
+        // Common subdomain optimization: if all committed columns are at least as large as
+        // eval_domain, we can evaluate on a common subdomain instead of extending.
+        let (actual_eval_domain, trace) = if let Some(subdomain) = try_get_common_subdomain(
+            component_polys.iter().flatten().map(|c| c.evals.domain),
+            eval_domain,
+        ) {
+            // Common subdomain path: borrow all columns as-is. The evaluator only accesses
+            // indices within the subdomain range, so larger columns are safe to borrow.
+            // When the subdomain is non-canonical, finalize() shifts the accumulated
+            // result back to the canonical domain via IFFT+FFT.
+            let trace = component_polys.map_cols(|c| Cow::Borrowed(&c.evals));
+            (subdomain, trace)
+        } else {
+            // Extension path: some columns are smaller than eval_domain.
             let _span = span!(Level::INFO, "Constraint Extension").entered();
             let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
             #[cfg(not(feature = "parallel"))]
-            {
-                component_polys.as_cols_ref().map_cols(|col| {
-                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
-                })
-            }
+            let trace = component_polys
+                .as_cols_ref()
+                .map_cols(|col| Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles)));
             #[cfg(feature = "parallel")]
-            {
-                component_polys.as_cols_ref().par_map_cols(|col| {
-                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
-                })
-            }
-        } else {
-            component_polys.map_cols(|c| Cow::Borrowed(&c.evals))
+            let trace = component_polys.as_cols_ref().par_map_cols(|col| {
+                Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
+            });
+            (eval_domain, trace)
         };
 
         // Denom inverses.
-        let log_expand = eval_domain.log_size() - trace_domain.log_size();
+        let log_expand = actual_eval_domain.log_size() - trace_domain.log_size();
         let mut denom_inv = (0..1 << log_expand)
-            .map(|i| coset_vanishing(trace_domain.coset(), eval_domain.at(i)).inverse())
+            .map(|i| coset_vanishing(trace_domain.coset(), actual_eval_domain.at(i)).inverse())
             .collect_vec();
         bit_reverse(&mut denom_inv);
 
         // Note that `accum` is a mutable reference to a column in `evaluation_accumulator`.
-        let [mut accum] = evaluation_accumulator.columns([(eval_domain, self.n_constraints())]);
+        let [mut accum] =
+            evaluation_accumulator.columns([(actual_eval_domain, self.n_constraints())]);
         accum.random_coeff_powers.reverse();
 
         let _span = span!(
@@ -104,7 +104,7 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
             *accum.col = SecureColumnByCoords::from_cpu(accumulate_pointwise_cpu(
                 self,
                 trace_cols,
-                eval_domain.log_size(),
+                actual_eval_domain.log_size(),
                 trace_domain.log_size(),
                 denom_inv,
                 &accum.random_coeff_powers,
@@ -115,7 +115,8 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
 
         let col = unsafe { VeryPackedSecureColumnByCoords::transform_under_mut(accum.col) };
 
-        let range = 0..(1 << (eval_domain.log_size() - LOG_N_LANES - LOG_N_VERY_PACKED_ELEMS));
+        let range =
+            0..(1 << (actual_eval_domain.log_size() - LOG_N_LANES - LOG_N_VERY_PACKED_ELEMS));
 
         #[cfg(not(feature = "parallel"))]
         let iter = range.step_by(CHUNK_SIZE).zip(col.chunks_mut(CHUNK_SIZE));
@@ -142,7 +143,7 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
                     vec_row,
                     &accum.random_coeff_powers,
                     trace_domain.log_size(),
-                    eval_domain.log_size(),
+                    actual_eval_domain.log_size(),
                     self_eval.log_size(),
                     self_claimed_sum,
                 );
@@ -239,6 +240,53 @@ impl<E: FrameworkEval + Sync> ComponentProver<CpuBackend> for FrameworkComponent
             accum.col,
         );
     }
+}
+
+/// Checks if all committed columns can be evaluated on a common subdomain of the given
+/// `eval_log_size`, avoiding the need for trace extension.
+///
+/// Returns `Some(subdomain)` if all columns have `committed_log_size >= eval_log_size` and all
+/// columns that need slicing share the same committed domain (so they split to the same
+/// subdomain). When all columns exactly match `eval_log_size`, returns `Some(eval_domain)`.
+/// Returns `None` if any column requires extension.
+fn try_get_common_subdomain(
+    committed_domains: impl Iterator<Item = CircleDomain>,
+    eval_domain: CircleDomain,
+) -> Option<CircleDomain> {
+    let eval_log_size = eval_domain.log_size();
+    let mut common_subdomain: Option<CircleDomain> = None;
+
+    for committed_domain in committed_domains {
+        let committed_log_size = committed_domain.log_size();
+
+        if committed_log_size < eval_log_size {
+            // Column is smaller than eval domain — must extend, can't use common subdomain.
+            return None;
+        }
+
+        if committed_log_size == eval_log_size {
+            // Column already matches eval size — no slicing needed.
+            continue;
+        }
+
+        // Column is larger — compute its subdomain.
+        let log_parts = committed_log_size - eval_log_size;
+        let (subdomain, _) = committed_domain.split(log_parts);
+
+        match common_subdomain {
+            None => common_subdomain = Some(subdomain),
+            Some(existing) if existing == subdomain => {}
+            Some(_) => {
+                // Columns of different sizes split into subdomains with different
+                // initial_index (different cosets), so there's no single subdomain
+                // we can evaluate all columns on.
+                return None;
+            }
+        }
+    }
+
+    // If no column was larger, all matched eval_log_size — use eval_domain directly.
+    Some(common_subdomain.unwrap_or(eval_domain))
 }
 
 fn accumulate_pointwise_cpu<E: FrameworkEval>(

--- a/crates/examples/src/blake/air.rs
+++ b/crates/examples/src/blake/air.rs
@@ -519,10 +519,16 @@ pub fn verify_blake<MC: MerkleChannel>(
 mod tests {
     use std::env;
 
+    use stwo::core::fri::FriConfig;
     use stwo::core::pcs::PcsConfig;
     use stwo::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
 
     use crate::blake::air::{prove_blake, verify_blake};
+
+    fn prove_and_verify_blake(log_n_instances: u32, config: PcsConfig) {
+        let proof = prove_blake::<Blake2sMerkleChannel>(log_n_instances, config);
+        verify_blake::<Blake2sMerkleChannel>(proof).unwrap();
+    }
 
     // Note: this test is slow. Only run in release.
     #[cfg_attr(not(feature = "slow-tests"), ignore)]
@@ -538,12 +544,20 @@ mod tests {
             .unwrap_or_else(|_| "6".to_string())
             .parse::<u32>()
             .unwrap();
-        let config = PcsConfig::default();
+        prove_and_verify_blake(log_n_instances, PcsConfig::default());
+    }
 
-        // Prove.
-        let proof = prove_blake::<Blake2sMerkleChannel>(log_n_instances, config);
-
-        // Verify.
-        verify_blake::<Blake2sMerkleChannel>(proof).unwrap();
+    /// Tests blake prove with log_blowup_factor=2, which triggers the common subdomain
+    /// optimization (committed columns are larger than the eval domain).
+    /// This exercises constraints with non-zero offsets (logup uses [-1, 0]) on
+    /// non-canonical subdomains.
+    #[cfg_attr(not(feature = "slow-tests"), ignore)]
+    #[test_log::test]
+    fn test_simd_blake_prove_large_blowup() {
+        let config = PcsConfig {
+            fri_config: FriConfig::new(0, 2, 3, 1),
+            ..PcsConfig::default()
+        };
+        prove_and_verify_blake(6, config);
     }
 }

--- a/crates/examples/src/wide_fibonacci/mod.rs
+++ b/crates/examples/src/wide_fibonacci/mod.rs
@@ -184,62 +184,61 @@ mod tests {
         );
     }
 
+    fn prove_and_verify_wide_fib(log_n_instances: u32, config: PcsConfig) {
+        let twiddles = SimdBackend::precompute_twiddles(
+            CanonicCoset::new(log_n_instances + 1 + config.fri_config.log_blowup_factor)
+                .circle_domain()
+                .half_coset,
+        );
+
+        // Setup protocol.
+        let prover_channel = &mut Blake2sM31Channel::default();
+        let mut commitment_scheme =
+            CommitmentSchemeProver::<SimdBackend, Blake2sM31MerkleChannel>::new(config, &twiddles);
+
+        // Preprocessed trace.
+        let mut tree_builder = commitment_scheme.tree_builder();
+        tree_builder.extend_evals(vec![]);
+        tree_builder.commit(prover_channel);
+
+        // Trace.
+        let trace =
+            generate_trace::<FIB_SEQUENCE_LENGTH, _>(&generate_test_inputs(log_n_instances));
+        let mut tree_builder = commitment_scheme.tree_builder();
+        tree_builder.extend_evals(trace);
+        tree_builder.commit(prover_channel);
+
+        // Prove constraints.
+        let component = WideFibonacciComponent::new(
+            &mut TraceLocationAllocator::default(),
+            WideFibonacciEval::<FIB_SEQUENCE_LENGTH> {
+                log_n_rows: log_n_instances,
+            },
+            SecureField::zero(),
+        );
+
+        let proof = prove::<SimdBackend, Blake2sM31MerkleChannel>(
+            &[&component],
+            prover_channel,
+            commitment_scheme,
+        )
+        .unwrap();
+
+        // Verify.
+        let verifier_channel = &mut Blake2sM31Channel::default();
+        let commitment_scheme =
+            &mut CommitmentSchemeVerifier::<Blake2sM31MerkleChannel>::new(config);
+
+        let sizes = component.trace_log_degree_bounds();
+        commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
+        commitment_scheme.commit(proof.commitments[1], &sizes[1], verifier_channel);
+        verify(&[&component], verifier_channel, commitment_scheme, proof).unwrap();
+    }
+
     #[test_log::test]
     fn test_wide_fib_prove_with_blake() {
         for log_n_instances in 4..=8 {
-            let config = PcsConfig::default();
-            // Precompute twiddles.
-            let twiddles = SimdBackend::precompute_twiddles(
-                CanonicCoset::new(log_n_instances + 1 + config.fri_config.log_blowup_factor)
-                    .circle_domain()
-                    .half_coset,
-            );
-
-            // Setup protocol.
-            let prover_channel = &mut Blake2sM31Channel::default();
-            let mut commitment_scheme = CommitmentSchemeProver::<
-                SimdBackend,
-                Blake2sM31MerkleChannel,
-            >::new(config, &twiddles);
-
-            // Preprocessed trace
-            let mut tree_builder = commitment_scheme.tree_builder();
-            tree_builder.extend_evals(vec![]);
-            tree_builder.commit(prover_channel);
-
-            // Trace.
-            let trace =
-                generate_trace::<FIB_SEQUENCE_LENGTH, _>(&generate_test_inputs(log_n_instances));
-            let mut tree_builder = commitment_scheme.tree_builder();
-            tree_builder.extend_evals(trace);
-            tree_builder.commit(prover_channel);
-
-            // Prove constraints.
-            let component = WideFibonacciComponent::new(
-                &mut TraceLocationAllocator::default(),
-                WideFibonacciEval::<FIB_SEQUENCE_LENGTH> {
-                    log_n_rows: log_n_instances,
-                },
-                SecureField::zero(),
-            );
-
-            let proof = prove::<SimdBackend, Blake2sM31MerkleChannel>(
-                &[&component],
-                prover_channel,
-                commitment_scheme,
-            )
-            .unwrap();
-
-            // Verify.
-            let verifier_channel = &mut Blake2sM31Channel::default();
-            let commitment_scheme =
-                &mut CommitmentSchemeVerifier::<Blake2sM31MerkleChannel>::new(config);
-
-            // Retrieve the expected column sizes in each commitment interaction, from the AIR.
-            let sizes = component.trace_log_degree_bounds();
-            commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
-            commitment_scheme.commit(proof.commitments[1], &sizes[1], verifier_channel);
-            verify(&[&component], verifier_channel, commitment_scheme, proof).unwrap();
+            prove_and_verify_wide_fib(log_n_instances, PcsConfig::default());
         }
     }
 
@@ -248,64 +247,12 @@ mod tests {
     fn test_wide_fib_prove_with_blake_with_fri_jumps() {
         for log_n_instances in 4..=8 {
             let mut config = PcsConfig::default();
-            // Test different steps.
             config.fri_config.line_fold_step = if (4..6).contains(&log_n_instances) {
                 2
             } else {
                 3
             };
-            // Precompute twiddles.
-            let twiddles = SimdBackend::precompute_twiddles(
-                CanonicCoset::new(log_n_instances + 1 + config.fri_config.log_blowup_factor)
-                    .circle_domain()
-                    .half_coset,
-            );
-
-            // Setup protocol.
-            let prover_channel = &mut Blake2sM31Channel::default();
-            let mut commitment_scheme = CommitmentSchemeProver::<
-                SimdBackend,
-                Blake2sM31MerkleChannel,
-            >::new(config, &twiddles);
-
-            // Preprocessed trace
-            let mut tree_builder = commitment_scheme.tree_builder();
-            tree_builder.extend_evals(vec![]);
-            tree_builder.commit(prover_channel);
-
-            // Trace.
-            let trace =
-                generate_trace::<FIB_SEQUENCE_LENGTH, _>(&generate_test_inputs(log_n_instances));
-            let mut tree_builder = commitment_scheme.tree_builder();
-            tree_builder.extend_evals(trace);
-            tree_builder.commit(prover_channel);
-
-            // Prove constraints.
-            let component = WideFibonacciComponent::new(
-                &mut TraceLocationAllocator::default(),
-                WideFibonacciEval::<FIB_SEQUENCE_LENGTH> {
-                    log_n_rows: log_n_instances,
-                },
-                SecureField::zero(),
-            );
-
-            let proof = prove::<SimdBackend, Blake2sM31MerkleChannel>(
-                &[&component],
-                prover_channel,
-                commitment_scheme,
-            )
-            .unwrap();
-
-            // Verify.
-            let verifier_channel = &mut Blake2sM31Channel::default();
-            let commitment_scheme =
-                &mut CommitmentSchemeVerifier::<Blake2sM31MerkleChannel>::new(config);
-
-            // Retrieve the expected column sizes in each commitment interaction, from the AIR.
-            let sizes = component.trace_log_degree_bounds();
-            commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
-            commitment_scheme.commit(proof.commitments[1], &sizes[1], verifier_channel);
-            verify(&[&component], verifier_channel, commitment_scheme, proof).unwrap();
+            prove_and_verify_wide_fib(log_n_instances, config);
         }
     }
 
@@ -450,6 +397,22 @@ mod tests {
             proof,
         )
         .is_ok());
+    }
+
+    /// Tests the common subdomain optimization: with log_blowup_factor=2, committed columns are
+    /// larger than the eval domain, so we slice a common subdomain instead of extending.
+    #[test_log::test]
+    fn test_wide_fib_prove_with_large_blowup_factor() {
+        use stwo::core::fri::FriConfig;
+
+        for log_n_instances in 5..=8 {
+            let config = PcsConfig {
+                pow_bits: 10,
+                fri_config: FriConfig::new(0, 2, 3, 1),
+                lifting_log_size: None,
+            };
+            prove_and_verify_wide_fib(log_n_instances, config);
+        }
     }
 
     #[test]


### PR DESCRIPTION
When committed columns are larger than the eval domain (log_blowup_factor > log_constraint_degree),
slice a common subdomain instead of extending via IFFT+FFT. The non-canonical
subdomain is converted back to canonical in DomainEvaluationAccumulator::finalize().

Also refactors wide_fibonacci prove tests to share a common helper and adds a test
with log_blowup_factor=2 that exercises the common subdomain path.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>