### PR TITLE
feat: add EvaluationMode enum to DomainEvaluationAccumulator

### DIFF
--- a/crates/constraint-framework/src/prover/component_prover.rs
+++ b/crates/constraint-framework/src/prover/component_prover.rs
@@ -8,17 +8,17 @@ use stwo::core::constraints::coset_vanishing;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::pcs::TreeVec;
-use stwo::core::poly::circle::CanonicCoset;
+use stwo::core::poly::circle::{CanonicCoset, CircleDomain};
 use stwo::core::utils::bit_reverse;
 use stwo::prover::backend::simd::column::VeryPackedSecureColumnByCoords;
 use stwo::prover::backend::simd::m31::LOG_N_LANES;
 use stwo::prover::backend::simd::very_packed_m31::{VeryPackedBaseField, LOG_N_VERY_PACKED_ELEMS};
 use stwo::prover::backend::simd::SimdBackend;
-use stwo::prover::backend::CpuBackend;
-use stwo::prover::poly::circle::{CircleEvaluation, PolyOps};
+use stwo::prover::backend::{Backend, CpuBackend};
+use stwo::prover::poly::circle::CircleEvaluation;
 use stwo::prover::poly::BitReversedOrder;
 use stwo::prover::secure_column::SecureColumnByCoords;
-use stwo::prover::{ComponentProver, DomainEvaluationAccumulator, Trace};
+use stwo::prover::{ComponentProver, DomainEvaluationAccumulator, EvaluationMode, Poly, Trace};
 use tracing::{span, Level};
 
 use super::{CpuDomainEvaluator, SimdDomainEvaluator};
@@ -51,33 +51,11 @@ impl<E: FrameworkEval + Sync> ComponentProver<SimdBackend> for FrameworkComponen
             .map(|idx| &trace.polys[PREPROCESSED_TRACE_IDX][*idx])
             .collect();
 
-        // Extend trace if necessary.
-        // TODO: Don't extend when eval_size < committed_size. Instead, pick a good
-        // subdomain. (For larger blowup factors).
-        let need_to_extend = component_polys
-            .iter()
-            .flatten()
-            .any(|c| c.evals.domain.log_size() != eval_domain.log_size());
-        let trace: TreeVec<
-            Vec<Cow<'_, CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>>,
-        > = if need_to_extend {
-            let _span = span!(Level::INFO, "Constraint Extension").entered();
-            let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
-            #[cfg(not(feature = "parallel"))]
-            {
-                component_polys.as_cols_ref().map_cols(|col| {
-                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
-                })
-            }
-            #[cfg(feature = "parallel")]
-            {
-                component_polys.as_cols_ref().par_map_cols(|col| {
-                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
-                })
-            }
-        } else {
-            component_polys.map_cols(|c| Cow::Borrowed(&c.evals))
-        };
+        let trace = get_constraint_quotients_inputs(
+            eval_domain,
+            component_polys,
+            evaluation_accumulator.evaluation_mode(),
+        );
 
         // Denom inverses.
         let log_expand = eval_domain.log_size() - trace_domain.log_size();
@@ -192,24 +170,11 @@ impl<E: FrameworkEval + Sync> ComponentProver<CpuBackend> for FrameworkComponent
             .map(|idx| &trace.polys[PREPROCESSED_TRACE_IDX][*idx])
             .collect();
 
-        // Extend trace if necessary.
-        // TODO: Don't extend when eval_size < committed_size. Instead, pick a good
-        // subdomain. (For larger blowup factors).
-        let need_to_extend = component_polys
-            .iter()
-            .flatten()
-            .any(|c| c.evals.domain.log_size() != eval_domain.log_size());
-        let trace: TreeVec<
-            Vec<Cow<'_, CircleEvaluation<CpuBackend, BaseField, BitReversedOrder>>>,
-        > = if need_to_extend {
-            let _span = span!(Level::INFO, "Constraint Extension").entered();
-            let twiddles = CpuBackend::precompute_twiddles(eval_domain.half_coset);
-            component_polys
-                .as_cols_ref()
-                .map_cols(|col| Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles)))
-        } else {
-            component_polys.map_cols(|c| Cow::Borrowed(&c.evals))
-        };
+        let trace = get_constraint_quotients_inputs(
+            eval_domain,
+            component_polys,
+            evaluation_accumulator.evaluation_mode(),
+        );
 
         // Denom inverses.
         let log_expand = eval_domain.log_size() - trace_domain.log_size();
@@ -240,6 +205,39 @@ impl<E: FrameworkEval + Sync> ComponentProver<CpuBackend> for FrameworkComponent
             &accum.random_coeff_powers,
             accum.col,
         );
