### PR TITLE
Add InvalidLiftingLogSizeError shared by prover and verifier.

### DIFF
--- a/crates/stwo/src/core/pcs/utils.rs
+++ b/crates/stwo/src/core/pcs/utils.rs
@@ -3,6 +3,7 @@ use core::ops::{Deref, DerefMut};
 use itertools::zip_eq;
 use serde::{Deserialize, Serialize};
 use std_shims::{vec, BTreeSet, Vec};
+use thiserror::Error;
 
 use super::TreeSubspan;
 use crate::core::pcs::PcsConfig;
@@ -212,9 +213,24 @@ pub fn prepare_preprocessed_query_positions(
         .collect()
 }
 
-pub fn get_lifting_log_size(config: &PcsConfig, log_trace_size: u32) -> u32 {
-    let lifting_log_size = config.lifting_log_size.unwrap_or(log_trace_size);
-    assert!(log_trace_size <= lifting_log_size);
+#[derive(Clone, Copy, Debug, Error)]
+#[error("Lifting log size is too small ({lifting_log_size}). It must be at least {min_log_size}.")]
+pub struct InvalidLiftingLogSizeError {
+    pub lifting_log_size: u32,
+    pub min_log_size: u32,
+}
 
-    lifting_log_size
+pub fn try_get_lifting_log_size(
+    config: &PcsConfig,
+    log_trace_size: u32,
+) -> Result<u32, InvalidLiftingLogSizeError> {
+    let lifting_log_size = config.lifting_log_size.unwrap_or(log_trace_size);
+    if lifting_log_size < log_trace_size {
+        return Err(InvalidLiftingLogSizeError {
+            lifting_log_size,
+            min_log_size: log_trace_size,
+        });
+    }
+
+    Ok(lifting_log_size)
 }

--- a/crates/stwo/src/core/verifier.rs
+++ b/crates/stwo/src/core/verifier.rs
@@ -6,7 +6,7 @@ use crate::core::channel::{Channel, MerkleChannel};
 use crate::core::circle::CirclePoint;
 use crate::core::fields::qm31::{SecureField, SECURE_EXTENSION_DEGREE};
 use crate::core::fri::FriVerificationError;
-use crate::core::pcs::utils::get_lifting_log_size;
+use crate::core::pcs::utils::try_get_lifting_log_size;
 use crate::core::pcs::CommitmentSchemeVerifier;
 use crate::core::proof::StarkProof;
 use crate::core::vcs_lifted::verifier::MerkleVerificationError;
@@ -56,12 +56,18 @@ pub fn verify_ex<MC: MerkleChannel>(
 
     // If `self.config.lifting_log_size` is None, the lifting size is the length of the split
     // composition polynomials' domain.
-    let lifting_log_size = get_lifting_log_size(
+    let lifting_log_size = try_get_lifting_log_size(
         &commitment_scheme.config,
         split_composition_log_degree_bound + commitment_scheme.config.fri_config.log_blowup_factor,
-    );
+    )?;
     if include_all_preprocessed_columns {
-        assert!(lifting_log_size >= commitment_scheme.trees[PREPROCESSED_TRACE_IDX].height);
+        let preprocessed_trace_height = commitment_scheme.trees[PREPROCESSED_TRACE_IDX].height;
+        if lifting_log_size < preprocessed_trace_height {
+            Err(crate::core::pcs::utils::InvalidLiftingLogSizeError {
+                lifting_log_size,
+                min_log_size: preprocessed_trace_height,
+            })?;
+        }
     }
 
     // The max degree of a committed polynomial. If `lifting_log_size` is not set,
@@ -130,4 +136,6 @@ pub enum VerificationError {
     Fri(#[from] FriVerificationError),
     #[error("Proof of work verification failed.")]
     ProofOfWork,
+    #[error(transparent)]
+    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
 }

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -4,7 +4,7 @@ use tracing::{info, instrument, span, Level};
 use crate::core::channel::{Channel, MerkleChannel};
 use crate::core::circle::CirclePoint;
 use crate::core::fields::qm31::{SecureField, SECURE_EXTENSION_DEGREE};
-use crate::core::pcs::utils::get_lifting_log_size;
+use crate::core::pcs::utils::{try_get_lifting_log_size, InvalidLiftingLogSizeError};
 use crate::core::proof::{ExtendedStarkProof, StarkProof};
 use crate::core::verifier::PREPROCESSED_TRACE_IDX;
 use crate::prover::backend::BackendForChannel;
@@ -94,7 +94,7 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
     // If `self.config.lifting_log_size` is None, the lifting size is the length of the split
     // composition polynomials' domain.
     let lifting_log_size =
-        get_lifting_log_size(&commitment_scheme.config, split_composition_log_size);
+        try_get_lifting_log_size(&commitment_scheme.config, split_composition_log_size)?;
     if include_all_preprocessed_columns {
         // If all the preprocessed columns are included, the lifting log size must be greater than
         // or equal to the preprocessed log size.
@@ -103,7 +103,12 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
             .layers
             .len() as u32
             - 1;
-        assert!(lifting_log_size >= preprocessed_log_size);
+        if lifting_log_size < preprocessed_log_size {
+            Err(InvalidLiftingLogSizeError {
+                lifting_log_size,
+                min_log_size: preprocessed_log_size,
+            })?;
+        }
     }
     let max_log_degree_bound =
         lifting_log_size - commitment_scheme.config.fri_config.log_blowup_factor;
@@ -150,4 +155,6 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
 pub enum ProvingError {
     #[error("Constraints not satisfied.")]
     ConstraintsNotSatisfied,
+    #[error(transparent)]
+    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
 }


### PR DESCRIPTION
Add a dedicated error type in pcs::utils so that
try_get_lifting_log_size works for both ProvingError and
VerificationError.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces `assert!`-based invariants in prover/verifier with fallible error returns, changing failure mode from panic to propagated error. Risk is limited but touches proving/verification parameter validation paths that gate core protocol execution.
> 
> **Overview**
> Adds a shared `InvalidLiftingLogSizeError` in `core/pcs/utils.rs` and replaces `get_lifting_log_size` with `try_get_lifting_log_size` that returns `Result` instead of panicking.
> 
> Updates both prover and verifier to propagate this error (including the preprocessed-trace lifting-size check) via new `InvalidLiftingLogSize` variants in `ProvingError` and `VerificationError`, converting previous `assert!` failures into structured, user-visible errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2de36dd74aeb62e6a46787dff8236fc6b053d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->