### PR TITLE
feat: support SubDomain evaluation with log_expansion > 0

### DIFF
--- a/crates/constraint-framework/src/prover/component_prover.rs
+++ b/crates/constraint-framework/src/prover/component_prover.rs
@@ -41,11 +41,15 @@ fn get_trace_columns<'a, B: Backend>(
     mode: EvaluationMode,
 ) -> TreeVec<Vec<Cow<'a, CircleEvaluation<B, BaseField, BitReversedOrder>>>> {
     match mode {
-        EvaluationMode::SubDomain { log_expansion: 0 } => {
+        EvaluationMode::SubDomain { .. } => {
+            // Borrow committed evaluations directly. Only the first
+            // 2^max_constraint_log_degree_bound indices are going to be used for the
+            // constraint quotient evaluation (in bit-reversed order these form the
+            // subdomain coset).
+            //
+            // Ideally we'd slice to just those indices, but the type system requires
+            // borrowing the entire evaluation.
             component_polys.map_cols(|c| Cow::Borrowed(&c.evals))
-        }
-        EvaluationMode::SubDomain { log_expansion: _ } => {
-            unimplemented!("SubDomain with log_expansion > 0 not yet supported")
         }
         EvaluationMode::ExtendToEvalDomain => {
             let _span = span!(Level::INFO, "Constraint Extension").entered();
@@ -74,8 +78,7 @@ fn get_constraint_quotient_inputs<'a, E: FrameworkEval, B: Backend>(
     trace: &'a Trace<'a, B>,
     mode: EvaluationMode,
 ) -> ConstraintQuotientInputs<'a, B> {
-    let eval_domain =
-        CanonicCoset::new(component.max_constraint_log_degree_bound()).circle_domain();
+    let max_constraint_log_degree_bound = component.max_constraint_log_degree_bound();
     let trace_domain = CanonicCoset::new(component.eval.log_size());
 
     let mut component_polys = trace.polys.sub_tree(&component.trace_locations);
@@ -85,6 +88,14 @@ fn get_constraint_quotient_inputs<'a, E: FrameworkEval, B: Backend>(
         .map(|idx| &trace.polys[PREPROCESSED_TRACE_IDX][*idx])
         .collect();
 
+    let eval_domain = match mode {
+        EvaluationMode::SubDomain { log_expansion } => {
+            subdomain_eval_domain(max_constraint_log_degree_bound, log_expansion)
+        }
+        EvaluationMode::ExtendToEvalDomain => {
+            CanonicCoset::new(max_constraint_log_degree_bound).circle_domain()
+        }
+    };
     let trace = get_trace_columns(component_polys, eval_domain, mode);
 
     // Denom inverses.
@@ -246,6 +257,18 @@ impl<E: FrameworkEval + Sync> ComponentProver<CpuBackend> for FrameworkComponent
             accum.col,
         );
     }