+    }
+}
+
+/// Prepares trace evaluations for constraint quotient computation. Either borrows committed
+/// evaluations directly (subdomain mode) or extends them to the evaluation domain.
+fn get_constraint_quotients_inputs<'a, B: Backend>(
+    eval_domain: CircleDomain,
+    component_polys: TreeVec<Vec<&'a &Poly<B>>>,
+    mode: EvaluationMode,
+) -> TreeVec<Vec<Cow<'a, CircleEvaluation<B, BaseField, BitReversedOrder>>>> {
+    match mode {
+        EvaluationMode::SubDomain { log_expansion: 0 } => {
+            component_polys.map_cols(|c| Cow::Borrowed(&c.evals))
+        }
+        EvaluationMode::SubDomain { log_expansion: _ } => {
+            unimplemented!("SubDomain with log_expansion > 0 not yet supported")
+        }
+        EvaluationMode::ExtendToEvalDomain => {
+            let _span = span!(Level::INFO, "Constraint Extension").entered();
+            let twiddles = B::precompute_twiddles(eval_domain.half_coset);
+            #[cfg(not(feature = "parallel"))]
+            {
+                component_polys.as_cols_ref().map_cols(|col| {
+                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
+                })
+            }
+            #[cfg(feature = "parallel")]
+            {
+                component_polys.as_cols_ref().par_map_cols(|col| {
+                    Cow::Owned(col.get_evaluation_on_domain(eval_domain, &twiddles))
+                })
+            }
+        }
     }
 }
 

--- a/crates/stwo/src/prover/air/accumulation.rs
+++ b/crates/stwo/src/prover/air/accumulation.rs
@@ -7,6 +7,7 @@
 use itertools::Itertools;
 use tracing::{span, Level};
 
