### PR TITLE
Add CanonicCosetLogSizeError and use it in CanonicCoset::try_new, ProvingError, and VerificationError.

### DIFF
--- a/crates/stwo/src/core/poly/circle/canonic.rs
+++ b/crates/stwo/src/core/poly/circle/canonic.rs
@@ -1,6 +1,21 @@
+use thiserror::Error;
+
 use super::CircleDomain;
-use crate::core::circle::{CirclePoint, CirclePointIndex, Coset};
+use crate::core::circle::{CirclePoint, CirclePointIndex, Coset, M31_CIRCLE_LOG_ORDER};
 use crate::core::fields::m31::BaseField;
+use crate::core::poly::circle::MIN_CIRCLE_DOMAIN_LOG_SIZE;
+
+/// The maximum log size of a canonic coset is `M31_CIRCLE_LOG_ORDER - 1`, because the canonic coset
+/// of size 2^n is shifted by the generator of the group of size 2^(n+1).
+const MAX_CANONICAL_COSET_LOG_SIZE: u32 = M31_CIRCLE_LOG_ORDER - 1;
+
+#[derive(Clone, Copy, Debug, Error)]
+#[error(
+    "Invalid canonic coset log size ({log_size}). Must be between 1 and {MAX_CANONICAL_COSET_LOG_SIZE}."
+)]
+pub struct InvalidCanonicCosetLogSize {
+    pub log_size: u32,
+}
 
 /// A coset of the form `G_{2n} + <G_n>`, where `G_n` is the generator of the subgroup of order `n`.
 ///
@@ -25,11 +40,17 @@ pub struct CanonicCoset {
 }
 
 impl CanonicCoset {
-    pub fn new(log_size: u32) -> Self {
-        assert!(log_size > 0);
-        Self {
-            coset: Coset::odds(log_size),
+    pub fn try_new(log_size: u32) -> Result<Self, InvalidCanonicCosetLogSize> {
+        if !(MIN_CIRCLE_DOMAIN_LOG_SIZE..=MAX_CANONICAL_COSET_LOG_SIZE).contains(&log_size) {
+            return Err(InvalidCanonicCosetLogSize { log_size });
         }
+        Ok(Self {
+            coset: Coset::odds(log_size),
+        })
+    }
+
+    pub fn new(log_size: u32) -> Self {
+        Self::try_new(log_size).unwrap()
     }
 
     /// Gets the full coset represented G_{2n} + <G_n>.

--- a/crates/stwo/src/core/poly/circle/domain.rs
+++ b/crates/stwo/src/core/poly/circle/domain.rs
@@ -9,6 +9,7 @@ use crate::core::circle::{
 use crate::core::fields::m31::BaseField;
 
 pub const MAX_CIRCLE_DOMAIN_LOG_SIZE: u32 = M31_CIRCLE_LOG_ORDER - 1;
+pub const MIN_CIRCLE_DOMAIN_LOG_SIZE: u32 = 1;
 
 /// A valid domain for circle polynomial interpolation and evaluation.
 ///

--- a/crates/stwo/src/core/poly/circle/mod.rs
+++ b/crates/stwo/src/core/poly/circle/mod.rs
@@ -1,8 +1,8 @@
 mod canonic;
 mod domain;
 
-pub use canonic::CanonicCoset;
-pub use domain::{CircleDomain, MAX_CIRCLE_DOMAIN_LOG_SIZE};
+pub use canonic::{CanonicCoset, InvalidCanonicCosetLogSize};
+pub use domain::{CircleDomain, MAX_CIRCLE_DOMAIN_LOG_SIZE, MIN_CIRCLE_DOMAIN_LOG_SIZE};
 
 #[cfg(test)]
 mod tests {

--- a/crates/stwo/src/core/verifier.rs
+++ b/crates/stwo/src/core/verifier.rs
@@ -138,4 +138,6 @@ pub enum VerificationError {
     ProofOfWork,
     #[error(transparent)]
     InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
+    #[error(transparent)]
+    InvalidCanonicCosetLogSize(#[from] crate::core::poly::circle::InvalidCanonicCosetLogSize),
 }

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -157,4 +157,6 @@ pub enum ProvingError {
     ConstraintsNotSatisfied,
     #[error(transparent)]
     InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
+    #[error(transparent)]
+    InvalidCanonicCosetLogSize(#[from] crate::core::poly::circle::InvalidCanonicCosetLogSize),
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change that mainly adds input validation and error plumbing; primary behavior change is earlier failure for oversized/zero log sizes.
> 
> **Overview**
> Adds explicit validation for canonic coset sizes by introducing `InvalidCanonicCosetLogSize` and a fallible `CanonicCoset::try_new` that enforces `1..=M31_CIRCLE_LOG_ORDER-1` (with `new()` now delegating via `unwrap()`).
> 
> Re-exports the new error from `core::poly::circle` and adds transparent variants to `ProvingError` and `VerificationError` so invalid canonic coset sizing can be propagated as a structured error instead of panicking/asserting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5572c6720103ebe90aadf13f0d147c98ea190a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->