### PR TITLE
Accumulate quotients on subdomain and extend.

### DIFF
--- a/crates/stwo/benches/fri_quotients.rs
+++ b/crates/stwo/benches/fri_quotients.rs
@@ -104,6 +104,7 @@ fn bench_accumulate_numerators(c: &mut Criterion) {
         },
     );
 }
+
 fn bench_compute_quotients_and_combine(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
 

--- a/crates/stwo/src/prover/backend/simd/quotients.rs
+++ b/crates/stwo/src/prover/backend/simd/quotients.rs
@@ -7,7 +7,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIter
 
 use super::column::CM31Column;
 use super::domain::CircleDomainBitRevIterator;
-use super::m31::PackedBaseField;
+use super::m31::{PackedBaseField, LOG_N_LANES};
 use super::qm31::PackedSecureField;
 use super::SimdBackend;
 use crate::core::circle::CirclePoint;
@@ -18,9 +18,10 @@ use crate::core::pcs::quotients::{quotient_constants, ColumnSampleBatch};
 use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 use crate::prover::backend::simd::cm31::PackedCM31;
 use crate::prover::backend::simd::utils::to_lifted_simd;
+use crate::prover::backend::CpuBackend;
 use crate::prover::pcs::quotient_ops::AccumulatedNumerators;
-use crate::prover::poly::circle::{CircleEvaluation, SecureEvaluation};
-use crate::prover::poly::twiddles::TwiddleTree;
+use crate::prover::poly::circle::{CircleEvaluation, PolyOps, SecureEvaluation};
+use crate::prover::poly::twiddles::{TwiddleBuffer, TwiddleTree};
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
 use crate::prover::QuotientOps;
@@ -31,87 +32,100 @@ pub struct QuotientConstants {
 }
 
 impl QuotientOps for SimdBackend {
-    // TODO(Leo): optimize.
     fn accumulate_numerators(
         columns: &[&CircleEvaluation<Self, BaseField, BitReversedOrder>],
         sample_batches: &[ColumnSampleBatch],
         accumulated_numerators_vec: &mut Vec<AccumulatedNumerators<Self>>,
-        _log_blowup_factor: u32,
+        log_blowup_factor: u32,
     ) {
-        // This constant is chosen empirically by benchmarking.
-        const NUMERATORS_CHUNK_SIZE: usize = 1 << 6;
+        let domain = columns[0].domain;
+        let (subdomain, _) = domain.split(log_blowup_factor);
 
-        let size = columns[0].length;
+        // Fall back to CPU for subdomains too small for SIMD.
+        if subdomain.log_size() < LOG_N_LANES {
+            let cpu_columns: Vec<_> = columns.iter().map(|c| c.to_cpu()).collect();
+            let cpu_column_refs: Vec<_> = cpu_columns.iter().collect();
+            let mut cpu_acc: Vec<AccumulatedNumerators<CpuBackend>> = vec![];
+            CpuBackend::accumulate_numerators(
+                &cpu_column_refs,
+                sample_batches,
+                &mut cpu_acc,
+                log_blowup_factor,
+            );
+            for acc in cpu_acc {
+                accumulated_numerators_vec.push(AccumulatedNumerators {
+                    sample_point: acc.sample_point,
+                    partial_numerators_acc: SecureColumnByCoords::from_cpu(
+                        acc.partial_numerators_acc,
+                    ),
+                    first_linear_term_acc: acc.first_linear_term_acc,
+                });
+            }
+            return;
+        }
+
         let quotient_constants = quotient_constants(sample_batches);
-
         for (batch, coeffs) in zip(sample_batches, quotient_constants.line_coeffs) {
-            let mut partial_numerators_acc =
-                unsafe { SecureColumnByCoords::<SimdBackend>::uninitialized(size) };
-
-            #[cfg(not(feature = "parallel"))]
-            let iter = partial_numerators_acc.chunks_mut(NUMERATORS_CHUNK_SIZE);
-
-            #[cfg(feature = "parallel")]
-            let iter = partial_numerators_acc.par_chunks_mut(NUMERATORS_CHUNK_SIZE);
-
-            iter.enumerate().for_each(|(chunk_idx, mut values_dst)| {
-                let chunk_start = chunk_idx * NUMERATORS_CHUNK_SIZE;
-                // Initialize accumulators for the chunk.
-                let mut accumulators = [PackedSecureField::zero(); NUMERATORS_CHUNK_SIZE];
-                // This is needed because the last chunk may be smaller than
-                // `NUMERATORS_CHUNK_SIZE`.
-                let packed_chunk_len = values_dst.0[0].0.len();
-                let accumulators = &mut accumulators[..packed_chunk_len];
-
-                for (numerator_data, (_, b, c)) in zip_eq(&batch.cols_vals_randpows, &coeffs) {
-                    let col_data = &columns[numerator_data.column_index].data;
-                    let b_broadcast = PackedSecureField::broadcast(*b);
-                    let c_broadcast = PackedSecureField::broadcast(*c);
-                    for (i, acc) in accumulators.iter_mut().enumerate() {
-                        let val = col_data[chunk_start + i];
-                        *acc += c_broadcast * val - b_broadcast;
-                    }
-                }
-
-                for (i, acc) in accumulators.iter().enumerate() {
-                    unsafe {
-                        values_dst.set_packed(i, *acc);
-                    }
-                }
-            });
+            let subdomain_acc =
+                accumulate_numerators_on_subdomain(subdomain, batch, columns, &coeffs);
             let first_linear_term_acc: SecureField = coeffs.iter().map(|(a, ..)| a).sum();
             accumulated_numerators_vec.push(AccumulatedNumerators {
                 sample_point: batch.point,
-                partial_numerators_acc,
+                partial_numerators_acc: subdomain_acc,
                 first_linear_term_acc,
             })
         }
     }
 
-    // TODO(Leo): optimize. Consider receiving the denominator inverses from the call site and
+    // TODO(Leo): Consider receiving the denominator inverses from the call site and
     // having them computed in parallel to other task.
     fn compute_quotients_and_combine(
         accumulations: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
-        _log_blowup_factor: u32,
-        _twiddles: &TwiddleTree<Self>,
+        log_blowup_factor: u32,
+        twiddles: &TwiddleTree<Self>,
     ) -> SecureEvaluation<Self, BitReversedOrder> {
         // This constant is chosen empirically by benchmarking.
         const COMBINE_CHUNK_SIZE: usize = 16;
 
-        let domain = CanonicCoset::new(lifting_log_size).circle_domain();
-        let domain_points: Vec<CirclePoint<PackedBaseField>> =
-            CircleDomainBitRevIterator::new(domain).collect();
+        let eval_domain = CanonicCoset::new(lifting_log_size).circle_domain();
+        let (eval_subdomain, _) = eval_domain.split(log_blowup_factor);
+
+        // Fall back to CPU for subdomains too small for SIMD.
+        if eval_subdomain.log_size() < LOG_N_LANES {
+            let cpu_twiddles = CpuBackend::precompute_twiddles(eval_domain.half_coset);
+            let cpu_accumulations: Vec<AccumulatedNumerators<CpuBackend>> = accumulations
+                .into_iter()
+                .map(|acc| AccumulatedNumerators {
+                    sample_point: acc.sample_point,
+                    partial_numerators_acc: acc.partial_numerators_acc.to_cpu(),
+                    first_linear_term_acc: acc.first_linear_term_acc,
+                })
+                .collect();
+            let cpu_result = CpuBackend::compute_quotients_and_combine(
+                cpu_accumulations,
+                lifting_log_size,
+                log_blowup_factor,
+                &cpu_twiddles,
+            );
+            return SecureEvaluation::new(
+                cpu_result.domain,
+                SecureColumnByCoords::from_cpu(cpu_result.values),
+            );
+        }
+        let subdomain_points: Vec<CirclePoint<PackedBaseField>> =
+            CircleDomainBitRevIterator::new(eval_subdomain).collect();
+        let subdomain_log_size = eval_subdomain.log_size();
         let mut quotients: SecureColumnByCoords<SimdBackend> =
-            unsafe { SecureColumnByCoords::uninitialized(1 << lifting_log_size) };
+            unsafe { SecureColumnByCoords::uninitialized(1 << subdomain_log_size) };
         let sample_points: Vec<CirclePoint<SecureField>> =
             accumulations.iter().map(|x| x.sample_point).collect();
-        let denominators_inverses = denominator_inverses(&sample_points, domain);
+        let denominators_inverses = denominator_inverses(&sample_points, eval_subdomain);
 
         // Precompute values needed inside the loop.
         let log_ratios: Vec<u32> = accumulations
             .iter()
-            .map(|acc| lifting_log_size - acc.partial_numerators_acc.len().ilog2())
+            .map(|acc| subdomain_log_size - acc.partial_numerators_acc.len().ilog2())
             .collect();
         let first_linear_terms: Vec<PackedSecureField> = accumulations
             .iter()
@@ -151,8 +165,8 @@ impl QuotientOps for SimdBackend {
                             unsafe { PackedBaseField::from_simd_unchecked(lifted_simd) }
                         }));
 
-                    let numerator =
-                        lifted_partial_numerator - *first_linear_term * domain_points[domain_idx].y;
+                    let numerator = lifted_partial_numerator
+                        - *first_linear_term * subdomain_points[domain_idx].y;
                     *accumulator += numerator * den_inv[domain_idx];
                 }
             }