+use crate::core::air::Component;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::poly::circle::CanonicCoset;
@@ -15,6 +16,65 @@ use crate::prover::poly::circle::{CircleCoefficients, CircleEvaluation, SecureCi
 use crate::prover::poly::twiddles::TwiddleTree;
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
+
+/// Controls how constraint evaluations are accumulated and finalized.
+#[derive(Debug, Clone, Copy)]
+pub enum EvaluationMode {
+    /// Reuses evaluations from the commitment phase by splitting commitment domains
+    /// `log_expansion` times into (possibly non-canonical) subdomains.
+    ///
+    /// Faster, but only applicable when the committed evaluations already cover the needed domain
+    /// and the log_expansion is consistent across all components.
+    /// TODO(ilya): Support `log_expansion > 0`.
+    SubDomain { log_expansion: u32 },
+    /// Low-degree extends all columns to the evaluation domain before evaluating constraints.
+    ///
+    /// Slower, but always applicable.
+    ExtendToEvalDomain,
+}
+
+impl EvaluationMode {
+    /// Determines whether the committed trace columns can be used directly for constraint
+    /// evaluation or must be extended to the evaluation domain.
+    ///
+    /// Returns `SubDomain { log_expansion }` when all components share the same expansion ratio
+    /// (`log_blowup_factor - constraint_log_degree`).
+    /// Otherwise returns `ExtendToEvalDomain`.
+    pub fn infer(components: &[&dyn Component], log_blowup_factor: u32) -> Self {
+        let mut common_log_expansion: Option<u32> = None;
+        for c in components {
+            let trace_log_size = c
+                .trace_log_degree_bounds()
+                .iter()
+                .flatten()
+                .copied()
+                .max()
+                .unwrap_or(0);
+            let constraint_log_degree = c
+                .max_constraint_log_degree_bound()
+                .saturating_sub(trace_log_size);
+            if constraint_log_degree > log_blowup_factor {
+                return EvaluationMode::ExtendToEvalDomain;
+            }
+            let log_expansion = log_blowup_factor - constraint_log_degree;
+
+            // TODO(ilya): Remove this once we support log_expansion != 0.
+            if log_expansion != 0 {
+                return EvaluationMode::ExtendToEvalDomain;
+            }
+            match common_log_expansion {
+                None => common_log_expansion = Some(log_expansion),
+                Some(prev) if prev != log_expansion => {
+                    return EvaluationMode::ExtendToEvalDomain;
+                }
+                _ => {}
+            }
+        }
+        EvaluationMode::SubDomain {
+            log_expansion: common_log_expansion.unwrap_or(0),
+        }
+    }
+}
 
 // TODO(ShaharS), rename terminology to constraints instead of columns.
 /// Accumulates evaluations of u_i(P), each at an evaluation domain of the size of that polynomial.
@@ -26,17 +86,25 @@ pub struct DomainEvaluationAccumulator<B: Backend> {
     /// `evaluation_i * alpha^(N - 1 - i)`
     /// where `N` is the total number of evaluations.
     sub_accumulations: Vec<Option<SecureColumnByCoords<B>>>,
+    /// Specifies how the constraints are evaluated.
+    evaluation_mode: EvaluationMode,
 }
 
 impl<B: Backend> DomainEvaluationAccumulator<B> {
     /// Creates a new accumulator.
     /// `random_coeff` should be a secure random field element, drawn from the channel.
     /// `max_log_size` is the maximum log_size of the accumulated evaluations.
-    pub fn new(random_coeff: SecureField, max_log_size: u32, total_columns: usize) -> Self {
+    pub fn new(
+        random_coeff: SecureField,
+        max_log_size: u32,
+        total_columns: usize,
+        evaluation_mode: EvaluationMode,
+    ) -> Self {
         let max_log_size = max_log_size as usize;
         Self {
             random_coeff_powers: B::generate_secure_powers(random_coeff, total_columns),
             sub_accumulations: (0..(max_log_size + 1)).map(|_| None).collect(),
+            evaluation_mode,
         }
     }
 
@@ -79,6 +147,11 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
     pub fn skip_coeffs(&mut self, n_coeffs: usize) {
         self.random_coeff_powers
             .truncate(self.random_coeff_powers.len() - n_coeffs);
+    }
+
+    /// Returns the evaluation mode.
+    pub const fn evaluation_mode(&self) -> EvaluationMode {
+        self.evaluation_mode
     }
 
     /// Returns the log size of the resulting polynomial.
@@ -195,6 +268,7 @@ mod tests {
             alpha,
             LOG_SIZE_BOUND - 1,
             evaluations.len(),
+            EvaluationMode::SubDomain { log_expansion: 0 },
         );
         let n_cols_per_size: [(u32, usize); (LOG_SIZE_BOUND - LOG_SIZE_MIN) as usize] =
             array::from_fn(|i| {

--- a/crates/stwo/src/prover/air/component_prover.rs
+++ b/crates/stwo/src/prover/air/component_prover.rs
@@ -7,7 +7,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::pcs::TreeVec;
 use crate::core::poly::circle::CircleDomain;
 use crate::core::ColumnVec;
-use crate::prover::air::accumulation::DomainEvaluationAccumulator;
+use crate::prover::air::accumulation::{DomainEvaluationAccumulator, EvaluationMode};
 use crate::prover::backend::{Backend, Col};
 use crate::prover::poly::circle::{CircleCoefficients, CircleEvaluation, SecureCirclePoly};
 use crate::prover::poly::twiddles::TwiddleTree;
@@ -100,12 +100,20 @@ impl<B: Backend> ComponentProvers<'_, B> {
         random_coeff: SecureField,
         trace: &Trace<'_, B>,
         twiddles: &TwiddleTree<B>,
+        log_blowup_factor: u32,
     ) -> SecureCirclePoly<B> {
         let total_constraints: usize = self.components.iter().map(|c| c.n_constraints()).sum();
+        let components: Vec<&dyn Component> = self
+            .components
+            .iter()
+            .map(|c| *c as &dyn Component)
+            .collect();
+        let evaluation_mode = EvaluationMode::infer(&components, log_blowup_factor);
         let mut accumulator = DomainEvaluationAccumulator::new(
             random_coeff,
             self.components().composition_log_degree_bound(),
             total_constraints,
+            evaluation_mode,
         );
         for component in &self.components {
             component.evaluate_constraint_quotients_on_domain(trace, &mut accumulator)

--- a/crates/stwo/src/prover/air/mod.rs
+++ b/crates/stwo/src/prover/air/mod.rs
@@ -1,3 +1,5 @@
 mod accumulation;
-pub use accumulation::{AccumulationOps, ColumnAccumulator, DomainEvaluationAccumulator};
+pub use accumulation::{
+    AccumulationOps, ColumnAccumulator, DomainEvaluationAccumulator, EvaluationMode,
+};
 pub mod component_prover;

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -10,8 +10,8 @@ use crate::core::verifier::PREPROCESSED_TRACE_IDX;
 use crate::prover::backend::BackendForChannel;
 
 mod air;
-pub use air::component_prover::{ComponentProver, ComponentProvers, Trace};
-pub use air::{AccumulationOps, ColumnAccumulator, DomainEvaluationAccumulator};
+pub use air::component_prover::{ComponentProver, ComponentProvers, Poly, Trace};
+pub use air::{AccumulationOps, ColumnAccumulator, DomainEvaluationAccumulator, EvaluationMode};
 mod pcs;
 pub use pcs::quotient_ops::QuotientOps;
 pub use pcs::{CommitmentSchemeProver, CommitmentTreeProver, TreeBuilder};
@@ -65,6 +65,7 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
         random_coeff,
         &trace,
         commitment_scheme.twiddles,
+        commitment_scheme.config.fri_config.log_blowup_factor,
     );
     span1.exit();
 


### PR DESCRIPTION
Introduces EvaluationMode with two variants:
- SubDomain { log_expansion }: constraints evaluated on (possibly
  non-canonical) subdomains of committed domains
- ExtendToEvalDomain: columns are LDE'd to the evaluation domain

The mode is determined by comparing each component's
max_constraint_log_degree_bound with trace_log_size + log_blowup_factor.
When they match (blowup == constraint degree), SubDomain { log_expansion: 0 }
is used. Otherwise, ExtendToEvalDomain is used.

Component provers now check evaluation_mode() instead of computing
need_to_extend per-component. This prepares for the subdomain optimization
where log_expansion > 0 will allow skipping per-size IFFT+FFT.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>