### PR TITLE
Optimize SimdBackend Keccak256 MerkleOps with parallel f1600.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
@@ -132,7 +132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -197,7 +197,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -220,6 +220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -343,6 +352,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,9 +488,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -612,7 +649,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -684,6 +730,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1130,8 +1186,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
 ]
 
 [[package]]
@@ -1240,6 +1306,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "sha3",
  "starknet-crypto",
  "starknet-ff",
  "stwo-std-shims",
@@ -1461,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1302,6 +1303,7 @@ dependencies = [
  "hex",
  "indexmap",
  "itertools 0.12.1",
+ "keccak",
  "num-traits",
  "rand",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ itertools = { version = "0.12", default-features = false, features = [
 ] }
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false }
+sha3 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 educe = "0.5.0"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.19", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ itertools = { version = "0.12", default-features = false, features = [
 blake2 = { version = "0.10.6", default-features = false }
 blake3 = { version = "1.5.0", default-features = false }
 sha3 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+keccak = { version = "0.2.0", default-features = false, features = ["parallel"] }
 educe = "0.5.0"
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 num-traits = { version = "0.2.19", default-features = false }

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -30,6 +30,7 @@ tracing = []
 [dependencies]
 blake2.workspace = true
 blake3.workspace = true
+sha3.workspace = true
 bytemuck = { workspace = true, features = ["derive", "extern_crate_alloc"] }
 cfg-if = "1.0.0"
 educe.workspace = true

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -31,6 +31,7 @@ tracing = []
 blake2.workspace = true
 blake3.workspace = true
 sha3.workspace = true
+keccak.workspace = true
 bytemuck = { workspace = true, features = ["derive", "extern_crate_alloc"] }
 cfg-if = "1.0.0"
 educe.workspace = true