@@ -163,8 +177,79 @@ impl QuotientOps for SimdBackend {
                 }
             }
         });
-        SecureEvaluation::new(domain, quotients)
+        let subdomain_twiddles = TwiddleTree {
+            root_coset: eval_subdomain.half_coset,
+            // Only itwiddles are needed for interpolation.
+            twiddles: TwiddleBuffer::empty(),
+            itwiddles: twiddles
+                .itwiddles
+                .extract_subdomain_twiddles(eval_domain.log_size(), eval_subdomain.log_size()),
+        };
+        let evals = SecureColumnByCoords {
+            columns: quotients.columns.map(|eval| {
+                let poly = CircleEvaluation::<SimdBackend, BaseField, BitReversedOrder>::new(
+                    eval_subdomain,
+                    eval,
+                )
+                .interpolate_with_twiddles(&subdomain_twiddles);
+                poly.evaluate_with_twiddles(eval_domain, twiddles).values
+            }),
+        };
+
+        SecureEvaluation::new(eval_domain, evals)
     }
+}
+
+/// Performs the pointwise accumulation of the numerators on `subdomain`.
+///
+/// Note that `columns` are assumed to be evaluations over a possibly larger domain containing
+/// `subdomain`. It must hold that the points of `subdomain` in bit-reversed order form a prefix of
+/// the points of the larger domain in bit-reversed order.
+fn accumulate_numerators_on_subdomain(
+    subdomain: CircleDomain,
+    sample_batch: &ColumnSampleBatch,
+    columns: &[&CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>],
+    quotient_coeffs: &[(SecureField, SecureField, SecureField)],
+) -> SecureColumnByCoords<SimdBackend> {
+    // This constant is chosen empirically by benchmarking.
+    const NUMERATORS_CHUNK_SIZE: usize = 1 << 6;
+
+    let mut values =
+        unsafe { SecureColumnByCoords::<SimdBackend>::uninitialized(subdomain.size()) };
+
+    #[cfg(not(feature = "parallel"))]
+    let iter = values.chunks_mut(NUMERATORS_CHUNK_SIZE);
+
+    #[cfg(feature = "parallel")]
+    let iter = values.par_chunks_mut(NUMERATORS_CHUNK_SIZE);
+
+    iter.enumerate().for_each(|(chunk_idx, mut values_dst)| {
+        let chunk_start = chunk_idx * NUMERATORS_CHUNK_SIZE;
+        // Initialize accumulators for the chunk.
+        let mut accumulators = [PackedSecureField::zero(); NUMERATORS_CHUNK_SIZE];
+        // This is needed because the last chunk may be smaller than
+        // `NUMERATORS_CHUNK_SIZE`.
+        let packed_chunk_len = values_dst.0[0].0.len();
+        let accumulators = &mut accumulators[..packed_chunk_len];
+
+        for (numerator_data, (_, b, c)) in zip_eq(&sample_batch.cols_vals_randpows, quotient_coeffs)
+        {
+            let col_data = &columns[numerator_data.column_index].data;
+            let b_broadcast = PackedSecureField::broadcast(*b);
+            let c_broadcast = PackedSecureField::broadcast(*c);
+            for (i, acc) in accumulators.iter_mut().enumerate() {
+                let val = col_data[chunk_start + i];
+                *acc += c_broadcast * val - b_broadcast;
+            }
+        }
+
+        for (i, acc) in accumulators.iter().enumerate() {
+            unsafe {
+                values_dst.set_packed(i, *acc);
+            }
+        }
+    });
+    values
 }
 
 fn denominator_inverses(
@@ -284,10 +369,6 @@ mod tests {
             LOG_BLOWUP_FACTOR,
         );
 
-        // The SIMD result is over the full domain, while the CPU result is over the subdomain
-        // (a bit-reversed prefix). Compare the prefix.
-        // TODO(Leo): revert in next PR after SIMD impl.
-        let subdomain_size = 1 << (LOG_SIZE - LOG_BLOWUP_FACTOR);
         accumulated_numerators_vec_simd
             .iter()
             .zip_eq(accumulated_numerators_vec_cpu)
@@ -296,13 +377,10 @@ mod tests {
                     acc_simd.first_linear_term_acc,
                     acc_cpu.first_linear_term_acc
                 );
-                let simd_cpu = acc_simd.partial_numerators_acc.to_cpu();
-                for col_idx in 0..4 {
-                    assert_eq!(
-                        simd_cpu.columns[col_idx][..subdomain_size],
-                        acc_cpu.partial_numerators_acc.columns[col_idx][..],
-                    );
-                }
+                assert_eq!(
+                    acc_simd.partial_numerators_acc.to_cpu().columns,
+                    acc_cpu.partial_numerators_acc.columns
+                );
             });
     }
 }

