### PR TITLE
Inline stwo crate license to fix wasm-pack manifest parsing.

### DIFF
--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stwo"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 description = "Core library implementing the Circle STARK prover and verifier"
 
 [features]


### PR DESCRIPTION
A recent wasm-pack release regressed support for `license.workspace = true`, causing `wasm-pack test --node` in CI to fail with "invalid type: map, expected a string for key `package.license`". Inline the license string until the upstream regression is fixed.