### PR TITLE
Accumulate quotients on subdomain and extend (CPU)

### DIFF
--- a/crates/stwo/benches/fri_quotients.rs
+++ b/crates/stwo/benches/fri_quotients.rs
@@ -95,6 +95,7 @@ fn bench_accumulate_numerators(c: &mut Criterion) {
                         black_box(&col_refs),
                         black_box(&sample_batches),
                         black_box(&mut acc),
+                        black_box(log_blowup_factor),
                     );
                     acc
                 },
@@ -106,15 +107,19 @@ fn bench_accumulate_numerators(c: &mut Criterion) {
 fn bench_compute_quotients_and_combine(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
 
+    let trace_log_size = 19;
+    let log_blowup_factor = 2;
+    let eval_log_size = trace_log_size + log_blowup_factor;
+    let eval_domain = CanonicCoset::new(eval_log_size).circle_domain();
+    let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
     let n_sample_points = 10;
-    let lifting_log_size = 21;
 
     let accumulations: Vec<AccumulatedNumerators<SimdBackend>> = (0..n_sample_points)
         .map(|i| {
             let partial_numerators_acc = SecureColumnByCoords {
                 columns: std::array::from_fn(|_| {
                     BaseColumn::from_cpu(
-                        &(0..(1 << lifting_log_size))
+                        &(0..(1 << trace_log_size))
                             .map(|_| rng.gen::<M31>())
                             .collect::<Vec<_>>(),
                     )
@@ -131,11 +136,18 @@ fn bench_compute_quotients_and_combine(c: &mut Criterion) {
         .collect();
 
     c.bench_function(
-        &format!("compute_quotients_and_combine 2^{lifting_log_size} x {n_sample_points} pts"),
+        &format!("compute_quotients_and_combine 2^{eval_log_size} x {n_sample_points} pts"),
         |b| {
             b.iter_batched(
                 || accumulations.clone(),
-                |acc| SimdBackend::compute_quotients_and_combine(black_box(acc), lifting_log_size),
+                |acc| {
+                    SimdBackend::compute_quotients_and_combine(
+                        black_box(acc),
+                        eval_log_size,
+                        log_blowup_factor,
+                        &twiddles,
+                    )
+                },
                 BatchSize::LargeInput,
             );
         },

--- a/crates/stwo/src/prover/backend/cpu/quotients.rs
+++ b/crates/stwo/src/prover/backend/cpu/quotients.rs
@@ -14,6 +14,7 @@ use crate::core::poly::circle::CanonicCoset;
 use crate::core::utils::bit_reverse_index;
 use crate::prover::pcs::quotient_ops::AccumulatedNumerators;
 use crate::prover::poly::circle::{CircleEvaluation, SecureEvaluation};
+use crate::prover::poly::twiddles::{TwiddleBuffer, TwiddleTree};
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
 use crate::prover::QuotientOps;
@@ -23,13 +24,16 @@ impl QuotientOps for CpuBackend {
         columns: &[&CircleEvaluation<Self, BaseField, BitReversedOrder>],
         sample_batches: &[ColumnSampleBatch],
         accumulated_numerators_vec: &mut Vec<AccumulatedNumerators<Self>>,
+        log_blowup_factor: u32,
     ) {
         let size = columns[0].len();
+        let subdomain_size = size >> log_blowup_factor;
         let quotient_constants = quotient_constants(sample_batches);
 
         for (batch, coeffs) in zip(sample_batches, quotient_constants.line_coeffs) {
-            let mut partial_numerators_acc = unsafe { SecureColumnByCoords::uninitialized(size) };
-            for row in 0..size {
+            let mut partial_numerators_acc =
+                unsafe { SecureColumnByCoords::uninitialized(subdomain_size) };
+            for row in 0..subdomain_size {
                 let query_values_at_row = columns.iter().map(|col| col[row]).collect_vec();
                 let row_value =
                     accumulate_row_partial_numerators(batch, &query_values_at_row, &coeffs);
@@ -47,20 +51,24 @@ impl QuotientOps for CpuBackend {
     fn compute_quotients_and_combine(
         accumulations: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
+        log_blowup_factor: u32,
+        twiddles: &TwiddleTree<Self>,
     ) -> SecureEvaluation<Self, BitReversedOrder> {
-        let domain = CanonicCoset::new(lifting_log_size).circle_domain();
+        let eval_domain = CanonicCoset::new(lifting_log_size).circle_domain();
+        let (eval_subdomain, _) = eval_domain.split(log_blowup_factor);
+        let subdomain_log_size = eval_subdomain.log_size();
         let mut quotients: SecureColumnByCoords<CpuBackend> =
-            unsafe { SecureColumnByCoords::uninitialized(1 << lifting_log_size) };
+            unsafe { SecureColumnByCoords::uninitialized(1 << subdomain_log_size) };
         let sample_points: Vec<CirclePoint<SecureField>> =
             accumulations.iter().map(|x| x.sample_point).collect();
-        // Populate `quotients`.
+        // Populate `quotients` on the subdomain.
         for row in 0..quotients.len() {
-            let domain_point = domain.at(bit_reverse_index(row, lifting_log_size));
+            let domain_point = eval_subdomain.at(bit_reverse_index(row, subdomain_log_size));
             let inverses = denominator_inverses(&sample_points, domain_point);
             let mut quotient = SecureField::zero();
             for (acc, den_inv) in accumulations.iter().zip_eq(inverses) {
                 let mut full_numerator = SecureField::zero();
-                let log_ratio = lifting_log_size - acc.partial_numerators_acc.len().ilog2();
+                let log_ratio = subdomain_log_size - acc.partial_numerators_acc.len().ilog2();
                 let lifted_idx = (row >> (log_ratio + 1) << 1) + (row & 1);
 
                 full_numerator += acc.partial_numerators_acc.at(lifted_idx)
@@ -71,6 +79,24 @@ impl QuotientOps for CpuBackend {
             }
             quotients.set(row, quotient);
         }
-        SecureEvaluation::new(domain, quotients)
+        // Interpolate on subdomain and evaluate on full domain.
+        let subdomain_twiddles = TwiddleTree {
+            root_coset: eval_subdomain.half_coset,
+            twiddles: TwiddleBuffer::empty(),
+            itwiddles: twiddles
+                .itwiddles
+                .extract_subdomain_twiddles(eval_domain.log_size(), eval_subdomain.log_size()),
+        };
+        let evals = SecureColumnByCoords {
+            columns: quotients.columns.map(|eval| {
+                let poly = CircleEvaluation::<CpuBackend, BaseField, BitReversedOrder>::new(
+                    eval_subdomain,
+                    eval,
+                )
+                .interpolate_with_twiddles(&subdomain_twiddles);
+                poly.evaluate_with_twiddles(eval_domain, twiddles).values
+            }),
+        };
+        SecureEvaluation::new(eval_domain, evals)
     }
 }

--- a/crates/stwo/src/prover/backend/simd/quotients.rs
+++ b/crates/stwo/src/prover/backend/simd/quotients.rs
@@ -20,6 +20,7 @@ use crate::prover::backend::simd::cm31::PackedCM31;
 use crate::prover::backend::simd::utils::to_lifted_simd;
 use crate::prover::pcs::quotient_ops::AccumulatedNumerators;
 use crate::prover::poly::circle::{CircleEvaluation, SecureEvaluation};
+use crate::prover::poly::twiddles::TwiddleTree;
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
 use crate::prover::QuotientOps;
@@ -35,6 +36,7 @@ impl QuotientOps for SimdBackend {
         columns: &[&CircleEvaluation<Self, BaseField, BitReversedOrder>],
         sample_batches: &[ColumnSampleBatch],
         accumulated_numerators_vec: &mut Vec<AccumulatedNumerators<Self>>,
+        _log_blowup_factor: u32,
     ) {
         // This constant is chosen empirically by benchmarking.
         const NUMERATORS_CHUNK_SIZE: usize = 1 << 6;
@@ -91,6 +93,8 @@ impl QuotientOps for SimdBackend {
     fn compute_quotients_and_combine(
         accumulations: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
+        _log_blowup_factor: u32,
+        _twiddles: &TwiddleTree<Self>,
     ) -> SecureEvaluation<Self, BitReversedOrder> {
         // This constant is chosen empirically by benchmarking.
         const COMBINE_CHUNK_SIZE: usize = 16;
@@ -220,6 +224,7 @@ mod tests {
     fn test_simd_and_cpu_numerators_are_consistent() {
         const LOG_SIZE: u32 = 10;
         const N_COLS: usize = 100;
+        const LOG_BLOWUP_FACTOR: u32 = 3;
         let mut rng = SmallRng::seed_from_u64(0);
         let domain = CanonicCoset::new(LOG_SIZE).circle_domain();
         let values = BaseColumn::from_cpu(&(0..1 << LOG_SIZE).map(BaseField::from).collect_vec());
@@ -257,7 +262,7 @@ mod tests {
             .flatten()
             .collect_vec(),
         );
-        // SIMD
+        // SIMD (still accumulates over full domain).
         let mut accumulated_numerators_vec_simd: Vec<AccumulatedNumerators<SimdBackend>> = vec![];
         let columns_simd: Vec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> =
             (0..N_COLS).map(|_| columns.clone()).collect();
@@ -266,8 +271,9 @@ mod tests {
             &columns_simd.iter().collect_vec(),
             &sample_batches,
             &mut accumulated_numerators_vec_simd,
+            LOG_BLOWUP_FACTOR,
         );
-        // CPU
+        // CPU (accumulates over subdomain).
         let mut accumulated_numerators_vec_cpu: Vec<AccumulatedNumerators<CpuBackend>> = vec![];
         let columns_cpu: Vec<CircleEvaluation<CpuBackend, BaseField, BitReversedOrder>> =
             (0..N_COLS).map(|_| columns.to_cpu().clone()).collect();
@@ -275,8 +281,13 @@ mod tests {
             &columns_cpu.iter().collect_vec(),
             &sample_batches,
             &mut accumulated_numerators_vec_cpu,
+            LOG_BLOWUP_FACTOR,
         );
 
+        // The SIMD result is over the full domain, while the CPU result is over the subdomain
+        // (a bit-reversed prefix). Compare the prefix.
+        // TODO(Leo): revert in next PR after SIMD impl.
+        let subdomain_size = 1 << (LOG_SIZE - LOG_BLOWUP_FACTOR);
         accumulated_numerators_vec_simd
             .iter()
             .zip_eq(accumulated_numerators_vec_cpu)
@@ -285,10 +296,13 @@ mod tests {
                     acc_simd.first_linear_term_acc,
                     acc_cpu.first_linear_term_acc
                 );
-                assert_eq!(
-                    acc_simd.partial_numerators_acc.to_cpu().columns,
-                    acc_cpu.partial_numerators_acc.columns
-                );
+                let simd_cpu = acc_simd.partial_numerators_acc.to_cpu();
+                for col_idx in 0..4 {
+                    assert_eq!(
+                        simd_cpu.columns[col_idx][..subdomain_size],
+                        acc_cpu.partial_numerators_acc.columns[col_idx][..],
+                    );
+                }
             });
     }
 }

--- a/crates/stwo/src/prover/pcs/mod.rs
+++ b/crates/stwo/src/prover/pcs/mod.rs
@@ -232,6 +232,7 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
             &samples,
             channel.draw_secure_felt(),
             lifting_log_size,
+            self.twiddles,
             self.config.fri_config.log_blowup_factor,
         );
 

--- a/crates/stwo/src/prover/pcs/quotient_ops.rs
+++ b/crates/stwo/src/prover/pcs/quotient_ops.rs
@@ -12,6 +12,7 @@ use crate::core::pcs::quotients::{
 use crate::core::pcs::TreeVec;
 use crate::prover::backend::ColumnOps;
 use crate::prover::poly::circle::{CircleEvaluation, PolyOps, SecureEvaluation};
+use crate::prover::poly::twiddles::TwiddleTree;
 use crate::prover::poly::BitReversedOrder;
 use crate::prover::secure_column::SecureColumnByCoords;
 use crate::prover::AccumulationOps;
@@ -28,6 +29,7 @@ pub trait QuotientOps: PolyOps {
         columns: &[&CircleEvaluation<Self, BaseField, BitReversedOrder>],
         sample_batches: &[ColumnSampleBatch],
         accumulated_numerators_vec: &mut Vec<AccumulatedNumerators<Self>>,
+        log_blowup_factor: u32,
     );
 
     /// Given a vector of `AccumulatedNumerators`, the function iterates over the points of the
@@ -39,6 +41,8 @@ pub trait QuotientOps: PolyOps {
     fn compute_quotients_and_combine(
         accs: Vec<AccumulatedNumerators<Self>>,
         lifting_log_size: u32,
+        log_blowup_factor: u32,
+        twiddles: &TwiddleTree<Self>,
     ) -> SecureEvaluation<Self, BitReversedOrder>;
 }
 
@@ -78,7 +82,8 @@ pub fn compute_fri_quotients<B: QuotientOps + AccumulationOps>(
     samples: &TreeVec<Vec<Vec<PointSample>>>,
     random_coeff: SecureField,
     lifting_log_size: u32,
-    _log_blowup_factor: u32,
+    twiddles: &TwiddleTree<B>,
+    log_blowup_factor: u32,
 ) -> SecureEvaluation<B, BitReversedOrder> {
     let _span = span!(Level::INFO, "Compute FRI quotients", class = "FRIQuotients").entered();
     let mut accumulated_numerators_vec: Vec<AccumulatedNumerators<B>> = vec![];
@@ -109,7 +114,12 @@ pub fn compute_fri_quotients<B: QuotientOps + AccumulationOps>(
         let (columns, samples_with_randomness): (Vec<_>, Vec<_>) = tuples.unzip();
         // TODO: slice.
         let sample_batches = ColumnSampleBatch::new_vec(&samples_with_randomness);
-        B::accumulate_numerators(&columns, &sample_batches, &mut accumulated_numerators_vec)
+        B::accumulate_numerators(
+            &columns,
+            &sample_batches,
+            &mut accumulated_numerators_vec,
+            log_blowup_factor,
+        )
     });
 
     // Group and accumulate the numerators per sample point: the accumulations (of different
@@ -144,7 +154,12 @@ pub fn compute_fri_quotients<B: QuotientOps + AccumulationOps>(
         })
         .collect_vec();
 
-    B::compute_quotients_and_combine(accumulations_per_sample_point, lifting_log_size)
+    B::compute_quotients_and_combine(
+        accumulations_per_sample_point,
+        lifting_log_size,
+        log_blowup_factor,
+        twiddles,
+    )
 }
 
 #[cfg(test)]
@@ -166,7 +181,7 @@ mod tests {
     use crate::prover::backend::simd::SimdBackend;
     use crate::prover::backend::{Backend, BackendForChannel, CpuBackend};
     use crate::prover::pcs::quotient_ops::compute_fri_quotients;
-    use crate::prover::poly::circle::CircleCoefficients;
+    use crate::prover::poly::circle::{CircleCoefficients, PolyOps};
     use crate::prover::{CommitmentSchemeProver, SecureField};
 
     #[test]
@@ -197,6 +212,7 @@ mod tests {
             &TreeVec(vec![vec![samples]]),
             rand_coeff,
             LOG_SIZE + LOG_BLOWUP_FACTOR,
+            &CpuBackend::precompute_twiddles(eval_domain.half_coset),
             LOG_BLOWUP_FACTOR,
         );
         let mut coeffs = quot_eval


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes core quotient evaluation logic used in FRI/PCS proving by computing on a smaller subdomain and then interpolating/extending, which can impact proof correctness and domain alignment. Also alters `QuotientOps` APIs to thread `log_blowup_factor` and twiddle data through callers, increasing integration risk across backends.
> 
> **Overview**
> Updates FRI quotient generation to **accumulate CPU numerators only over the evaluation subdomain** (shrinking work by `log_blowup_factor`) and then **interpolate on that subdomain and re-evaluate on the full domain** using extracted inverse twiddles.
> 
> This threads `log_blowup_factor` and a `TwiddleTree` through the `QuotientOps` trait, `compute_fri_quotients`, and the PCS prover call site; SIMD is updated to the new signatures but still computes over the full domain (tests/benchmarks adjusted accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 732e3504416d2c099b75c7b4cc8ca51f51b5bb23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->