### PR TITLE
Bump version to 2.2.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -9,8 +9,8 @@ description = "Utility functions for AIR (Algebraic Intermediate Representation)
 bytemuck.workspace = true
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = false }
-stwo = { path = "../stwo", version = "2.1.0", features = ["prover"] }
-stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.1.0" }
+stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
+stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.2.0" }
 
 [lib]
 bench = false

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.1.0"
+version = "2.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
@@ -16,7 +16,7 @@ rayon = { workspace = true, optional = true }
 num-traits.workspace = true
 itertools.workspace = true
 tracing.workspace = true
-stwo = { path = "../stwo", version = "2.1.0", default-features = false }
+stwo = { path = "../stwo", version = "2.2.0", default-features = false }
 rand.workspace = true
 hashbrown.workspace = true
 stwo-std-shims = { version = "1.0.0", default-features = false }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -20,8 +20,8 @@ itertools.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-stwo = { path = "../stwo", version = "2.1.0", features = ["prover"] }
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.1.0", features = [
+stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
     "prover",
     "parallel",
 ] }

--- a/scripts/bump_versions.sh
+++ b/scripts/bump_versions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CURRENT_VERSION='2.1.0'
+CURRENT_VERSION='2.2.0'
 NEW_VERSION="$@"
 
 if [ -z "$NEW_VERSION" ]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a dependency/version bump across workspace manifests and the version bump script, with no functional code changes.
> 
> **Overview**
> Bumps the workspace/package version from `2.1.0` to `2.2.0` and updates internal crate dependency pins (`stwo`, `stwo-air-utils-derive`, `stwo-constraint-framework`) to match.
> 
> Updates `scripts/bump_versions.sh` to treat `2.2.0` as the current version for future automated version bumps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33167dc62ac4965ab6c5ffff513421b3b3a8d2b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->