### PR TITLE
Clarify that lifting_log_size includes log_blowup_factor in doc comment

### DIFF
--- a/crates/stwo/src/core/pcs/mod.rs
+++ b/crates/stwo/src/core/pcs/mod.rs
@@ -32,11 +32,12 @@ pub struct PcsConfig {
     /// The number of proof of work bits before the FRI queries.
     pub pow_bits: u32,
     pub fri_config: FriConfig,
-    /// An optional integer which controls the size of the lifting domain. If `None`, the prover
-    /// lifts each tree’s polynomials to the largest domain within that tree (an implicit
-    /// assumption here is that the largest domains are all of equal size across trees, except
-    /// possibly for the preprocessed tree). If not `None`, all polynomials are lifted to the
-    /// domain of given log size.
+    /// An optional integer which controls the size of the lifting domain (This size includes the
+    /// `log_blowup_factor`). When specified, the prover lifts all polynomials to the domain of
+    /// given log size.
+    /// If `None`, the prover lifts each tree’s polynomials to the largest domain within that tree
+    /// (an implicit assumption here is that the largest domains are all of equal size across
+    /// trees, except possibly for the preprocessed tree).
     pub lifting_log_size: Option<u32>,
 }
 impl PcsConfig {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Doc-only change that clarifies how `lifting_log_size` is interpreted; no functional or security-impacting code changes.
> 
> **Overview**
> Updates the doc comment on `PcsConfig::lifting_log_size` to explicitly state the provided log size **includes** the FRI `log_blowup_factor`, and to more clearly describe the lifting behavior when the value is `Some` versus `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acfb6646a9fd6a8eae95f915d56185d0787b233d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->