### PR TITLE
Update Cargo.lock file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "criterion",
  "educe",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only update bumping `stwo` and related crates from `2.1.0` to `2.2.0`, with no source changes; risk is limited to potential dependency behavior changes at build/runtime.
> 
> **Overview**
> Updates `Cargo.lock` to bump the `stwo` dependency set (`stwo`, `stwo-air-utils`, `stwo-air-utils-derive`, `stwo-constraint-framework`, `stwo-examples`) from `2.1.0` to `2.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea550fbf8f72f2f502f458cda237e197e9e996e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->