### PR TITLE
Configurable chunks in compute_quotients_and_combine.

### DIFF
--- a/crates/stwo/benches/fri_quotients.rs
+++ b/crates/stwo/benches/fri_quotients.rs
@@ -10,10 +10,12 @@ use stwo::core::pcs::quotients::{
 };
 use stwo::core::pcs::TreeVec;
 use stwo::core::poly::circle::CanonicCoset;
+use stwo::prover::backend::simd::column::BaseColumn;
 use stwo::prover::backend::simd::SimdBackend;
 use stwo::prover::pcs::quotient_ops::AccumulatedNumerators;
 use stwo::prover::poly::circle::{CircleCoefficients, CircleEvaluation, PolyOps};
 use stwo::prover::poly::BitReversedOrder;
+use stwo::prover::secure_column::SecureColumnByCoords;
 use stwo::prover::QuotientOps;
 
 #[allow(clippy::type_complexity)]
@@ -101,10 +103,48 @@ fn bench_accumulate_numerators(c: &mut Criterion) {
         },
     );
 }
+fn bench_compute_quotients_and_combine(c: &mut Criterion) {
+    let mut rng = SmallRng::seed_from_u64(0);
+
+    let n_sample_points = 10;
+    let lifting_log_size = 21;
+
+    let accumulations: Vec<AccumulatedNumerators<SimdBackend>> = (0..n_sample_points)
+        .map(|i| {
+            let partial_numerators_acc = SecureColumnByCoords {
+                columns: std::array::from_fn(|_| {
+                    BaseColumn::from_cpu(
+                        &(0..(1 << lifting_log_size))
+                            .map(|_| rng.gen::<M31>())
+                            .collect::<Vec<_>>(),
+                    )
+                }),
+            };
+            AccumulatedNumerators {
+                sample_point: SECURE_FIELD_CIRCLE_GEN.mul(i as u128 + 1),
+                partial_numerators_acc,
+                first_linear_term_acc: SecureField::from_m31_array(std::array::from_fn(|j| {
+                    BaseField::from(j as u32)
+                })),
+            }
+        })
+        .collect();
+
+    c.bench_function(
+        &format!("compute_quotients_and_combine 2^{lifting_log_size} x {n_sample_points} pts"),
+        |b| {
+            b.iter_batched(
+                || accumulations.clone(),
+                |acc| SimdBackend::compute_quotients_and_combine(black_box(acc), lifting_log_size),
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
 
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = bench_accumulate_numerators
+    targets = bench_accumulate_numerators, bench_compute_quotients_and_combine
 );
 criterion_main!(benches);

--- a/crates/stwo/src/prover/backend/simd/quotients.rs
+++ b/crates/stwo/src/prover/backend/simd/quotients.rs
@@ -86,11 +86,15 @@ impl QuotientOps for SimdBackend {
         }
     }
 
-    // TODO(Leo): optimize.
+    // TODO(Leo): optimize. Consider receiving the denominator inverses from the call site and
+    // having them computed in parallel to other task.
     fn compute_quotients_and_combine(
         accumulations: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
     ) -> SecureEvaluation<Self, BitReversedOrder> {
+        // This constant is chosen empirically by benchmarking.
+        const COMBINE_CHUNK_SIZE: usize = 16;
+
         let domain = CanonicCoset::new(lifting_log_size).circle_domain();
         let domain_points: Vec<CirclePoint<PackedBaseField>> =
             CircleDomainBitRevIterator::new(domain).collect();
@@ -100,38 +104,59 @@ impl QuotientOps for SimdBackend {
             accumulations.iter().map(|x| x.sample_point).collect();
         let denominators_inverses = denominator_inverses(&sample_points, domain);
 
+        // Precompute values needed inside the loop.
+        let log_ratios: Vec<u32> = accumulations
+            .iter()
+            .map(|acc| lifting_log_size - acc.partial_numerators_acc.len().ilog2())
+            .collect();
+        let first_linear_terms: Vec<PackedSecureField> = accumulations
+            .iter()
+            .map(|acc| PackedSecureField::broadcast(acc.first_linear_term_acc))
+            .collect();
+
         // Populate `quotients`.
-        // TODO(Leo): make chunk size configurable.
         #[cfg(not(feature = "parallel"))]
-        let iter = quotients.chunks_mut(1).enumerate();
+        let iter = quotients.chunks_mut(COMBINE_CHUNK_SIZE).enumerate();
 
         #[cfg(feature = "parallel")]
-        let iter = quotients.par_chunks_mut(1).enumerate();
+        let iter = quotients.par_chunks_mut(COMBINE_CHUNK_SIZE).enumerate();
 
-        iter.for_each(|(domain_idx, mut value_dst)| {
-            let mut quotient = PackedSecureField::zero();
-            for (acc, den_inv) in accumulations.iter().zip_eq(denominators_inverses.iter()) {
-                let mut full_numerator = PackedSecureField::zero();
+        iter.for_each(|(chunk_idx, mut value_dst)| {
+            let chunk_start = chunk_idx * COMBINE_CHUNK_SIZE;
+            let packed_chunk_len = value_dst.0[0].0.len();
 
-                let log_ratio = lifting_log_size - acc.partial_numerators_acc.len().ilog2();
-                let lifted_partial_numerator =
-                    PackedSecureField::from_packed_m31s(std::array::from_fn(|j| {
-                        let lifted_simd = to_lifted_simd(
-                            acc.partial_numerators_acc.columns[j].data[domain_idx >> log_ratio]
-                                .into_simd(),
-                            log_ratio,
-                            domain_idx,
-                        );
-                        unsafe { PackedBaseField::from_simd_unchecked(lifted_simd) }
-                    }));
+            let mut chunk_acc = [PackedSecureField::zero(); COMBINE_CHUNK_SIZE];
+            let chunk_acc = &mut chunk_acc[..packed_chunk_len];
 
-                full_numerator += lifted_partial_numerator
-                    - PackedSecureField::broadcast(acc.first_linear_term_acc)
-                        * domain_points[domain_idx].y;
-                quotient += full_numerator * den_inv[domain_idx];
+            for (((acc, den_inv), log_ratio), first_linear_term) in accumulations
+                .iter()
+                .zip_eq(denominators_inverses.iter())
+                .zip_eq(log_ratios.iter())
+                .zip_eq(first_linear_terms.iter())
+            {
+                for (i, accumulator) in chunk_acc.iter_mut().enumerate() {
+                    let domain_idx = chunk_start + i;
+                    let lifted_partial_numerator =
+                        PackedSecureField::from_packed_m31s(std::array::from_fn(|j| {
+                            let lifted_simd = to_lifted_simd(
+                                acc.partial_numerators_acc.columns[j].data[domain_idx >> log_ratio]
+                                    .into_simd(),
+                                *log_ratio,
+                                domain_idx,
+                            );
+                            unsafe { PackedBaseField::from_simd_unchecked(lifted_simd) }
+                        }));
+
+                    let numerator =
+                        lifted_partial_numerator - *first_linear_term * domain_points[domain_idx].y;
+                    *accumulator += numerator * den_inv[domain_idx];
+                }
             }
-            unsafe {
-                value_dst.set_packed(0, quotient);
+
+            for (i, accumulator) in chunk_acc.iter().enumerate() {
+                unsafe {
+                    value_dst.set_packed(i, *accumulator);
+                }
             }
         });
         SecureEvaluation::new(domain, quotients)

--- a/crates/stwo/src/prover/pcs/quotient_ops.rs
+++ b/crates/stwo/src/prover/pcs/quotient_ops.rs
@@ -44,6 +44,9 @@ pub trait QuotientOps: PolyOps {
 
 /// Helper struct that keeps track of the accumulation of the numerators involved in the FRI
 /// quotients.
+///
+/// Note: `Clone` is derived only for benchmarking purposes.
+#[derive(Clone)]
 pub struct AccumulatedNumerators<B: ColumnOps<BaseField>> {
     /// One of the sample points received by the pcs.
     pub sample_point: CirclePoint<SecureField>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SIMD FRI quotient computation hot path; chunked iteration and new precomputations could introduce subtle indexing/off-by-one issues, though changes are localized and benchmarked.
> 
> **Overview**
> Optimizes SIMD `compute_quotients_and_combine` by processing the output in fixed-size chunks (`COMBINE_CHUNK_SIZE`) and precomputing per-accumulation values (`log_ratios`, broadcasted `first_linear_term`) to reduce repeated work in the inner loop.
> 
> Adds a Criterion benchmark for `compute_quotients_and_combine` and derives `Clone` for `AccumulatedNumerators` (explicitly for benchmarking) to support batched benchmark inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeeaefc59244f5a0f0d103fd202cff5c1cf500ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->