### PR TITLE
Increase numerators chunk size.

### DIFF
--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -142,3 +142,8 @@ required-features = ["prover"]
 harness = false
 name = "pcs"
 required-features = ["prover"]
+
+[[bench]]
+harness = false
+name = "fri_quotients"
+required-features = ["prover"]

--- a/crates/stwo/benches/README.md
+++ b/crates/stwo/benches/README.md
@@ -1,2 +1,8 @@
 dev benchmark results can be seen at
 https://starkware-libs.github.io/stwo/dev/bench/index.html
+
+To run a bench:
+```bash
+cargo bench --features prover,parallel --bench [BENCH_NAME]
+```
+where `BENCH_NAME` is the name of the bench as it appears in `../Cargo.toml`.

--- a/crates/stwo/benches/fri_quotients.rs
+++ b/crates/stwo/benches/fri_quotients.rs
@@ -1,0 +1,110 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use itertools::Itertools;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use stwo::core::circle::SECURE_FIELD_CIRCLE_GEN;
+use stwo::core::fields::m31::{BaseField, M31};
+use stwo::core::fields::qm31::SecureField;
+use stwo::core::pcs::quotients::{
+    build_samples_with_randomness_and_periodicity, ColumnSampleBatch, PointSample,
+};
+use stwo::core::pcs::TreeVec;
+use stwo::core::poly::circle::CanonicCoset;
+use stwo::prover::backend::simd::SimdBackend;
+use stwo::prover::pcs::quotient_ops::AccumulatedNumerators;
+use stwo::prover::poly::circle::{CircleCoefficients, CircleEvaluation, PolyOps};
+use stwo::prover::poly::BitReversedOrder;
+use stwo::prover::QuotientOps;
+
+#[allow(clippy::type_complexity)]
+fn setup(
+    trace_log_size: u32,
+    log_blowup_factor: u32,
+    n_cols: usize,
+) -> (
+    Vec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
+    Vec<ColumnSampleBatch>,
+) {
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    let eval_log_size = trace_log_size + log_blowup_factor;
+    let eval_domain = CanonicCoset::new(eval_log_size).circle_domain();
+    let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
+
+    let polys: Vec<CircleCoefficients<SimdBackend>> = (0..n_cols)
+        .map(|_| {
+            CircleCoefficients::new((0..1 << trace_log_size).map(|_| rng.gen::<M31>()).collect())
+        })
+        .collect();
+
+    let columns: Vec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> = polys
+        .iter()
+        .map(|poly| poly.evaluate_with_twiddles(eval_domain, &twiddles))
+        .collect();
+
+    let sample_points = [SECURE_FIELD_CIRCLE_GEN, SECURE_FIELD_CIRCLE_GEN.double()];
+
+    let samples: Vec<Vec<PointSample>> = polys
+        .iter()
+        .map(|poly| {
+            sample_points
+                .iter()
+                .map(|&point| PointSample {
+                    point,
+                    value: poly.eval_at_point(point),
+                })
+                .collect()
+        })
+        .collect();
+
+    let random_coeff =
+        SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.gen::<u32>())));
+
+    let sample_batches = ColumnSampleBatch::new_vec(
+        &build_samples_with_randomness_and_periodicity(
+            &TreeVec(vec![samples]),
+            vec![vec![eval_log_size; n_cols].into_iter()],
+            eval_log_size,
+            random_coeff,
+        )
+        .iter()
+        .flatten()
+        .collect_vec(),
+    );
+    (columns, sample_batches)
+}
+
+fn bench_accumulate_numerators(c: &mut Criterion) {
+    let trace_log_size = 20;
+    let log_blowup_factor = 1;
+    let eval_log_size = trace_log_size + log_blowup_factor;
+    let n_cols = 100;
+    let (columns, sample_batches) = setup(trace_log_size, log_blowup_factor, n_cols);
+    let col_refs: Vec<&CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> =
+        columns.iter().collect();
+
+    c.bench_function(
+        &format!("accumulate_numerators 2^{eval_log_size} x {n_cols} cols"),
+        |b| {
+            b.iter_batched(
+                Vec::<AccumulatedNumerators<SimdBackend>>::new,
+                |mut acc| {
+                    SimdBackend::accumulate_numerators(
+                        black_box(&col_refs),
+                        black_box(&sample_batches),
+                        black_box(&mut acc),
+                    );
+                    acc
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_accumulate_numerators
+);
+criterion_main!(benches);

--- a/crates/stwo/src/prover/backend/simd/quotients.rs
+++ b/crates/stwo/src/prover/backend/simd/quotients.rs
@@ -14,7 +14,7 @@ use crate::core::circle::CirclePoint;
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::FieldExpOps;
-use crate::core::pcs::quotients::{quotient_constants, ColumnSampleBatch, NumeratorData};
+use crate::core::pcs::quotients::{quotient_constants, ColumnSampleBatch};
 use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 use crate::prover::backend::simd::cm31::PackedCM31;
 use crate::prover::backend::simd::utils::to_lifted_simd;
@@ -36,28 +36,45 @@ impl QuotientOps for SimdBackend {
         sample_batches: &[ColumnSampleBatch],
         accumulated_numerators_vec: &mut Vec<AccumulatedNumerators<Self>>,
     ) {
+        // This constant is chosen empirically by benchmarking.
+        const NUMERATORS_CHUNK_SIZE: usize = 1 << 6;
+
         let size = columns[0].length;
         let quotient_constants = quotient_constants(sample_batches);
 
         for (batch, coeffs) in zip(sample_batches, quotient_constants.line_coeffs) {
-            let mut partial_numerators_acc = unsafe { SecureColumnByCoords::uninitialized(size) };
+            let mut partial_numerators_acc =
+                unsafe { SecureColumnByCoords::<SimdBackend>::uninitialized(size) };
 
             #[cfg(not(feature = "parallel"))]
-            let iter = partial_numerators_acc.chunks_mut(1);
+            let iter = partial_numerators_acc.chunks_mut(NUMERATORS_CHUNK_SIZE);
 
-            // TODO(Leo): make chunk size configurable.
             #[cfg(feature = "parallel")]
-            let iter = partial_numerators_acc.par_chunks_mut(1);
+            let iter = partial_numerators_acc.par_chunks_mut(NUMERATORS_CHUNK_SIZE);
 
             iter.enumerate().for_each(|(chunk_idx, mut values_dst)| {
-                let query_values_at_row = batch.cols_vals_randpows.iter().map(
-                    |NumeratorData {
-                         column_index: idx, ..
-                     }| columns[*idx].data[chunk_idx],
-                );
-                let row_value = accumulate_row_partial_numerators(query_values_at_row, &coeffs);
-                unsafe {
-                    values_dst.set_packed(0, row_value);
+                let chunk_start = chunk_idx * NUMERATORS_CHUNK_SIZE;
+                // Initialize accumulators for the chunk.
+                let mut accumulators = [PackedSecureField::zero(); NUMERATORS_CHUNK_SIZE];
+                // This is needed because the last chunk may be smaller than
+                // `NUMERATORS_CHUNK_SIZE`.
+                let packed_chunk_len = values_dst.0[0].0.len();
+                let accumulators = &mut accumulators[..packed_chunk_len];
+
+                for (numerator_data, (_, b, c)) in zip_eq(&batch.cols_vals_randpows, &coeffs) {
+                    let col_data = &columns[numerator_data.column_index].data;
+                    let b_broadcast = PackedSecureField::broadcast(*b);
+                    let c_broadcast = PackedSecureField::broadcast(*c);
+                    for (i, acc) in accumulators.iter_mut().enumerate() {
+                        let val = col_data[chunk_start + i];
+                        *acc += c_broadcast * val - b_broadcast;
+                    }
+                }
+
+                for (i, acc) in accumulators.iter().enumerate() {
+                    unsafe {
+                        values_dst.set_packed(i, *acc);
+                    }
                 }
             });
             let first_linear_term_acc: SecureField = coeffs.iter().map(|(a, ..)| a).sum();
@@ -119,18 +136,6 @@ impl QuotientOps for SimdBackend {
         });
         SecureEvaluation::new(domain, quotients)
     }
-}
-
-fn accumulate_row_partial_numerators(
-    queried_values_at_row: impl Iterator<Item = PackedBaseField>,
-    coeffs: &Vec<(SecureField, SecureField, SecureField)>,
-) -> PackedSecureField {
-    let mut numerator = PackedSecureField::zero();
-    for (val_at_row, (_, b, c)) in zip_eq(queried_values_at_row, coeffs) {
-        let value = PackedSecureField::broadcast(*c) * val_at_row;
-        numerator += value - PackedSecureField::broadcast(*b);
-    }
-    numerator
 }
 
 fn denominator_inverses(

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -12,7 +12,7 @@ use crate::prover::backend::BackendForChannel;
 mod air;
 pub use air::component_prover::{ComponentProver, ComponentProvers, Poly, Trace};
 pub use air::{AccumulationOps, ColumnAccumulator, DomainEvaluationAccumulator, EvaluationMode};
-mod pcs;
+pub mod pcs;
 pub use pcs::quotient_ops::QuotientOps;
 pub use pcs::{CommitmentSchemeProver, CommitmentTreeProver, TreeBuilder};
 pub mod backend;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SIMD quotient/numerator accumulation in the prover and changes iteration/chunking logic, which could introduce subtle indexing or parallelism regressions despite being performance-focused.
> 
> **Overview**
> Improves `SimdBackend::accumulate_numerators` by processing rows in larger fixed-size chunks (empirically set to `1<<6`) and computing multiple packed accumulators per chunk, replacing the previous per-row accumulation helper.
> 
> Adds a new Criterion benchmark (`fri_quotients`) and updates bench docs to make it easier to measure the numerator accumulation performance, and makes `prover::pcs` public to support external bench access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a070f20faa495f493c6f84793a006a67784905a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->