### PR TITLE
Add CI check that ensure-verifier-no_std/Cargo.lock is up-to-date.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,6 +265,8 @@ jobs:
           toolchain: ${{ env.NIGHTLY_VERSION }}
       - name: Check Cargo.lock is up-to-date
         run: cargo fetch --locked
+      - name: Check ensure-verifier-no_std/Cargo.lock is up-to-date
+        run: cargo fetch --locked --manifest-path ensure-verifier-no_std/Cargo.toml
 
   all-tests:
     runs-on: namespace-profile-starkware-libs-stwo-small-ubuntu-24-04-amd64

--- a/ensure-verifier-no_std/Cargo.lock
+++ b/ensure-verifier-no_std/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "stwo"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "blake2",
  "blake3",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change plus a lockfile bump for the `ensure-verifier-no_std` crate; no production code paths are modified.
> 
> **Overview**
> Adds a CI step in `cargo-lock` to run `cargo fetch --locked` against `ensure-verifier-no_std/Cargo.toml`, ensuring that crate’s `Cargo.lock` stays in sync.
> 
> Updates `ensure-verifier-no_std/Cargo.lock` to reflect current local crate versions (e.g., `stwo` and `stwo-constraint-framework` to `2.2.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95db6e8a4add46660bb5378ecff9475606c44358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->