### PR TITLE
Change fold_line to accept explicit alphas slice.

### DIFF
--- a/crates/stwo/benches/fri.rs
+++ b/crates/stwo/benches/fri.rs
@@ -26,9 +26,8 @@ fn folding_benchmark(c: &mut Criterion) {
         b.iter(|| {
             black_box(CpuBackend::fold_line(
                 black_box(&evals),
-                black_box(alpha),
+                black_box(&[alpha]),
                 &twiddles,
-                1,
             ));
         })
     });

--- a/crates/stwo/src/prover/backend/cpu/circle.rs
+++ b/crates/stwo/src/prover/backend/cpu/circle.rs
@@ -164,12 +164,8 @@ impl PolyOps for CpuBackend {
         );
 
         while layer_evaluation.len() > 1 {
-            layer_evaluation = CpuBackend::fold_line(
-                &layer_evaluation,
-                folding_alphas.pop().unwrap(),
-                twiddles,
-                1,
-            );
+            let alpha = folding_alphas.pop().unwrap();
+            layer_evaluation = CpuBackend::fold_line(&layer_evaluation, &[alpha], twiddles);
         }
 
         layer_evaluation.values.at(0) / SecureField::from(2_u32.pow(log_size))

--- a/crates/stwo/src/prover/backend/cpu/fri.rs
+++ b/crates/stwo/src/prover/backend/cpu/fri.rs
@@ -15,17 +15,15 @@ use crate::prover::secure_column::SecureColumnByCoords;
 impl FriOps for CpuBackend {
     fn fold_line(
         eval: &LineEvaluation<Self>,
-        alpha: SecureField,
+        alphas: &[SecureField],
         _twiddles: &TwiddleTree<Self>,
-        fold_step: u32,
     ) -> LineEvaluation<Self> {
+        let fold_step = alphas.len();
         assert!(fold_step >= 1);
 
-        let mut folding_alpha = alpha;
-        let mut res = fold_line_cpu(eval, folding_alpha);
-        for _ in 0..fold_step - 1 {
-            folding_alpha = folding_alpha * folding_alpha;
-            res = fold_line_cpu(&res, folding_alpha)
+        let mut res = fold_line_cpu(eval, alphas[0]);
+        for &alpha in &alphas[1..] {
+            res = fold_line_cpu(&res, alpha);
         }
         res
     }

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -357,12 +357,8 @@ impl PolyOps for SimdBackend {
             fold_circle_evaluation_into_line(evals, folding_alphas.pop().unwrap(), twiddles);
 
         while layer_evaluation.len() > 1 {
-            layer_evaluation = SimdBackend::fold_line(
-                &layer_evaluation,
-                folding_alphas.pop().unwrap(),
-                twiddles,
-                1,
-            );
+            let alpha = folding_alphas.pop().unwrap();
+            layer_evaluation = SimdBackend::fold_line(&layer_evaluation, &[alpha], twiddles);
         }
 
         layer_evaluation.values.at(0) / SecureField::from(2_u32.pow(log_size))

--- a/crates/stwo/src/prover/backend/simd/column.rs
+++ b/crates/stwo/src/prover/backend/simd/column.rs
@@ -794,8 +794,7 @@ impl VeryPackedSecureColumnByCoords {
             .get_disjoint_mut([0, 1, 2, 3])
             .unwrap()
             .map(|x| x.chunks_mut(chunk_size));
-        izip!(a, b, c, d)
-            .map(|(a, b, c, d)| VeryPackedSecureColumnByCoordsMutSlice([a, b, c, d]))
+        izip!(a, b, c, d).map(|(a, b, c, d)| VeryPackedSecureColumnByCoordsMutSlice([a, b, c, d]))
     }
 
     #[cfg(feature = "parallel")]

--- a/crates/stwo/src/prover/backend/simd/fri.rs
+++ b/crates/stwo/src/prover/backend/simd/fri.rs
@@ -31,28 +31,20 @@ const FOLD_CHUNK_SIZE: usize = 128;
 impl FriOps for SimdBackend {
     fn fold_line(
         eval: &LineEvaluation<Self>,
-        alpha: SecureField,
+        alphas: &[SecureField],
         twiddles: &TwiddleTree<Self>,
-        fold_step: u32,
     ) -> LineEvaluation<Self> {
+        let fold_step = alphas.len() as u32;
         assert!(fold_step >= 1, "fold_step must be positive.");
 
         let log_size = eval.len().ilog2();
         // Fallback to cpu if the log size is too small.
         if log_size < LOG_N_LANES + fold_step {
-            let mut folding_alpha = alpha;
-            let mut eval = fold_line_cpu(&eval.to_cpu(), folding_alpha);
-            for _ in 0..fold_step - 1 {
-                folding_alpha = folding_alpha * folding_alpha;
-                eval = fold_line_cpu(&eval, folding_alpha)
+            let mut eval = fold_line_cpu(&eval.to_cpu(), alphas[0]);
+            for &alpha in &alphas[1..] {
+                eval = fold_line_cpu(&eval, alpha)
             }
             return LineEvaluation::new(eval.domain(), eval.values.into_iter().collect());
-        }
-        let mut alphas = vec![];
-        let mut folding_alpha = alpha;
-        for _ in 0..fold_step {
-            alphas.push(folding_alpha);
-            folding_alpha = folding_alpha * folding_alpha;
         }
 
         let domain = eval.domain();
@@ -328,16 +320,14 @@ mod tests {
         let domain = LineDomain::new(CanonicCoset::new(LOG_SIZE + 1).half_coset());
         let cpu_fold = CpuBackend::fold_line(
             &LineEvaluation::new(domain, values.iter().copied().collect()),
-            alpha,
+            &[alpha],
             &CpuBackend::precompute_twiddles(domain.coset()),
-            1,
         );
 
         let avx_fold = SimdBackend::fold_line(
             &LineEvaluation::new(domain, values.iter().copied().collect()),
-            alpha,
+            &[alpha],
             &SimdBackend::precompute_twiddles(domain.coset()),
-            1,
         );
 
         assert_eq!(cpu_fold.values.to_vec(), avx_fold.values.to_vec());

--- a/crates/stwo/src/prover/fri.rs
+++ b/crates/stwo/src/prover/fri.rs
@@ -24,21 +24,23 @@ use crate::prover::vcs_lifted::ops::MerkleOpsLifted;
 use crate::prover::vcs_lifted::prover::MerkleProverLifted;
 
 pub trait FriOps: ColumnOps<BaseField> + PolyOps + Sized + ColumnOps<SecureField> {
-    /// Folds a degree `d` polynomial into a degree `d/2` polynomial.
+    /// Folds a degree `d` polynomial into a degree `d / 2^k` polynomial, where `k = alphas.len()`.
     ///
-    /// Let `eval` be a polynomial evaluated on a [LineDomain] `E`, `alpha` be a random field
-    /// element and `pi(x) = 2x^2 - 1` be the circle's x-coordinate doubling map. This function
-    /// returns `f' = f0 + alpha * f1` evaluated on `pi(E)` such that `2f(x) = f0(pi(x)) + x *
-    /// f1(pi(x))`.
+    /// For i ∈ [0, k), the i-th fold computes the evaluation of `f_{i+1} = f_{i,0} + alphas[i] *
+    /// f_{i,1}` on `E_{i+1} = pi(E_i)`, where:
+    /// * `f_i` is the folded polynomial at fold i (`f_0 = eval`), evaluated on line domain `E_i`
+    ///   (`E_0 = eval.domain()`).
+    /// * `pi(x) = 2x^2 - 1` is the doubling map.
+    /// * `f_{i,0}` and `f_{i,1}` are the polynomials determined by the identity `2*f_i(x) =
+    ///   f_{i,0}(pi(x)) + x * f_{i,1}(pi(x))`.
     ///
     /// # Panics
     ///
-    /// Panics if there are less than two evaluations.
+    /// Panics if `alphas` is empty.
     fn fold_line(
         eval: &LineEvaluation<Self>,
-        alpha: SecureField,
+        alphas: &[SecureField],
         twiddles: &TwiddleTree<Self>,
-        fold_step: u32,
     ) -> LineEvaluation<Self>;
 
     /// Folds and accumulates a degree `d` circle polynomial into a degree `d/2` univariate
@@ -70,6 +72,17 @@ pub trait FriOps: ColumnOps<BaseField> + PolyOps + Sized + ColumnOps<SecureField
     fn decompose(
         eval: &SecureEvaluation<Self, BitReversedOrder>,
     ) -> (SecureEvaluation<Self, BitReversedOrder>, SecureField);
+}
+
+/// Computes `len` folding alphas derived by repeated squaring: `[alpha, alpha^2, alpha^4, ...]`.
+pub fn squared_alpha_powers(alpha: SecureField, len: u32) -> Vec<SecureField> {
+    let mut alphas = Vec::with_capacity(len as usize);
+    let mut alpha = alpha;
+    for _ in 0..len {
+        alphas.push(alpha);
+        alpha = alpha * alpha;
+    }
+    alphas
 }
 
 pub struct FriDecommitResult<H: MerkleHasherLifted> {
@@ -146,9 +159,9 @@ impl<'a, B: FriOps + MerkleOpsLifted<MC::H>, MC: MerkleChannel> FriProver<'a, B,
         // Apply any additional line folds requested for the first stage.
         if config.fold_step > 1 {
             let extra_line_folds = config.fold_step - 1;
-            let alpha_sq = folding_alpha * folding_alpha;
-            layer_evaluation =
-                B::fold_line(&layer_evaluation, alpha_sq, twiddles, extra_line_folds);
+            let alpha_sq_powers =
+                squared_alpha_powers(folding_alpha * folding_alpha, extra_line_folds);
+            layer_evaluation = B::fold_line(&layer_evaluation, &alpha_sq_powers, twiddles);
             line_log_size -= extra_line_folds;
         }
 
@@ -166,8 +179,8 @@ impl<'a, B: FriOps + MerkleOpsLifted<MC::H>, MC: MerkleChannel> FriProver<'a, B,
             let layer = FriInnerLayerProver::new(layer_evaluation, config.fold_step);
             MC::mix_root(channel, layer.merkle_tree.root());
             let folding_alpha = channel.draw_secure_felt();
-            layer_evaluation =
-                B::fold_line(&layer.evaluation, folding_alpha, twiddles, config.fold_step);
+            let alpha_sq_powers = squared_alpha_powers(folding_alpha, config.fold_step);
+            layer_evaluation = B::fold_line(&layer.evaluation, &alpha_sq_powers, twiddles);
             layers.push(layer);
             line_log_size -= config.fold_step;
         }
@@ -177,7 +190,8 @@ impl<'a, B: FriOps + MerkleOpsLifted<MC::H>, MC: MerkleChannel> FriProver<'a, B,
         let layer = FriInnerLayerProver::new(layer_evaluation, last_fold_step);
         MC::mix_root(channel, layer.merkle_tree.root());
         let folding_alpha = channel.draw_secure_felt();
-        layer_evaluation = B::fold_line(&layer.evaluation, folding_alpha, twiddles, last_fold_step);
+        let alpha_sq_powers = squared_alpha_powers(folding_alpha, last_fold_step);
+        layer_evaluation = B::fold_line(&layer.evaluation, &alpha_sq_powers, twiddles);
         layers.push(layer);
 
         (layers, layer_evaluation)


### PR DESCRIPTION
The fold_line trait method now takes `alphas: &[SecureField]` instead of deriving
folding alphas internally by squaring. This enables callers to provide independently
computed alphas (e.g. eval_at_point_by_folding where alphas are related by double_x).
Add squared_alpha_powers() helper for FRI callers that still derive alphas by squaring.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>