--- a/crates/stwo/src/core/channel/keccak256.rs
+++ b/crates/stwo/src/core/channel/keccak256.rs
@@ -1,0 +1,265 @@
+use core::{array, iter};
+
+use itertools::Itertools;
+use std_shims::Vec;
+
+use super::Channel;
+use crate::core::fields::m31::{BaseField, P};
+use crate::core::fields::qm31::{SecureField, SECURE_EXTENSION_DEGREE};
+use crate::core::vcs::keccak256_hash::{Keccak256Hash, Keccak256Hasher};
+
+pub const KECCAK_BYTES_PER_HASH: usize = 32;
+pub const FELTS_PER_HASH: usize = 8;
+
+/// A Fiat-Shamir channel backed by `keccak256`.
+///
+/// All multi-byte integer inputs are big-endian, matching Solidity's
+/// `abi.encodePacked` conventions so that an on-chain Solidity verifier can
+/// reproduce the transcript without byte-order translation.
+#[derive(Default, Clone, Debug)]
+pub struct Keccak256Channel {
+    digest: Keccak256Hash,
+    n_draws: u32,
+}
+
+impl Keccak256Channel {
+    pub const POW_PREFIX: u32 = 0x12345678;
+
+    pub const fn digest(&self) -> Keccak256Hash {
+        self.digest
+    }
+
+    pub const fn update_digest(&mut self, new_digest: Keccak256Hash) {
+        self.digest = new_digest;
+        self.n_draws = 0;
+    }
+
+    /// Generates a uniform random vector of BaseField elements via rejection
+    /// sampling. Retry probability per round is ~2^-28.
+    fn draw_base_felts(&mut self) -> [BaseField; FELTS_PER_HASH] {
+        loop {
+            let u32s: [u32; FELTS_PER_HASH] = self.draw_u32s().try_into().unwrap();
+
+            if u32s.iter().all(|x| *x < 2 * P) {
+                return u32s
+                    .into_iter()
+                    .map(|x| BaseField::reduce(x as u64))
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap();
+            }
+        }
+    }
+}
+
+impl Channel for Keccak256Channel {
+    const BYTES_PER_HASH: usize = KECCAK_BYTES_PER_HASH;
+
+    fn mix_felts(&mut self, felts: &[SecureField]) {
+        let felts_bytes = felts
+            .iter()
+            .flat_map(|qm31| qm31.to_m31_array())
+            .flat_map(|m31| m31.0.to_be_bytes())
+            .collect_vec();
+        let mut hasher = Keccak256Hasher::new();
+        hasher.update(self.digest.as_ref());
+        hasher.update(&felts_bytes);
+
+        self.update_digest(hasher.finalize());
+    }
+
+    fn mix_u32s(&mut self, data: &[u32]) {
+        let mut hasher = Keccak256Hasher::new();
+        hasher.update(self.digest.as_ref());
+        for word in data {
+            hasher.update(&word.to_be_bytes());
+        }
+
+        self.update_digest(hasher.finalize());
+    }
+
+    fn mix_u64(&mut self, value: u64) {
+        let mut hasher = Keccak256Hasher::new();
+        hasher.update(self.digest.as_ref());
+        hasher.update(&value.to_be_bytes());
+
+        self.update_digest(hasher.finalize());
+    }
+
+    fn draw_secure_felt(&mut self) -> SecureField {
+        let felts: [BaseField; FELTS_PER_HASH] = self.draw_base_felts();
+        SecureField::from_m31_array(felts[..SECURE_EXTENSION_DEGREE].try_into().unwrap())
+    }
+
+    fn draw_secure_felts(&mut self, n_felts: usize) -> Vec<SecureField> {
+        let mut felts = iter::from_fn(|| Some(self.draw_base_felts())).flatten();
+        let secure_felts = iter::from_fn(|| {
+            Some(SecureField::from_m31_array([
+                felts.next()?,
+                felts.next()?,
+                felts.next()?,
+                felts.next()?,
+            ]))
+        });
+        secure_felts.take(n_felts).collect()
+    }
+
+    fn draw_u32s(&mut self) -> Vec<u32> {
+        let mut hash_input = self.digest.as_ref().to_vec();
+
+        // Append BE counter bytes (4 bytes for u32).
+        hash_input.extend_from_slice(&self.n_draws.to_be_bytes());
+
+        // Domain separation byte between the draw and mix-single-u32 paths.
+        hash_input.push(0_u8);
+
+        self.n_draws += 1;
+        Keccak256Hasher::hash(&hash_input)
+            .0
+            .chunks_exact(4)
+            .map(|chunk| u32::from_be_bytes(chunk.try_into().unwrap()))
+            .collect()
+    }
+
+    /// Verifies that `H(H(POW_PREFIX_BE || [0u8;12] || digest || n_bits_BE) || nonce_BE)` has at
+    /// least `n_bits` leading zero bits when its first 16 bytes are interpreted as a big-endian
+    /// u128. Equivalent to Solidity's `uint256(hash) < 2**(256 - n_bits)` for `n_bits <= 128`.
+    fn verify_pow_nonce(&self, n_bits: u32, nonce: u64) -> bool {
+        let digest = self.digest();
+        let mut hasher = Keccak256Hasher::default();
+        hasher.update(&Self::POW_PREFIX.to_be_bytes());
+        hasher.update(&[0_u8; 12]);
+        hasher.update(&digest.0[..]);
+        hasher.update(&n_bits.to_be_bytes());
+        let prefixed_digest = hasher.finalize();
+
+        let mut hasher = Keccak256Hasher::default();
+        hasher.update(prefixed_digest.as_ref());
+        hasher.update(&nonce.to_be_bytes());
+        let res = hasher.finalize();
+
+        let n_zeros = u128::from_be_bytes(array::from_fn(|i| res.0[i])).leading_zeros();
+        n_zeros >= n_bits
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use std_shims::BTreeSet;
+
+    use crate::core::channel::keccak256::Keccak256Channel;
+    use crate::core::channel::Channel;
+    use crate::core::fields::qm31::SecureField;
+    use crate::m31;
+
+    #[test]
+    fn test_channel_draws() {
+        let mut channel = Keccak256Channel::default();
+
+        assert_eq!(channel.n_draws, 0);
+
+        channel.draw_u32s();
+        assert_eq!(channel.n_draws, 1);
+
+        channel.draw_secure_felts(9);
+        assert_eq!(channel.n_draws, 6);
+    }
+
+    #[test]
+    fn test_draw_u32s() {
+        let mut channel = Keccak256Channel::default();
+
+        let first_random_words = channel.draw_u32s();
+
+        assert_ne!(first_random_words, channel.draw_u32s());
+    }
+
+    #[test]
+    pub fn test_draw_secure_felt() {
+        let mut channel = Keccak256Channel::default();
+
+        let first_random_felt = channel.draw_secure_felt();
+
+        assert_ne!(first_random_felt, channel.draw_secure_felt());
+    }
+
+    #[test]
+    pub fn test_draw_secure_felts() {
+        let mut channel = Keccak256Channel::default();
+
+        let mut random_felts = channel.draw_secure_felts(5);
+        random_felts.extend(channel.draw_secure_felts(4));
+
+        assert_eq!(
+            random_felts.len(),
+            random_felts.iter().collect::<BTreeSet<_>>().len()
+        );
+    }
+
+    #[test]
+    pub fn test_mix_felts() {
+        let mut channel = Keccak256Channel::default();
+        let initial_digest = channel.digest;
+        let felts = (0..2)
+            .map(|i| SecureField::from(m31!(i + 1923782)))
+            .collect_vec();
+
+        channel.mix_felts(felts.as_slice());
+
+        assert_ne!(initial_digest, channel.digest);
+    }
+
+    /// Solidity-equivalence KAT: `mix_u64(value)` should equal
+    /// `keccak256(abi.encodePacked(prev_digest, uint64(value)))` where
+    /// `prev_digest` is the all-zero default initial digest.
+    #[test]
+    pub fn test_mix_u64_solidity_kat() {
+        let mut channel = Keccak256Channel::default();
+        channel.mix_u64(0x1111222233334444);
+
+        // Reproduce by directly hashing the equivalent Solidity input:
+        //   bytes.concat(bytes32(0), bytes8(0x1111222233334444))
+        use sha3::{Digest, Keccak256};
+        let mut hasher = Keccak256::new();
+        hasher.update([0u8; 32]); // initial digest
+        hasher.update(0x1111222233334444u64.to_be_bytes());
+        let expected: [u8; 32] = hasher.finalize().into();
+
+        let actual: [u8; 32] = channel.digest.into();
+        assert_eq!(actual, expected);
+    }
+
+    /// `mix_u64` and `mix_u32s(&[high, low])` (BE word order) must agree, since
+    /// `u64::to_be_bytes` is `[high_u32_be, low_u32_be]` concatenated.
+    #[test]
+    pub fn test_mix_u64_matches_mix_u32s_be() {
+        let mut channel = Keccak256Channel::default();
+        channel.mix_u64(0x1111222233334444);
+        let digest_64 = channel.digest;
+
+        let mut channel = Keccak256Channel::default();
+        channel.mix_u32s(&[0x11112222, 0x33334444]);
+
+        assert_eq!(digest_64, channel.digest);
+    }
+
+    /// Solidity-equivalence KAT for `mix_u32s` against
+    /// `keccak256(abi.encodePacked(prev_digest, uint32(...) ...))`.
+    #[test]
+    pub fn test_mix_u32s_solidity_kat() {
+        let mut channel = Keccak256Channel::default();
+        channel.mix_u32s(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        use sha3::{Digest, Keccak256};
+        let mut hasher = Keccak256::new();
+        hasher.update([0u8; 32]);
+        for w in [1u32, 2, 3, 4, 5, 6, 7, 8, 9] {
+            hasher.update(w.to_be_bytes());
+        }
+        let expected: [u8; 32] = hasher.finalize().into();
+
+        let actual: [u8; 32] = channel.digest.into();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/stwo/src/core/channel/mod.rs
+++ b/crates/stwo/src/core/channel/mod.rs
@@ -13,6 +13,9 @@ pub use poseidon252::Poseidon252Channel;
 mod blake2s;
 pub use blake2s::{Blake2sChannel, Blake2sChannelGeneric, Blake2sM31Channel};
 
+mod keccak256;
+pub use keccak256::Keccak256Channel;
+
 pub const EXTENSION_FELTS_PER_HASH: usize = 2;
 
 pub trait Channel: Default + Clone + Debug {

--- a/crates/stwo/src/core/vcs/keccak256_hash.rs
+++ b/crates/stwo/src/core/vcs/keccak256_hash.rs
@@ -1,0 +1,136 @@
+use core::fmt;
+
+use bytemuck::{Pod, Zeroable};
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+use std_shims::Vec;
+
+#[repr(C, align(32))]
+#[derive(Clone, Copy, PartialEq, Default, Eq, Pod, Zeroable, Deserialize, Serialize)]
+pub struct Keccak256Hash(pub [u8; 32]);
+
+impl From<Keccak256Hash> for Vec<u8> {
+    fn from(value: Keccak256Hash) -> Self {
+        Vec::from(value.0)
+    }
+}
+
+impl From<Vec<u8>> for Keccak256Hash {
+    fn from(value: Vec<u8>) -> Self {
+        Self(
+            value
+                .try_into()
+                .expect("Failed converting Vec<u8> to Keccak256Hash type"),
+        )
+    }
+}
+
+impl From<&[u8]> for Keccak256Hash {
+    fn from(value: &[u8]) -> Self {
+        Self(
+            value
+                .try_into()
+                .expect("Failed converting &[u8] to Keccak256Hash type"),
+        )
+    }
+}
+
+impl AsRef<[u8]> for Keccak256Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Keccak256Hash> for [u8; 32] {
+    fn from(val: Keccak256Hash) -> Self {
+        val.0
+    }
+}
+
+impl fmt::Display for Keccak256Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+impl fmt::Debug for Keccak256Hash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Keccak256Hash as fmt::Display>::fmt(self, f)
+    }
+}
+
+impl super::hash::Hash for Keccak256Hash {}
+
+#[derive(Clone, Debug, Default)]
+pub struct Keccak256Hasher {
+    state: Keccak256,
+}
+
+impl Keccak256Hasher {
+    pub fn new() -> Self {
+        Self {
+            state: Keccak256::new(),
+        }
+    }
+
+    pub fn update(&mut self, data: &[u8]) {
+        Digest::update(&mut self.state, data);
+    }
+
+    pub fn finalize(self) -> Keccak256Hash {
+        Keccak256Hash(self.state.finalize().into())
+    }
+
+    pub fn concat_and_hash(v1: &Keccak256Hash, v2: &Keccak256Hash) -> Keccak256Hash {
+        let mut hasher = Self::new();
+        hasher.update(v1.as_ref());
+        hasher.update(v2.as_ref());
+        hasher.finalize()
+    }
+
+    pub fn hash(data: &[u8]) -> Keccak256Hash {
+        let mut hasher = Self::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std_shims::ToString;
+
+    use super::{Keccak256Hash, Keccak256Hasher};
+
+    impl Keccak256Hasher {
+        fn finalize_reset(&mut self) -> Keccak256Hash {
+            use sha3::Digest;
+            let state = core::mem::take(&mut self.state);
+            Keccak256Hash(state.finalize().into())
+        }
+    }
+
+    #[test]
+    fn single_hash_test() {
+        let hash_a = Keccak256Hasher::hash(b"a");
+        // keccak256("a") — well-known Ethereum-compatible value
+        assert_eq!(
+            hash_a.to_string(),
+            "3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb"
+        );
+    }
+
+    #[test]
+    fn hash_state_test() {
+        let mut state = Keccak256Hasher::new();
+        state.update(b"a");
+        state.update(b"b");
+        let hash = state.finalize_reset();
+        let hash_empty = state.finalize();
+
+        assert_eq!(hash.to_string(), Keccak256Hasher::hash(b"ab").to_string());
+        assert_eq!(
+            hash_empty.to_string(),
+            Keccak256Hasher::hash(b"").to_string()
+        );
+    }
+}

--- a/crates/stwo/src/core/vcs/keccak256_merkle.rs
+++ b/crates/stwo/src/core/vcs/keccak256_merkle.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+
+use super::keccak256_hash::Keccak256Hash;
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::MerkleHasher;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub struct Keccak256MerkleHasher;
+
+impl MerkleHasher for Keccak256MerkleHasher {
+    type Hash = Keccak256Hash;
+
+    fn hash_node(
+        children_hashes: Option<(Self::Hash, Self::Hash)>,
+        column_values: &[BaseField],
+    ) -> Self::Hash {
+        let mut hasher = Keccak256::new();
+
+        if let Some((left_child, right_child)) = children_hashes {
+            hasher.update(left_child);
+            hasher.update(right_child);
+        }
+
+        // Big-endian 4 bytes per M31 (Solidity-friendly: matches
+        // `abi.encodePacked(uint32(m31), ...)`). No padding for non-8-aligned counts.
+        for value in column_values {
+            hasher.update(value.0.to_be_bytes());
+        }
+
+        Keccak256Hash(hasher.finalize().into())
+    }
+}
+
+#[derive(Default)]
+pub struct Keccak256MerkleChannel;
+
+#[cfg(all(test, feature = "prover"))]
+mod tests {
+    use num_traits::Zero;
+
+    use crate::core::fields::m31::BaseField;
+    use crate::core::vcs::keccak256_hash::Keccak256Hash;
+    use crate::core::vcs::keccak256_merkle::Keccak256MerkleHasher;
+    use crate::core::vcs::test_utils::prepare_merkle;
+    use crate::core::vcs::verifier::MerkleVerificationError;
+
+    #[test]
+    fn test_merkle_success() {
+        let (queries, decommitment, values, verifier) = prepare_merkle::<Keccak256MerkleHasher>();
+
+        verifier.verify(&queries, values, decommitment).unwrap();
+    }
+
+    #[test]
+    fn test_merkle_invalid_witness() {
+        let (queries, mut decommitment, values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        decommitment.hash_witness[4] = Keccak256Hash::default();
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_invalid_value() {
+        let (queries, decommitment, mut values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        values[6] = BaseField::zero();
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::RootMismatch
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_short() {
+        let (queries, mut decommitment, values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        decommitment.hash_witness.pop();
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooShort
+        );
+    }
+
+    #[test]
+    fn test_merkle_witness_too_long() {
+        let (queries, mut decommitment, values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        decommitment.hash_witness.push(Keccak256Hash::default());
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::WitnessTooLong
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_long() {
+        let (queries, decommitment, mut values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        values.insert(3, BaseField::zero());
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::TooManyQueriedValues
+        );
+    }
+
+    #[test]
+    fn test_merkle_column_values_too_short() {
+        let (queries, decommitment, mut values, verifier) =
+            prepare_merkle::<Keccak256MerkleHasher>();
+        values.remove(3);
+
+        assert_eq!(
+            verifier.verify(&queries, values, decommitment).unwrap_err(),
+            MerkleVerificationError::TooFewQueriedValues
+        );
+    }
+}

--- a/crates/stwo/src/core/vcs/mod.rs
+++ b/crates/stwo/src/core/vcs/mod.rs
@@ -4,6 +4,8 @@ pub mod blake2_hash;
 pub mod blake2_merkle;
 pub mod blake3_hash;
 pub mod hash;
+pub mod keccak256_hash;
+pub mod keccak256_merkle;
 mod merkle_hasher;
 pub use merkle_hasher::MerkleHasher;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/stwo/src/core/vcs_lifted/keccak256_merkle.rs
+++ b/crates/stwo/src/core/vcs_lifted/keccak256_merkle.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+
+use super::merkle_hasher::MerkleHasherLifted;
+use crate::core::channel::{Keccak256Channel, MerkleChannel};
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::keccak256_hash::{Keccak256Hash, Keccak256Hasher};
+
+pub type Keccak256MerkleHasher = Keccak256Hasher;
+
+impl MerkleHasherLifted for Keccak256Hasher {
+    type Hash = Keccak256Hash;
+
+    fn hash_children(children_hashes: (Self::Hash, Self::Hash)) -> Self::Hash {
+        let mut hasher = Self::default();
+        let (left_child, right_child) = children_hashes;
+        hasher.update(&left_child.0);
+        hasher.update(&right_child.0);
+        hasher.finalize()
+    }
+
+    fn update_leaf(&mut self, column_values: &[BaseField]) {
+        column_values
+            .iter()
+            .for_each(|x| self.update(&x.0.to_be_bytes()));
+    }
+
+    fn finalize(self) -> Self::Hash {
+        self.finalize()
+    }
+}
+
+#[derive(Default)]
+pub struct Keccak256MerkleChannel;
+
+impl MerkleChannel for Keccak256MerkleChannel {
+    type C = Keccak256Channel;
+    type H = Keccak256MerkleHasher;
+
+    fn mix_root(channel: &mut Self::C, root: <Self::H as MerkleHasherLifted>::Hash) {
+        channel.update_digest(Keccak256Hasher::concat_and_hash(&channel.digest(), &root));
+    }
+}
+
+/// Dummy implementations of `Serialize` and `Deserialize` for `Keccak256Hasher` (we cannot derive
+/// them because its inner field is from an external crate and doesn't implement these traits).
+/// Note: remove this code when possible.
+impl Serialize for Keccak256Hasher {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let ser = serializer.serialize_struct("Keccak256Hasher", 1)?;
+        serde::ser::SerializeStruct::end(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for Keccak256Hasher {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::default())
+    }
+}

--- a/crates/stwo/src/core/vcs_lifted/mod.rs
+++ b/crates/stwo/src/core/vcs_lifted/mod.rs
@@ -1,4 +1,5 @@
 pub mod blake2_merkle;
+pub mod keccak256_merkle;
 pub mod merkle_hasher;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod poseidon252_merkle;

--- a/crates/stwo/src/prover/backend/cpu/keccak256.rs
+++ b/crates/stwo/src/prover/backend/cpu/keccak256.rs
@@ -1,0 +1,25 @@
+use itertools::Itertools;
+
+use crate::core::fields::m31::BaseField;
+use crate::core::vcs::keccak256_hash::Keccak256Hash;
+use crate::core::vcs::keccak256_merkle::Keccak256MerkleHasher;
+use crate::core::vcs::MerkleHasher;
+use crate::prover::backend::CpuBackend;
+use crate::prover::vcs::ops::MerkleOps;
+
+impl MerkleOps<Keccak256MerkleHasher> for CpuBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Keccak256Hash>>,
+        columns: &[&Vec<BaseField>],
+    ) -> Vec<Keccak256Hash> {
+        (0..(1 << log_size))
+            .map(|i| {
+                Keccak256MerkleHasher::hash_node(
+                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                    &columns.iter().map(|column| column[i]).collect_vec(),
+                )
+            })
+            .collect()
+    }
+}

--- a/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
+++ b/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
@@ -59,8 +59,10 @@ impl<H: MerkleHasherLifted> MerkleOpsLifted<H> for CpuBackend {
                 .map(|idx| prev_layer[(idx >> (log_ratio + 1) << 1) + (idx & 1)].clone())
                 .collect();
 
-            // We chunk by 16 because it's the amount of M31 elements needed to trigger a
-            // hash permutation, both in blake and in poseidon.
+            // We chunk by 16 — the amount of M31 elements that triggers a hash permutation
+            // in Blake2s (block = 64 bytes = 16 × 4) and matches Poseidon252's absorption rate.
+            // For Keccak256 the rate is larger (136 bytes ≈ 34 M31s), so this chunking is
+            // suboptimal but still correct.
             for chunk in &group.into_iter().chunks(16) {
                 let vec = chunk.into_iter().collect_vec();
                 prev_layer.iter_mut().enumerate().for_each(|(i, hasher)| {

--- a/crates/stwo/src/prover/backend/cpu/mod.rs
+++ b/crates/stwo/src/prover/backend/cpu/mod.rs
@@ -3,6 +3,7 @@ mod blake2s;
 pub mod circle;
 mod fri;
 mod grind;
+mod keccak256;
 pub mod lookups;
 mod merkle_lifted;
 #[cfg(not(target_arch = "wasm32"))]
@@ -17,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use super::{Backend, BackendForChannel, Column, ColumnOps};
 use crate::core::utils::bit_reverse;
 use crate::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
+use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
 use crate::prover::lookups::mle::Mle;
@@ -28,6 +30,7 @@ pub struct CpuBackend;
 impl Backend for CpuBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for CpuBackend {}
 impl BackendForChannel<Blake2sM31MerkleChannel> for CpuBackend {}
+impl BackendForChannel<Keccak256MerkleChannel> for CpuBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for CpuBackend {}
 

--- a/crates/stwo/src/prover/backend/simd/keccak256.rs
+++ b/crates/stwo/src/prover/backend/simd/keccak256.rs
@@ -1,0 +1,79 @@
+//! Naive SIMD-backend bindings for the Keccak256 channel/merkle path.
+//!
+//! These delegate to the CPU implementation (or to per-element scalar code) and
+//! exist to satisfy the trait bounds of `BackendForChannel<Keccak256MerkleChannel>`
+//! for `SimdBackend`. A future "Optimized" stage will replace these with parallel-
+//! permutation (`keccak::parallel`, `f1600x4`/`x8`) implementations.
+
+use itertools::Itertools;
+
+use super::SimdBackend;
+use crate::core::channel::{Channel, Keccak256Channel};
+use crate::core::fields::m31::BaseField;
+use crate::core::proof_of_work::GrindOps;
+use crate::core::vcs::keccak256_hash::Keccak256Hash;
+use crate::core::vcs::keccak256_merkle::Keccak256MerkleHasher;
+use crate::core::vcs::MerkleHasher;
+use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleHasher as Keccak256MerkleHasherLifted;
+use crate::prover::backend::{Col, Column, ColumnOps, CpuBackend};
+use crate::prover::vcs::ops::MerkleOps;
+use crate::prover::vcs_lifted::ops::MerkleOpsLifted;
+
+impl ColumnOps<Keccak256Hash> for SimdBackend {
+    type Column = Vec<Keccak256Hash>;
+
+    fn bit_reverse_column(_column: &mut Self::Column) {
+        unimplemented!()
+    }
+}
+
+impl GrindOps<Keccak256Channel> for SimdBackend {
+    fn grind(channel: &Keccak256Channel, pow_bits: u32) -> u64 {
+        let mut nonce = 0u64;
+        loop {
+            if channel.verify_pow_nonce(pow_bits, nonce) {
+                return nonce;
+            }
+            nonce += 1;
+        }
+    }
+}
+
+// TODO: replace with an optimized SIMD implementation using parallel keccak permutations
+// (e.g. `keccak::parallel` `f1600x4`/`x8`).
+impl MerkleOps<Keccak256MerkleHasher> for SimdBackend {
+    fn commit_on_layer(
+        log_size: u32,
+        prev_layer: Option<&Vec<Keccak256Hash>>,
+        columns: &[&Col<Self, BaseField>],
+    ) -> Vec<Keccak256Hash> {
+        (0..(1usize << log_size))
+            .map(|i| {
+                Keccak256MerkleHasher::hash_node(
+                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
+                    &columns.iter().map(|column| column.at(i)).collect_vec(),
+                )
+            })
+            .collect()
+    }
+}
+
+/// Naive `MerkleOpsLifted` for `SimdBackend`: copies columns to CPU and dispatches to the generic
+/// `CpuBackend` lifted impl. Correctness-first; the optimized stage will replace this with a
+/// parallel-permutation implementation.
+impl MerkleOpsLifted<Keccak256MerkleHasherLifted> for SimdBackend {
+    fn build_leaves(
+        columns: &[&Col<Self, BaseField>],
+        lifting_log_size: u32,
+    ) -> Col<Self, Keccak256Hash> {
+        let cpu_cols = columns.iter().map(|column| column.to_cpu()).collect_vec();
+        <CpuBackend as MerkleOpsLifted<Keccak256MerkleHasherLifted>>::build_leaves(
+            &cpu_cols.iter().collect_vec(),
+            lifting_log_size,
+        )
+    }
+
+    fn build_next_layer(prev_layer: &Vec<Keccak256Hash>) -> Vec<Keccak256Hash> {
+        <CpuBackend as MerkleOpsLifted<Keccak256MerkleHasherLifted>>::build_next_layer(prev_layer)
+    }
+}

--- a/crates/stwo/src/prover/backend/simd/keccak256.rs
+++ b/crates/stwo/src/prover/backend/simd/keccak256.rs
@@ -1,11 +1,16 @@
-//! Naive SIMD-backend bindings for the Keccak256 channel/merkle path.
+//! SIMD-backend bindings for the Keccak256 channel/merkle path.
 //!
-//! These delegate to the CPU implementation (or to per-element scalar code) and
-//! exist to satisfy the trait bounds of `BackendForChannel<Keccak256MerkleChannel>`
-//! for `SimdBackend`. A future "Optimized" stage will replace these with parallel-
-//! permutation (`keccak::parallel`, `f1600x4`/`x8`) implementations.
+//! - `MerkleOps<Keccak256MerkleHasher>` is implemented using parallel-permutation
+//!   `keccak::parallel`. With `RUSTFLAGS='--cfg keccak_backend="simd256"'` (or `simd128`/`simd512`)
+//!   this dispatches to vectorized `f1600x{2,4,8}`. Without any cfg, it falls back gracefully to
+//!   the scalar soft backend (parallel width `U1`), which is still correct.
+//! - `MerkleOpsLifted` and `GrindOps` here remain naive delegations to the CPU path; optimizing
+//!   them is tracked separately.
+
+use core::mem;
 
 use itertools::Itertools;
+use keccak::{Backend, BackendClosure, Keccak, ParState1600, State1600};
 
 use super::SimdBackend;
 use crate::core::channel::{Channel, Keccak256Channel};
@@ -13,11 +18,14 @@ use crate::core::fields::m31::BaseField;
 use crate::core::proof_of_work::GrindOps;
 use crate::core::vcs::keccak256_hash::Keccak256Hash;
 use crate::core::vcs::keccak256_merkle::Keccak256MerkleHasher;
-use crate::core::vcs::MerkleHasher;
 use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleHasher as Keccak256MerkleHasherLifted;
 use crate::prover::backend::{Col, Column, ColumnOps, CpuBackend};
 use crate::prover::vcs::ops::MerkleOps;
 use crate::prover::vcs_lifted::ops::MerkleOpsLifted;
+
+/// Keccak256 sponge rate (1088 bits = 17 × 64-bit lanes = 136 bytes).
+const KECCAK256_RATE: usize = 136;
+const KECCAK256_RATE_WORDS: usize = KECCAK256_RATE / 8;
 
 impl ColumnOps<Keccak256Hash> for SimdBackend {
     type Column = Vec<Keccak256Hash>;
@@ -27,6 +35,7 @@ impl ColumnOps<Keccak256Hash> for SimdBackend {
     }
 }
 
+// TODO: optimize by parallelizing over nonces with `keccak::parallel`.
 impl GrindOps<Keccak256Channel> for SimdBackend {
     fn grind(channel: &Keccak256Channel, pow_bits: u32) -> u64 {
         let mut nonce = 0u64;
@@ -39,22 +48,140 @@ impl GrindOps<Keccak256Channel> for SimdBackend {
     }
 }
 
-// TODO: replace with an optimized SIMD implementation using parallel keccak permutations
-// (e.g. `keccak::parallel` `f1600x4`/`x8`).
 impl MerkleOps<Keccak256MerkleHasher> for SimdBackend {
     fn commit_on_layer(
         log_size: u32,
         prev_layer: Option<&Vec<Keccak256Hash>>,
         columns: &[&Col<Self, BaseField>],
     ) -> Vec<Keccak256Hash> {
-        (0..(1usize << log_size))
+        let n_nodes = 1usize << log_size;
+
+        // Each node's input = (children if present) || (column values, BE-packed M31s).
+        // All nodes in this layer share the same input length.
+        let inputs: Vec<Vec<u8>> = (0..n_nodes)
             .map(|i| {
-                Keccak256MerkleHasher::hash_node(
-                    prev_layer.map(|prev_layer| (prev_layer[2 * i], prev_layer[2 * i + 1])),
-                    &columns.iter().map(|column| column.at(i)).collect_vec(),
-                )
+                let cap = if prev_layer.is_some() { 64 } else { 0 } + 4 * columns.len();
+                let mut buf = Vec::with_capacity(cap);
+                if let Some(prev) = prev_layer {
+                    buf.extend_from_slice(&prev[2 * i].0);
+                    buf.extend_from_slice(&prev[2 * i + 1].0);
+                }
+                for col in columns {
+                    buf.extend_from_slice(&col.at(i).0.to_be_bytes());
+                }
+                buf
             })
-            .collect()
+            .collect();
+
+        let mut output = vec![Keccak256Hash::default(); n_nodes];
+        Keccak::new().with_backend(LayerHasher {
+            inputs: &inputs,
+            output: &mut output,
+        });
+        output
+    }
+}
+
+/// Sponge-construction closure dispatched against the runtime-selected `keccak::Backend`.
+/// `call_once` is generic over `B`, so the parallel/scalar permutation function pointers
+/// are monomorphized at the right SIMD width.
+struct LayerHasher<'a> {
+    inputs: &'a [Vec<u8>],
+    output: &'a mut [Keccak256Hash],
+}
+
+impl BackendClosure for LayerHasher<'_> {
+    fn call_once<B: Backend>(self) {
+        let par_f1600 = B::get_par_f1600();
+        let f1600 = B::get_f1600();
+
+        // Parallel width = how many State1600s fit in one ParState1600<B>.
+        // Avoids depending on `hybrid_array::ArraySize` to read the typenum constant.
+        let par_width = mem::size_of::<ParState1600<B>>() / mem::size_of::<State1600>();
+        debug_assert!(par_width >= 1);
+        debug_assert_eq!(
+            par_width * mem::size_of::<State1600>(),
+            mem::size_of::<ParState1600<B>>(),
+            "ParState1600<B> layout is not a packed array of State1600",
+        );
+
+        let n_nodes = self.inputs.len();
+        if n_nodes == 0 {
+            return;
+        }
+        let mut states: Vec<State1600> = vec![[0u64; 25]; n_nodes];
+
+        let input_len = self.inputs[0].len();
+        let n_full_blocks = input_len / KECCAK256_RATE;
+
+        // Absorb full rate blocks.
+        for block_idx in 0..n_full_blocks {
+            let block_start = block_idx * KECCAK256_RATE;
+            for (state, input) in states.iter_mut().zip(self.inputs.iter()) {
+                xor_rate_block_into_state(state, &input[block_start..block_start + KECCAK256_RATE]);
+            }
+            permute_all::<B>(&mut states, par_width, par_f1600, f1600);
+        }
+
+        // Final padded block: keccak (not SHA-3) padding `0x01 ... 0x80`.
+        // If the data fills the rate exactly, we still emit one extra padding-only block.
+        let last_start = n_full_blocks * KECCAK256_RATE;
+        let mut padded = [0u8; KECCAK256_RATE];
+        for (state, input) in states.iter_mut().zip(self.inputs.iter()) {
+            let last = &input[last_start..];
+            let last_len = last.len();
+            padded[..last_len].copy_from_slice(last);
+            padded[last_len] = 0x01;
+            padded[KECCAK256_RATE - 1] |= 0x80;
+            xor_rate_block_into_state(state, &padded);
+            // Reset the bytes we touched for the next iteration.
+            padded[..last_len].fill(0);
+            padded[last_len] = 0;
+            padded[KECCAK256_RATE - 1] = 0;
+        }
+        permute_all::<B>(&mut states, par_width, par_f1600, f1600);
+
+        // Squeeze: the keccak256 output is the first 32 bytes (4 u64s, LE) of each state.
+        for (state, out) in states.iter().zip(self.output.iter_mut()) {
+            let mut digest = [0u8; 32];
+            for w in 0..4 {
+                digest[w * 8..(w + 1) * 8].copy_from_slice(&state[w].to_le_bytes());
+            }
+            *out = Keccak256Hash(digest);
+        }
+    }
+}
+
+fn xor_rate_block_into_state(state: &mut State1600, block: &[u8]) {
+    debug_assert_eq!(block.len(), KECCAK256_RATE);
+    for w in 0..KECCAK256_RATE_WORDS {
+        let word = u64::from_le_bytes(block[w * 8..(w + 1) * 8].try_into().unwrap());
+        state[w] ^= word;
+    }
+}
+
+/// Apply `f1600` to all states. Uses the parallel function on chunks of `par_width`
+/// states and the scalar function on the (shorter than `par_width`) tail.
+fn permute_all<B: Backend>(
+    states: &mut [State1600],
+    par_width: usize,
+    par_f1600: keccak::ParFn1600<B>,
+    f1600: keccak::Fn1600,
+) {
+    let mut chunks = states.chunks_exact_mut(par_width);
+    for chunk in &mut chunks {
+        // SAFETY: `ParState1600<B> = hybrid_array::Array<State1600, B::ParSize1600>` is
+        // `#[repr(transparent)]` over `[State1600; par_width]` (where `par_width` matches
+        // `B::ParSize1600`'s `USIZE`, asserted above via `size_of`). Casting a
+        // `&mut [State1600]` slice of length `par_width` to `&mut ParState1600<B>` therefore
+        // preserves layout and aliasing — the slice and the target share the same memory and
+        // lifetime, and we only construct one `&mut` at a time.
+        let par_state: &mut ParState1600<B> =
+            unsafe { &mut *(chunk.as_mut_ptr() as *mut ParState1600<B>) };
+        par_f1600(par_state);
+    }
+    for state in chunks.into_remainder() {
+        f1600(state);
     }
 }
 
@@ -75,5 +202,86 @@ impl MerkleOpsLifted<Keccak256MerkleHasherLifted> for SimdBackend {
 
     fn build_next_layer(prev_layer: &Vec<Keccak256Hash>) -> Vec<Keccak256Hash> {
         <CpuBackend as MerkleOpsLifted<Keccak256MerkleHasherLifted>>::build_next_layer(prev_layer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use crate::core::fields::m31::BaseField;
+    use crate::core::vcs::keccak256_hash::Keccak256Hash;
+    use crate::core::vcs::keccak256_merkle::Keccak256MerkleHasher;
+    use crate::prover::backend::simd::column::BaseColumn;
+    use crate::prover::backend::simd::SimdBackend;
+    use crate::prover::backend::CpuBackend;
+    use crate::prover::vcs::ops::MerkleOps;
+
+    /// Asserts that `CpuBackend::commit_on_layer` and `SimdBackend::commit_on_layer` produce
+    /// bit-identical outputs for the given parameters.
+    fn assert_simd_eq_cpu(log_size: u32, n_cols: usize, has_prev_layer: bool, seed: u64) {
+        let n_nodes = 1usize << log_size;
+        let mut rng = SmallRng::seed_from_u64(seed);
+
+        let cpu_cols: Vec<Vec<BaseField>> = (0..n_cols)
+            .map(|_| {
+                (0..n_nodes)
+                    .map(|_| BaseField::from(rng.gen_range(0..(1u32 << 30))))
+                    .collect()
+            })
+            .collect();
+        let simd_cols: Vec<BaseColumn> = cpu_cols.iter().map(|c| BaseColumn::from_cpu(c)).collect();
+
+        let cpu_prev: Option<Vec<Keccak256Hash>> = has_prev_layer.then(|| {
+            (0..2 * n_nodes)
+                .map(|_| Keccak256Hash(core::array::from_fn(|_| rng.gen())))
+                .collect()
+        });
+
+        let cpu_root = <CpuBackend as MerkleOps<Keccak256MerkleHasher>>::commit_on_layer(
+            log_size,
+            cpu_prev.as_ref(),
+            &cpu_cols.iter().collect_vec(),
+        );
+        let simd_root = <SimdBackend as MerkleOps<Keccak256MerkleHasher>>::commit_on_layer(
+            log_size,
+            cpu_prev.as_ref(),
+            &simd_cols.iter().collect_vec(),
+        );
+
+        assert_eq!(
+            cpu_root, simd_root,
+            "SIMD/CPU mismatch: log_size={log_size}, n_cols={n_cols}, has_prev_layer={has_prev_layer}",
+        );
+    }
+
+    /// Sweeps across input-length boundaries (1 rate = 136 bytes, M31 = 4 bytes, children = 64
+    /// bytes): below 1 rate, exactly 1 rate (triggers extra padding-only block), above 1 rate,
+    /// exactly 2 rates, and above 2 rates. `n_cols` is chosen so `input_len % 136` lands on 0,
+    /// near the rate boundary, and well below.
+    #[test]
+    fn test_simd_matches_cpu_keccak256_commit_on_layer() {
+        // Leaf layer (no children).
+        assert_simd_eq_cpu(4, 0, false, 1); //   0 bytes (pure padding block)
+        assert_simd_eq_cpu(4, 1, false, 2); //   4 bytes
+        assert_simd_eq_cpu(5, 7, false, 3); //  28 bytes
+        assert_simd_eq_cpu(6, 16, false, 4); //  64 bytes
+        assert_simd_eq_cpu(4, 33, false, 5); // 132 bytes (just below rate)
+        assert_simd_eq_cpu(5, 34, false, 6); // 136 bytes (== rate, extra padding-only block)
+        assert_simd_eq_cpu(4, 35, false, 7); // 140 bytes (> rate, two blocks)
+        assert_simd_eq_cpu(4, 64, false, 8); // 256 bytes
+        assert_simd_eq_cpu(4, 68, false, 9); // 272 bytes (== 2 * rate)
+
+        // Inner layer (with children: +64 bytes).
+        assert_simd_eq_cpu(4, 0, true, 10); //  64 bytes
+        assert_simd_eq_cpu(4, 1, true, 11); //  68 bytes
+        assert_simd_eq_cpu(5, 16, true, 12); // 128 bytes (just below rate)
+        assert_simd_eq_cpu(6, 18, true, 13); // 136 bytes (== rate boundary)
+        assert_simd_eq_cpu(4, 33, true, 14); // 196 bytes
+        assert_simd_eq_cpu(4, 50, true, 15); // 264 bytes
+        assert_simd_eq_cpu(4, 52, true, 16); // 272 bytes (== 2 * rate)
+        assert_simd_eq_cpu(4, 64, true, 17); // 320 bytes
     }
 }

--- a/crates/stwo/src/prover/backend/simd/mod.rs
+++ b/crates/stwo/src/prover/backend/simd/mod.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Backend, BackendForChannel};
 use crate::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
+use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
 
@@ -19,6 +20,7 @@ pub mod domain;
 pub mod fft;
 pub mod fri;
 mod grind;
+pub mod keccak256;
 pub mod lookups;
 pub mod m31;
 #[cfg(not(target_arch = "wasm32"))]
@@ -37,6 +39,7 @@ pub struct SimdBackend;
 impl Backend for SimdBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for SimdBackend {}
 impl BackendForChannel<Blake2sM31MerkleChannel> for SimdBackend {}
+impl BackendForChannel<Keccak256MerkleChannel> for SimdBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for SimdBackend {}
 

--- a/crates/stwo/src/prover/fri.rs
+++ b/crates/stwo/src/prover/fri.rs
@@ -570,6 +570,47 @@ mod tests {
     }
 
     #[test]
+    fn test_fri_commit_decommit_keccak256_cpu() {
+        use crate::core::channel::Keccak256Channel;
+        use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
+
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2);
+        let column = polynomial_evaluation(6, LOG_BLOWUP_FACTOR);
+        let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
+
+        let prover = super::FriProver::<'_, CpuBackend, Keccak256MerkleChannel>::commit(
+            &mut Keccak256Channel::default(),
+            config,
+            &column,
+            &twiddles,
+        );
+        let queries = Queries::from_positions(vec![0, 3], 6 + LOG_BLOWUP_FACTOR);
+        prover.decommit_on_queries(&queries);
+    }
+
+    #[test]
+    fn test_fri_commit_decommit_keccak256_simd() {
+        use crate::core::channel::Keccak256Channel;
+        use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
+
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2);
+        let cpu_eval = polynomial_evaluation(8, LOG_BLOWUP_FACTOR);
+        let column = SecureEvaluation::new(
+            cpu_eval.domain,
+            cpu_eval.values.to_vec().into_iter().collect(),
+        );
+        let twiddles = SimdBackend::precompute_twiddles(column.domain.half_coset);
+        let prover = super::FriProver::<'_, SimdBackend, Keccak256MerkleChannel>::commit(
+            &mut Keccak256Channel::default(),
+            config,
+            &column,
+            &twiddles,
+        );
+        let queries = Queries::from_positions(vec![1, 6, 11], 8 + LOG_BLOWUP_FACTOR);
+        prover.decommit_on_queries(&queries);
+    }
+
+    #[test]
     fn test_pack_leaves_input_simd_matches_cpu() {
         for log_size in 2..8 {
             let values = (0..1 << log_size).map(|i| {

--- a/ensure-verifier-no_std/Cargo.lock
+++ b/ensure-verifier-no_std/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
@@ -58,7 +58,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
 ]
 
@@ -114,7 +114,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -137,6 +137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -202,6 +211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +244,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -259,9 +286,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -382,7 +419,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -421,6 +467,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if 1.0.1",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -629,8 +685,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.1",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.2",
+ "keccak",
 ]
 
 [[package]]
@@ -717,6 +783,7 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+ "sha3",
  "starknet-crypto",
  "starknet-ff",
  "stwo-std-shims",
@@ -819,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/ensure-verifier-no_std/Cargo.lock
+++ b/ensure-verifier-no_std/Cargo.lock
@@ -477,6 +477,7 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if 1.0.1",
  "cpufeatures 0.3.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -780,6 +781,7 @@ dependencies = [
  "hex",
  "indexmap",
  "itertools 0.12.1",
+ "keccak",
  "num-traits",
  "rand",
  "serde",


### PR DESCRIPTION
Replaces the scalar per-element hashing loop in
`MerkleOps<Keccak256MerkleHasher> for SimdBackend` with a parallel-
permutation sponge construction built on `keccak::parallel`. With
`RUSTFLAGS='--cfg keccak_backend="simd256"'` (or simd128/simd512), this
dispatches to vectorized `f1600x{2,4,8}`. Without any cfg the soft
backend (parallel width 1) provides correct scalar fallback.

Drops down to `keccak::Backend::get_par_f1600` via `BackendClosure`
since the SIMD `Backend` impl is `pub(crate)`. Casts `&mut [State1600]`
chunks to `&mut ParState1600<B>` via raw pointer (sound under
`Array<T, N>`'s `#[repr(transparent)]`) to avoid taking on
`hybrid-array` as a direct dependency. Parallel width is read from
`size_of::<ParState1600<B>>() / size_of::<State1600>()`.

Adds a CPU/SIMD equivalence test that sweeps input lengths across rate
boundaries (rate = 136 bytes), with and without children, including
exact-rate cases that exercise the extra padding-only block.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>