### PR TITLE
Pin wasm-pack to v0.13.1 in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: "latest"
+          version: "v0.13.1"
       - run: cd crates/stwo && wasm-pack test --node
         env:
           RUSTFLAGS: -C target-feature=+simd128


### PR DESCRIPTION
wasm-pack v0.14.0 (released 2026-01-20) regressed parsing of `license.workspace = true`, causing the run-wasm32-unknown-tests CI job to fail with "invalid type: map, expected a string for key `package.license`". The action used `version: "latest"`, which started resolving to v0.14.0 between 2026-04-29 and 2026-04-30. Pin to v0.13.1 until the upstream regression is fixed.