+}
+
+/// Computes the evaluation subdomain for a component given its constraint degree bound
+/// and the log_expansion from `EvaluationMode::SubDomain`.
+///
+/// When `log_expansion == 0`, returns the canonical domain.
+/// When `log_expansion > 0`, returns the first subdomain obtained by splitting the
+/// committed domain `log_expansion` times.
+fn subdomain_eval_domain(max_constraint_log_degree_bound: u32, log_expansion: u32) -> CircleDomain {
+    let committed_domain =
+        CanonicCoset::new(max_constraint_log_degree_bound + log_expansion).circle_domain();
+    committed_domain.split(log_expansion).0
 }
 
 fn accumulate_pointwise_cpu<E: FrameworkEval>(

--- a/crates/examples/src/wide_fibonacci/mod.rs
+++ b/crates/examples/src/wide_fibonacci/mod.rs
@@ -110,6 +110,7 @@ mod tests {
     use stwo::core::channel::Poseidon252Channel;
     use stwo::core::fields::m31::BaseField;
     use stwo::core::fields::qm31::SecureField;
+    use stwo::core::fri::FriConfig;
     use stwo::core::pcs::{CommitmentSchemeVerifier, PcsConfig, TreeVec};
     use stwo::core::poly::circle::CanonicCoset;
     use stwo::core::vcs_lifted::blake2_merkle::Blake2sM31MerkleChannel;
@@ -236,6 +237,67 @@ mod tests {
                 &mut CommitmentSchemeVerifier::<Blake2sM31MerkleChannel>::new(config);
 
             // Retrieve the expected column sizes in each commitment interaction, from the AIR.
+            let sizes = component.trace_log_degree_bounds();
+            commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
+            commitment_scheme.commit(proof.commitments[1], &sizes[1], verifier_channel);
+            verify(&[&component], verifier_channel, commitment_scheme, proof).unwrap();
+        }
+    }
+
+    /// Tests the subdomain evaluation path (log_expansion > 0) by using log_blowup_factor = 2
+    /// with constraint degree 1, so the committed domain is larger than the eval domain.
+    #[test_log::test]
+    fn test_wide_fib_prove_with_larger_blowup() {
+        for log_n_instances in 4..=7 {
+            let config = PcsConfig {
+                pow_bits: 10,
+                fri_config: FriConfig::new(0, 2, 3, 1),
+                lifting_log_size: None,
+            };
+            // Precompute twiddles for the larger committed domain.
+            let twiddles = SimdBackend::precompute_twiddles(
+                CanonicCoset::new(log_n_instances + 1 + config.fri_config.log_blowup_factor)
+                    .circle_domain()
+                    .half_coset,
+            );
+
+            let prover_channel = &mut Blake2sM31Channel::default();
+            let mut commitment_scheme = CommitmentSchemeProver::<
+                SimdBackend,
+                Blake2sM31MerkleChannel,
+            >::new(config, &twiddles);
+
+            // Preprocessed trace.
+            let mut tree_builder = commitment_scheme.tree_builder();
+            tree_builder.extend_evals(vec![]);
+            tree_builder.commit(prover_channel);
+
+            // Trace.
+            let trace =
+                generate_trace::<FIB_SEQUENCE_LENGTH, _>(&generate_test_inputs(log_n_instances));
+            let mut tree_builder = commitment_scheme.tree_builder();
+            tree_builder.extend_evals(trace);
+            tree_builder.commit(prover_channel);
+
+            let component = WideFibonacciComponent::new(
+                &mut TraceLocationAllocator::default(),
+                WideFibonacciEval::<FIB_SEQUENCE_LENGTH> {
+                    log_n_rows: log_n_instances,
+                },
+                SecureField::zero(),
+            );
+
+            let proof = prove::<SimdBackend, Blake2sM31MerkleChannel>(
+                &[&component],
+                prover_channel,
+                commitment_scheme,
+            )
+            .unwrap();
+
+            // Verify.
+            let verifier_channel = &mut Blake2sM31Channel::default();
+            let commitment_scheme =
+                &mut CommitmentSchemeVerifier::<Blake2sM31MerkleChannel>::new(config);
             let sizes = component.trace_log_degree_bounds();
             commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
             commitment_scheme.commit(proof.commitments[1], &sizes[1], verifier_channel);

--- a/crates/stwo/src/prover/air/accumulation.rs
+++ b/crates/stwo/src/prover/air/accumulation.rs
@@ -25,7 +25,6 @@ pub enum EvaluationMode {
     ///
     /// Faster, but only applicable when the committed evaluations already cover the needed domain
     /// and the log_expansion is consistent across all components.
-    /// TODO(ilya): Support `log_expansion > 0`.
     SubDomain { log_expansion: u32 },
     /// Low-degree extends all columns to the evaluation domain before evaluating constraints.
     ///
@@ -57,11 +56,6 @@ impl EvaluationMode {
                 return EvaluationMode::ExtendToEvalDomain;
             }
             let log_expansion = log_blowup_factor - constraint_log_degree;
-
-            // TODO(ilya): Remove this once we support log_expansion != 0.
-            if log_expansion != 0 {
-                return EvaluationMode::ExtendToEvalDomain;
-            }
             match common_log_expansion {
                 None => common_log_expansion = Some(log_expansion),
                 Some(prev) if prev != log_expansion => {
@@ -179,14 +173,25 @@ impl<B: Backend> DomainEvaluationAccumulator<B> {
         let lifted_accumulation = B::lift_and_accumulate(sub_accumulations);
 
         if let Some(eval) = lifted_accumulation {
-            // `lifted_accumulation` must be of size `log_size`, i.e. there must at least one sub
-            // accumulation of size `log_size`.
+            // Determine the domain and twiddles based on evaluation mode.
+            let (domain, owned_twiddles) = match self.evaluation_mode {
+                EvaluationMode::SubDomain { log_expansion: 0 }
+                | EvaluationMode::ExtendToEvalDomain => {
+                    (CanonicCoset::new(log_size).circle_domain(), None)
+                }
+                EvaluationMode::SubDomain { log_expansion } => {
+                    let committed_domain =
+                        CanonicCoset::new(log_size + log_expansion).circle_domain();
+                    let subdomain = committed_domain.split(log_expansion).0;
+                    let tw = B::precompute_twiddles(subdomain.half_coset);
+                    (subdomain, Some(tw))
+                }
+            };
+            let twiddles_ref = owned_twiddles.as_ref().unwrap_or(twiddles);
+
             SecureCirclePoly(eval.columns.map(|c| {
-                CircleEvaluation::<B, BaseField, BitReversedOrder>::new(
-                    CanonicCoset::new(log_size).circle_domain(),
-                    c,
-                )
-                .interpolate_with_twiddles(twiddles)
+                CircleEvaluation::<B, BaseField, BitReversedOrder>::new(domain, c)
+                    .interpolate_with_twiddles(twiddles_ref)
             }))
         } else {
             SecureCirclePoly(std::array::from_fn(|_| {


### PR DESCRIPTION
When blowup factor exceeds constraint degree, evaluate constraints on
non-canonical subdomains of committed domains instead of extending via
IFFT+FFT. The subdomain is obtained by splitting the committed domain
log_expansion times, borrowing committed column data directly. The final
IFFT in finalize() uses twiddles recomputed for the non-canonical
subdomain to account for the shift introduced by log_expansion.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>