--- a/crates/stwo/src/prover/pcs/quotient_ops.rs
+++ b/crates/stwo/src/prover/pcs/quotient_ops.rs
@@ -22,9 +22,10 @@ pub trait QuotientOps: PolyOps {
     /// `accumulated_numerators_vec` with their FRI numerators accumulations, across
     /// `sample_batches`.
     ///
-    /// For each sample batch in sample_batches, accumulates the numerators of the columns involved
-    /// in this batch and pushes an `AccumulatedNumerators` object into
-    /// `accumulated_numerators_vec`.
+    /// For each sample batch in `sample_batches`, accumulates the numerators of the columns
+    /// involved in this batch over the evaluation subdomain (the first
+    /// `column_size >> log_blowup_factor` rows in bit-reversed order) and pushes an
+    /// `AccumulatedNumerators` object into `accumulated_numerators_vec`.
     fn accumulate_numerators(
         columns: &[&CircleEvaluation<Self, BaseField, BitReversedOrder>],
         sample_batches: &[ColumnSampleBatch],
@@ -32,12 +33,17 @@ pub trait QuotientOps: PolyOps {
         log_blowup_factor: u32,
     );
 
-    /// Given a vector of `AccumulatedNumerators`, the function iterates over the points of the
-    /// largest domain of the accumulated numerators, and:
-    /// * for each sample point, computes the denominator of the quotient for that (domain point,
-    ///   sample point).
-    /// * multiplies it by the accumulated numerator for that domain point and sample point.
-    /// * sums across sample points.
+    /// Given a vector of `AccumulatedNumerators` (computed on evaluation subdomains), computes
+    /// the full quotient on the subdomain of size `2^(lifting_log_size - log_blowup_factor)`,
+    /// then interpolates and evaluates on the full domain of size `2^lifting_log_size`.
+    ///
+    /// For each subdomain point:
+    /// * Computes the denominator inverse for each sample point.
+    /// * Multiplies it by the accumulated numerator for that (subdomain point, sample point).
+    /// * Sums across sample points.
+    ///
+    /// The result is then extended to the full evaluation domain via interpolation on the
+    /// subdomain followed by evaluation on the full domain, using the provided `twiddles`.
     fn compute_quotients_and_combine(
         accs: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
@@ -178,10 +184,11 @@ mod tests {
     use crate::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
     use crate::core::verifier::VerificationError;
     use crate::prover::backend::cpu::{CpuCircleEvaluation, CpuCirclePoly};
+    use crate::prover::backend::simd::column::BaseColumn;
     use crate::prover::backend::simd::SimdBackend;
-    use crate::prover::backend::{Backend, BackendForChannel, CpuBackend};
+    use crate::prover::backend::{Backend, BackendForChannel, Column, CpuBackend};
     use crate::prover::pcs::quotient_ops::compute_fri_quotients;
-    use crate::prover::poly::circle::{CircleCoefficients, PolyOps};
+    use crate::prover::poly::circle::{CircleCoefficients, CircleEvaluation, PolyOps};
     use crate::prover::{CommitmentSchemeProver, SecureField};
 
     #[test]
@@ -302,5 +309,51 @@ mod tests {
     #[test]
     fn test_pcs_prove_and_verify_simd_with_barycentric() {
         assert!(prove_and_verify_pcs::<SimdBackend, false>().is_ok());
+    }
+
+    /// Tests that SIMD quotient computation produces low-degree quotients even when the trace
+    /// polynomial is very small (subdomain size < N_LANES).
+    #[test]
+    fn test_simd_quotients_are_low_degree_small_trace() {
+        let mut rng = SmallRng::seed_from_u64(0);
+        const LOG_SIZE: u32 = 3;
+        const LOG_BLOWUP_FACTOR: u32 = 4;
+
+        let polynomial = CpuCirclePoly::new((0..1 << LOG_SIZE).map(M31::from).collect());
+        let eval_domain = CanonicCoset::new(LOG_SIZE + LOG_BLOWUP_FACTOR).circle_domain();
+        let cpu_eval = polynomial.evaluate(eval_domain);
+        let simd_eval = CircleEvaluation::new(eval_domain, BaseColumn::from_cpu(&cpu_eval.values));
+
+        let sample_points = [
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+        ];
+        let samples = sample_points
+            .into_iter()
+            .map(|x| PointSample {
+                point: x,
+                value: polynomial.eval_at_point(x),
+            })
+            .collect_vec();
+        let rand_coeff =
+            SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.gen::<u32>())));
+        let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
+        let quot_eval = compute_fri_quotients(
+            &TreeVec(vec![vec![&simd_eval]]),
+            &TreeVec(vec![vec![samples]]),
+            rand_coeff,
+            LOG_SIZE + LOG_BLOWUP_FACTOR,
+            &twiddles,
+            LOG_BLOWUP_FACTOR,
+        );
+        let mut coeffs = quot_eval
+            .values
+            .columns
+            .iter()
+            .map(|c| CpuCircleEvaluation::new(eval_domain, c.to_cpu()).interpolate())
+            .collect_vec();
+        let zeros = coeffs[0].coeffs.split_off((1 << LOG_SIZE) - 1);
+
+        assert!(zeros.iter().all(|c| c.is_zero()));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches SIMD FRI quotient accumulation/combination logic and introduces subdomain interpolation/evaluation, which is correctness-critical for proofs. Risk is mitigated by CPU fallbacks for small domains plus added benchmark coverage and new low-degree regression tests.
> 
> **Overview**
> Updates the SIMD FRI quotient pipeline to **accumulate numerators only on the evaluation subdomain** and to **compute quotients on that subdomain then extend to the full evaluation domain** via interpolation+evaluation using extracted subdomain `itwiddles`.
> 
> Adds a small-domain safeguard by **falling back to the CPU backend when the subdomain is smaller than SIMD lane width**, and tightens tests to cover both CPU/SIMD consistency and a new regression for *very small traces* (subdomain size < lanes). Also adds a Criterion benchmark for `compute_quotients_and_combine`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdae11018c9ddfb6dafdd709850211282ae1c57f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->