### PR TITLE
Replace Vec with fixed-size array for column_index_per_interaction.

### DIFF
--- a/crates/constraint-framework/src/lib.rs
+++ b/crates/constraint-framework/src/lib.rs
@@ -38,6 +38,10 @@ use stwo::core::Fraction;
 pub use stwo::core::verifier::PREPROCESSED_TRACE_IDX;
 pub const ORIGINAL_TRACE_IDX: usize = 1;
 pub const INTERACTION_TRACE_IDX: usize = 2;
+/// Maximum number of trace interactions (i.e. trace polynomials committed before the composition
+/// polynomial is computed). Currently all components need at most 3 interactions, except
+/// [`examples::xor::gkr_lookups::MleEvalProverComponent`] which uses 4.
+pub const MAX_N_INTERACTIONS: usize = 4;
 
 /// A vector that describes the batching of logup entries.
 /// Each vector member corresponds to a logup entry, and contains the batch number to which the

--- a/crates/constraint-framework/src/prover/cpu_domain.rs
+++ b/crates/constraint-framework/src/prover/cpu_domain.rs
@@ -11,12 +11,12 @@ use stwo::prover::poly::circle::CircleEvaluation;
 use stwo::prover::poly::BitReversedOrder;
 
 use crate::logup::LogupAtRow;
-use crate::{EvalAtRow, INTERACTION_TRACE_IDX};
+use crate::{EvalAtRow, INTERACTION_TRACE_IDX, MAX_N_INTERACTIONS};
 
 /// Evaluates constraints at an evaluation domain points.
 pub struct CpuDomainEvaluator<'a> {
     pub trace_eval: &'a TreeVec<Vec<&'a CircleEvaluation<CpuBackend, BaseField, BitReversedOrder>>>,
-    pub column_index_per_interaction: Vec<usize>,
+    pub column_index_per_interaction: [usize; MAX_N_INTERACTIONS],
     pub row: usize,
     pub random_coeff_powers: &'a [SecureField],
     pub row_res: SecureField,
@@ -39,7 +39,10 @@ impl<'a> CpuDomainEvaluator<'a> {
     ) -> Self {
         Self {
             trace_eval,
-            column_index_per_interaction: vec![0; trace_eval.len()],
+            column_index_per_interaction: {
+                debug_assert!(trace_eval.len() <= MAX_N_INTERACTIONS);
+                [0; MAX_N_INTERACTIONS]
+            },
             row,
             random_coeff_powers,
             row_res: SecureField::zero(),

--- a/crates/constraint-framework/src/prover/relation_tracker.rs
+++ b/crates/constraint-framework/src/prover/relation_tracker.rs
@@ -14,7 +14,7 @@ use stwo::prover::backend::Column;
 
 use crate::{
     Batching, EvalAtRow, FrameworkComponent, FrameworkEval, Relation, RelationEntry,
-    INTERACTION_TRACE_IDX, PREPROCESSED_TRACE_IDX,
+    INTERACTION_TRACE_IDX, MAX_N_INTERACTIONS, PREPROCESSED_TRACE_IDX,
 };
 
 #[derive(Debug)]
@@ -56,7 +56,7 @@ pub fn add_to_relation_entries<E: FrameworkEval>(
 pub struct RelationTrackerEvaluator<'a> {
     entries: Vec<RelationTrackerEntry>,
     trace: &'a TreeVec<Vec<&'a Vec<BaseField>>>,
-    pub column_index_per_interaction: Vec<usize>,
+    pub column_index_per_interaction: [usize; MAX_N_INTERACTIONS],
     pub vec_row: usize,
     pub domain_log_size: u32,
 }
@@ -65,7 +65,10 @@ impl<'a> RelationTrackerEvaluator<'a> {
         Self {
             entries: vec![],
             trace,
-            column_index_per_interaction: vec![0; trace.len()],
+            column_index_per_interaction: {
+                debug_assert!(trace.len() <= MAX_N_INTERACTIONS);
+                [0; MAX_N_INTERACTIONS]
+            },
             vec_row: row,
             domain_log_size,
         }

--- a/crates/constraint-framework/src/prover/simd_domain.rs
+++ b/crates/constraint-framework/src/prover/simd_domain.rs
@@ -17,13 +17,13 @@ use stwo::prover::poly::circle::CircleEvaluation;
 use stwo::prover::poly::BitReversedOrder;
 
 use crate::logup::LogupAtRow;
-use crate::{EvalAtRow, INTERACTION_TRACE_IDX};
+use crate::{EvalAtRow, INTERACTION_TRACE_IDX, MAX_N_INTERACTIONS};
 
 /// Evaluates constraints at an evaluation domain points.
 pub struct SimdDomainEvaluator<'a> {
     pub trace_eval:
         &'a TreeVec<Vec<&'a CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>>,
-    pub column_index_per_interaction: Vec<usize>,
+    pub column_index_per_interaction: [usize; MAX_N_INTERACTIONS],
     /// The row index of the simd-vector row to evaluate the constraints at.
     pub vec_row: usize,
     pub random_coeff_powers: &'a [SecureField],
@@ -45,7 +45,10 @@ impl<'a> SimdDomainEvaluator<'a> {
     ) -> Self {
         Self {
             trace_eval,
-            column_index_per_interaction: vec![0; trace_eval.len()],
+            column_index_per_interaction: {
+                debug_assert!(trace_eval.len() <= MAX_N_INTERACTIONS);
+                [0; MAX_N_INTERACTIONS]
+            },
             vec_row,
             random_coeff_powers,
             row_res: VeryPackedSecureField::zero(),


### PR DESCRIPTION
This field tracks per-interaction column indices during constraint
evaluation and is re-created for every row in the hot loop. Switching
from Vec<usize> to [usize; MAX_N_INTERACTIONS] eliminates a heap
allocation per evaluator construction (millions of times per proof).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces allocations in the prover hot loop, but correctness now relies on `MAX_N_INTERACTIONS` being an upper bound; exceeding it would cause out-of-bounds indexing in release builds.
> 
> **Overview**
> Introduces a global `MAX_N_INTERACTIONS` constant (set to 4) and switches `column_index_per_interaction` in `CpuDomainEvaluator`, `SimdDomainEvaluator`, and `RelationTrackerEvaluator` from a `Vec<usize>` to a fixed `[usize; MAX_N_INTERACTIONS]`.
> 
> Evaluator constructors now zero-initialize the fixed array and `debug_assert!` that the trace has no more than `MAX_N_INTERACTIONS`, eliminating a heap allocation on each per-row evaluator creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ade70db208a3e9d05b1ec864ea906ed9528f049. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->