### PR TITLE
Make the repo compile with Rust 1.94 nightly

### DIFF
--- a/.github/workflows/benchmarks-pages.yaml
+++ b/.github/workflows/benchmarks-pages.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/bootstrap_runners
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - name: Run benchmark
         run: |
           cargo install cargo-criterion

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  NIGHTLY_VERSION: "nightly-2025-07-14"
+  NIGHTLY_VERSION: "nightly-2026-01-15"
   STABLE_VERSION: "1.88.0"
 
 on:
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - uses: Swatinem/rust-cache@v2
       - name: Install Machete
         run: cargo install --locked cargo-machete

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,14 +13,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
         # TODO: Merge coverage reports for tests on different architectures.
         # <https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#merge-coverages-generated-under-different-test-conditions>
       - name: Generate code coverage
-        run: cargo +nightly-2025-07-14 llvm-cov --codecov --output-path codecov.json
+        run: cargo +nightly-2026-01-15 llvm-cov --codecov --output-path codecov.json
         env:
           RUSTFLAGS: "-C target-feature=+avx512f"
       - name: Upload coverage to Codecov

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ All agent behavior is governed by this hierarchy. No exception, no override.
 
 | Layer | Technology | Notes |
 |-------|-----------|-------|
-| Language | Rust nightly-2025-07-14 | Stable features except SIMD. See `rust-toolchain.toml` |
+| Language | Rust nightly-2026-01-15 | Stable features except SIMD. See `rust-toolchain.toml` |
 | Field | Mersenne31 (M31) | CM31, QM31 extension tower. p = 2^31 - 1 |
 | Proof system | Circle STARKs | FRI-based, circle group C(F_p) |
 | Test framework | Rust built-in + criterion | No proptest (coverage gap) |

--- a/crates/air-utils/src/lib.rs
+++ b/crates/air-utils/src/lib.rs
@@ -1,3 +1,3 @@
-#![feature(exact_size_is_empty, raw_slice_split, portable_simd, array_chunks)]
+#![feature(exact_size_is_empty, raw_slice_split, portable_simd)]
 pub mod lookup_data;
 pub mod trace;

--- a/crates/air-utils/src/lib.rs
+++ b/crates/air-utils/src/lib.rs
@@ -1,3 +1,19 @@
 #![feature(exact_size_is_empty, raw_slice_split, portable_simd)]
 pub mod lookup_data;
 pub mod trace;
+
+/// Ensures a usable rayon global thread pool exists before running parallel code in tests.
+///
+/// On threadless wasm targets (e.g. `wasm32-wasip1`) rayon cannot spawn worker threads, so its
+/// default lazily-built global pool aborts. Build a single-threaded global pool that runs work on
+/// the calling thread instead. Idempotent and a no-op off wasm, where the default pool is fine.
+#[cfg(test)]
+pub(crate) fn ensure_rayon_pool() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .use_current_thread()
+            .build_global();
+    }
+}

--- a/crates/air-utils/src/lookup_data/mod.rs
+++ b/crates/air-utils/src/lookup_data/mod.rs
@@ -48,7 +48,9 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .array_chunks::<N_LANES>()
+            .as_chunks::<N_LANES>()
+            .0
+            .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);
                 let x1 = x + PackedM31::broadcast(M31(1));
@@ -113,7 +115,9 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .array_chunks::<N_LANES>()
+            .as_chunks::<N_LANES>()
+            .0
+            .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);
                 let x1 = x + PackedM31::broadcast(M31(1));

--- a/crates/air-utils/src/lookup_data/mod.rs
+++ b/crates/air-utils/src/lookup_data/mod.rs
@@ -4,6 +4,7 @@ mod tests {
     use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
     use rayon::slice::ParallelSlice;
     use stwo::core::fields::m31::M31;
+    use stwo::core::utils::SliceExt;
     use stwo::prover::backend::simd::m31::{PackedM31, LOG_N_LANES, N_LANES};
     use stwo_air_utils_derive::{IterMut, ParIterMut, Uninitialized};
 
@@ -48,8 +49,7 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .as_chunks::<N_LANES>()
-            .0
+            .checked_as_chunks::<N_LANES>()
             .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);
@@ -105,6 +105,7 @@ mod tests {
 
     #[test]
     fn test_derived_lookup_data_par_iter() {
+        crate::ensure_rayon_pool();
         const N_COLUMNS: usize = 5;
         const LOG_N_ROWS: u32 = 8;
         let mut trace = ComponentTrace::<N_COLUMNS>::zeroed(LOG_N_ROWS);
@@ -115,8 +116,7 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .as_chunks::<N_LANES>()
-            .0
+            .checked_as_chunks::<N_LANES>()
             .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);

--- a/crates/air-utils/src/trace/component_trace.rs
+++ b/crates/air-utils/src/trace/component_trace.rs
@@ -161,6 +161,8 @@ mod tests {
         use rayon::iter::{IndexedParallelIterator, ParallelIterator};
         use rayon::slice::ParallelSlice;
 
+        crate::ensure_rayon_pool();
+
         const N_COLUMNS: usize = 3;
         const LOG_SIZE: u32 = 8;
         const CHUNK_SIZE: usize = 4;

--- a/crates/constraint-framework/src/expr/degree.rs
+++ b/crates/constraint-framework/src/expr/degree.rs
@@ -71,7 +71,6 @@ impl ExtExpr {
         match self {
             ExtExpr::SecureCol(coefs) => coefs
                 .iter()
-                .cloned()
                 .map(|coef| coef.degree_bound(named_exprs))
                 .max()
                 .unwrap(),

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -23,10 +23,17 @@ serde.workspace = true
 stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
 stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
     "prover",
-    "parallel",
 ] }
 rand.workspace = true
 educe.workspace = true
+
+# rayon cannot build a thread pool on threadless wasm targets (e.g. wasm32-wasip1),
+# so the `parallel` feature (which pulls in rayon) is only enabled off-wasm. On wasm
+# the crates fall back to their sequential code paths.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+    "parallel",
+] }
 
 [dev-dependencies]
 criterion = { default-features = false, features = [

--- a/crates/examples/src/blake/round/gen.rs
+++ b/crates/examples/src/blake/round/gen.rs
@@ -252,7 +252,7 @@ pub fn generate_interaction_trace(
     let _span = span!(Level::INFO, "Generate round interaction trace").entered();
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.array_chunks::<2>() {
+    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.as_chunks::<2>().0.iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/round/gen.rs
+++ b/crates/examples/src/blake/round/gen.rs
@@ -6,6 +6,7 @@ use num_traits::One;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::poly::circle::CanonicCoset;
+use stwo::core::utils::SliceExt;
 use stwo::core::ColumnVec;
 use stwo::prover::backend::simd::column::BaseColumn;
 use stwo::prover::backend::simd::m31::{PackedBaseField, LOG_N_LANES};
@@ -252,7 +253,7 @@ pub fn generate_interaction_trace(
     let _span = span!(Level::INFO, "Generate round interaction trace").entered();
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.as_chunks::<2>().0.iter() {
+    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.checked_as_chunks::<2>().iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/scheduler/gen.rs
+++ b/crates/examples/src/blake/scheduler/gen.rs
@@ -5,6 +5,7 @@ use num_traits::Zero;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::poly::circle::CanonicCoset;
+use stwo::core::utils::SliceExt;
 use stwo::core::ColumnVec;
 use stwo::prover::backend::simd::column::BaseColumn;
 use stwo::prover::backend::simd::m31::LOG_N_LANES;
@@ -126,7 +127,7 @@ pub fn gen_interaction_trace(
 
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [l0, l1] in lookup_data.round_lookups.as_chunks::<2>().0.iter() {
+    for [l0, l1] in lookup_data.round_lookups.checked_as_chunks::<2>().iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/scheduler/gen.rs
+++ b/crates/examples/src/blake/scheduler/gen.rs
@@ -126,7 +126,7 @@ pub fn gen_interaction_trace(
 
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [l0, l1] in lookup_data.round_lookups.array_chunks::<2>() {
+    for [l0, l1] in lookup_data.round_lookups.as_chunks::<2>().0.iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/scheduler/gen.rs
+++ b/crates/examples/src/blake/scheduler/gen.rs
@@ -152,11 +152,8 @@ pub fn gen_interaction_trace(
                 .map(|l| l.data[vec_row]),
         );
         if N_ROUNDS % 2 == 1 {
-            let p_round: PackedSecureField = round_lookup_elements.combine(
-                &reminder[0]
-                    .each_ref()
-                    .map(|l| l.data[vec_row]),
-            );
+            let p_round: PackedSecureField =
+                round_lookup_elements.combine(&reminder[0].each_ref().map(|l| l.data[vec_row]));
             // TODO(alont): Remove.
             col_gen.write_frac(vec_row, p_blake, p_round * p_blake);
         } else {

--- a/crates/examples/src/blake/scheduler/gen.rs
+++ b/crates/examples/src/blake/scheduler/gen.rs
@@ -5,7 +5,6 @@ use num_traits::Zero;
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::poly::circle::CanonicCoset;
-use stwo::core::utils::SliceExt;
 use stwo::core::ColumnVec;
 use stwo::prover::backend::simd::column::BaseColumn;
 use stwo::prover::backend::simd::m31::LOG_N_LANES;
@@ -127,7 +126,8 @@ pub fn gen_interaction_trace(
 
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [l0, l1] in lookup_data.round_lookups.checked_as_chunks::<2>().iter() {
+    let (pairs, reminder) = lookup_data.round_lookups.as_chunks::<2>();
+    for [l0, l1] in pairs.iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
@@ -153,7 +153,7 @@ pub fn gen_interaction_trace(
         );
         if N_ROUNDS % 2 == 1 {
             let p_round: PackedSecureField = round_lookup_elements.combine(
-                &lookup_data.round_lookups[N_ROUNDS - 1]
+                &reminder[0]
                     .each_ref()
                     .map(|l| l.data[vec_row]),
             );

--- a/crates/examples/src/blake/xor_table/gen.rs
+++ b/crates/examples/src/blake/xor_table/gen.rs
@@ -100,34 +100,32 @@ macro_rules! xor_table_gen {
             }
 
             // If there is an odd number of lookup expressions, handle the last one.
-            if let Some(rem) = iter.into_remainder() {
-                if let Some((i, mults)) = rem.collect_vec().pop() {
-                    let mut col_gen = logup_gen.new_col();
-                    let ah = i as u32 >> EXPAND_BITS;
-                    let bh = i as u32 & ((1 << EXPAND_BITS) - 1);
+            let rem = iter.into_remainder();
+            if let Some((i, mults)) = rem.collect_vec().pop() {
+                let mut col_gen = logup_gen.new_col();
+                let ah = i as u32 >> EXPAND_BITS;
+                let bh = i as u32 & ((1 << EXPAND_BITS) - 1);
 
-                    for vec_row in 0..(1
-                        << (XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits() - LOG_N_LANES))
-                    {
-                        // vec_row is LIMB_BITS of a, and LIMB_BITS - LOG_N_LANES of b.
-                        let al = vec_row >> (limb_bits - LOG_N_LANES);
-                        let a = u32x16::splat((ah << limb_bits) | al);
-                        let bm = vec_row & ((1 << (limb_bits - LOG_N_LANES)) - 1);
-                        let b =
-                            u32x16::splat((bh << limb_bits) | (bm << LOG_N_LANES)) | offsets_vec;
+                for vec_row in
+                    0..(1 << (XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits() - LOG_N_LANES))
+                {
+                    // vec_row is LIMB_BITS of a, and LIMB_BITS - LOG_N_LANES of b.
+                    let al = vec_row >> (limb_bits - LOG_N_LANES);
+                    let a = u32x16::splat((ah << limb_bits) | al);
+                    let bm = vec_row & ((1 << (limb_bits - LOG_N_LANES)) - 1);
+                    let b = u32x16::splat((bh << limb_bits) | (bm << LOG_N_LANES)) | offsets_vec;
 
-                        let c = a ^ b;
+                    let c = a ^ b;
 
-                        let p: PackedSecureField = lookup_elements.combine(
-                            &[a, b, c].map(|x| unsafe { PackedBaseField::from_simd_unchecked(x) }),
-                        );
+                    let p: PackedSecureField = lookup_elements.combine(
+                        &[a, b, c].map(|x| unsafe { PackedBaseField::from_simd_unchecked(x) }),
+                    );
 
-                        let num = mults.data[vec_row as usize];
-                        let denom = p;
-                        col_gen.write_frac(vec_row as usize, PackedSecureField::from(-num), denom);
-                    }
-                    col_gen.finalize_col();
+                    let num = mults.data[vec_row as usize];
+                    let denom = p;
+                    col_gen.write_frac(vec_row as usize, PackedSecureField::from(-num), denom);
                 }
+                col_gen.finalize_col();
             }
 
             logup_gen.finalize_last()

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, iter_array_chunks, array_chunks)]
+#![feature(portable_simd, iter_array_chunks)]
 pub mod blake;
 pub mod plonk;
 pub mod poseidon;

--- a/crates/stwo/src/core/utils.rs
+++ b/crates/stwo/src/core/utils.rs
@@ -70,6 +70,36 @@ impl<'a, I: Iterator> PeekableExt<'a, I> for Peekable<I> {
     }
 }
 
+/// Extension trait providing `checked_as_chunks` / `checked_as_chunks_mut` on slices.
+/// Wraps `as_chunks`, asserting that no remainder is left over.
+pub trait SliceExt {
+    type Item;
+
+    /// Splits the slice into chunks of exactly `N` elements and returns them as a slice of arrays.
+    /// Panics if the slice length is not a multiple of `N`.
+    fn checked_as_chunks<const N: usize>(&self) -> &[[Self::Item; N]];
+
+    /// Splits the slice into mutable chunks of exactly `N` elements.
+    /// Panics if the slice length is not a multiple of `N`.
+    fn checked_as_chunks_mut<const N: usize>(&mut self) -> &mut [[Self::Item; N]];
+}
+
+impl<T> SliceExt for [T] {
+    type Item = T;
+
+    fn checked_as_chunks<const N: usize>(&self) -> &[[T; N]] {
+        let (chunks, remainder) = self.as_chunks::<N>();
+        assert!(remainder.is_empty());
+        chunks
+    }
+
+    fn checked_as_chunks_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
+        let (chunks, remainder) = self.as_chunks_mut::<N>();
+        assert!(remainder.is_empty());
+        chunks
+    }
+}
+
 pub fn all_unique<T: Eq + core::hash::Hash>(iter: impl IntoIterator<Item = T>) -> bool {
     let mut used = hashbrown::HashSet::new();
     iter.into_iter().all(|elt| used.insert(elt))

--- a/crates/stwo/src/lib.rs
+++ b/crates/stwo/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     feature = "prover",
-    feature(array_chunks, iter_array_chunks, portable_simd, slice_ptr_get)
+    feature(iter_array_chunks, portable_simd, slice_ptr_get)
 )]
 pub mod core;
 

--- a/crates/stwo/src/prover/backend/cpu/circle.rs
+++ b/crates/stwo/src/prover/backend/cpu/circle.rs
@@ -10,7 +10,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::fields::{batch_inverse_in_place, ExtensionOf};
 use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 use crate::core::poly::utils::{domain_line_twiddles_from_tree, fold, get_folding_alphas};
-use crate::core::utils::{bit_reverse, bit_reverse_index};
+use crate::core::utils::{bit_reverse, bit_reverse_index, SliceExt};
 use crate::prover::backend::{Col, Column};
 use crate::prover::fri::FriOps;
 use crate::prover::poly::circle::{
@@ -261,10 +261,9 @@ impl PolyOps for CpuBackend {
 
         let mut itwiddles = vec![BaseField::zero(); twiddles.len()];
         twiddles
-            .as_chunks::<CHUNK_SIZE>()
-            .0
+            .checked_as_chunks::<CHUNK_SIZE>()
             .iter()
-            .zip(itwiddles.as_chunks_mut::<CHUNK_SIZE>().0.iter_mut())
+            .zip(itwiddles.checked_as_chunks_mut::<CHUNK_SIZE>().iter_mut())
             .for_each(|(src, dst)| {
                 batch_inverse_in_place(src, dst);
             });

--- a/crates/stwo/src/prover/backend/cpu/circle.rs
+++ b/crates/stwo/src/prover/backend/cpu/circle.rs
@@ -261,8 +261,10 @@ impl PolyOps for CpuBackend {
 
         let mut itwiddles = vec![BaseField::zero(); twiddles.len()];
         twiddles
-            .array_chunks::<CHUNK_SIZE>()
-            .zip(itwiddles.array_chunks_mut::<CHUNK_SIZE>())
+            .as_chunks::<CHUNK_SIZE>()
+            .0
+            .iter()
+            .zip(itwiddles.as_chunks_mut::<CHUNK_SIZE>().0.iter_mut())
             .for_each(|(src, dst)| {
                 batch_inverse_in_place(src, dst);
             });

--- a/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
@@ -231,7 +231,7 @@ pub fn gen_eq_evals(y: &[SecureField], v: SecureField) -> Vec<SecureField> {
 }
 
 fn next_grand_product_layer(layer: &Mle<CpuBackend, SecureField>) -> Layer<CpuBackend> {
-    let res = layer.array_chunks().map(|&[a, b]| a * b).collect();
+    let res = layer.as_chunks().0.iter().map(|&[a, b]| a * b).collect();
     Layer::GrandProduct(Mle::new(res))
 }
 

--- a/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
@@ -5,6 +5,7 @@ use num_traits::{One, Zero};
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
 use crate::core::fields::{ExtensionOf, Field};
+use crate::core::utils::SliceExt;
 use crate::core::Fraction;
 use crate::prover::backend::CpuBackend;
 use crate::prover::lookups::gkr_prover::{
@@ -231,7 +232,11 @@ pub fn gen_eq_evals(y: &[SecureField], v: SecureField) -> Vec<SecureField> {
 }
 
 fn next_grand_product_layer(layer: &Mle<CpuBackend, SecureField>) -> Layer<CpuBackend> {
-    let res = layer.as_chunks().0.iter().map(|&[a, b]| a * b).collect();
+    let res = layer
+        .checked_as_chunks()
+        .iter()
+        .map(|&[a, b]| a * b)
+        .collect();
     Layer::GrandProduct(Mle::new(res))
 }
 

--- a/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
+++ b/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
@@ -279,6 +279,7 @@ impl PackLeavesOps for SimdBackend {
         let output_packed_len_floor = output_len / N_LANES;
 
         // TODO(Leo): parallelize.
+        #[allow(clippy::needless_range_loop)]
         for row in 0..output_packed_len_floor {
             let packed_start_idx = row * PACKED_LEAF_SIZE;
             let packed_values = core::array::from_fn(|j| {
@@ -303,6 +304,7 @@ impl PackLeavesOps for SimdBackend {
             let mut tail_columns: [[BaseField; N_LANES];
                 SECURE_EXTENSION_DEGREE * PACKED_LEAF_SIZE] =
                 core::array::from_fn(|_| [BaseField::zero(); N_LANES]);
+            #[allow(clippy::needless_range_loop)]
             for row in 0..tail_rows {
                 // The index in the input vector corresponding to `row`.
                 let source_row_start = (output_packed_len_floor * N_LANES + row) * PACKED_LEAF_SIZE;

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -197,7 +197,7 @@ impl PolyOps for SimdBackend {
                                  offset: usize| {
             let mut sum = PackedSecureField::zeroed();
             let mut twiddle_high = Self::twiddle_at(&mappings, offset * N_LANES);
-            for (i, coeff_chunk) in coeff_chunk.array_chunks::<N_LANES>().enumerate() {
+            for (i, coeff_chunk) in coeff_chunk.as_chunks::<N_LANES>().0.iter().enumerate() {
                 // For every chunk of 2 ^ 4 * 2 ^ 4 = 2 ^ 8 elements, the twiddle high is the same.
                 // Multiply it by every mid twiddle factor to get the factors for the current chunk.
                 let high_twiddle_factors =

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -21,7 +21,7 @@ use crate::core::fields::qm31::SecureField;
 use crate::core::fields::{batch_inverse, Field, FieldExpOps};
 use crate::core::poly::circle::{CanonicCoset, CircleDomain};
 use crate::core::poly::utils::{domain_line_twiddles_from_tree, fold, get_folding_alphas};
-use crate::core::utils::bit_reverse_index;
+use crate::core::utils::{bit_reverse_index, SliceExt};
 use crate::prover::backend::cpu::circle::slow_precompute_twiddles;
 use crate::prover::backend::simd::column::BaseColumn;
 use crate::prover::backend::simd::fft::transpose_vecs;
@@ -197,7 +197,11 @@ impl PolyOps for SimdBackend {
                                  offset: usize| {
             let mut sum = PackedSecureField::zeroed();
             let mut twiddle_high = Self::twiddle_at(&mappings, offset * N_LANES);
-            for (i, coeff_chunk) in coeff_chunk.as_chunks::<N_LANES>().0.iter().enumerate() {
+            for (i, coeff_chunk) in coeff_chunk
+                .checked_as_chunks::<N_LANES>()
+                .iter()
+                .enumerate()
+            {
                 // For every chunk of 2 ^ 4 * 2 ^ 4 = 2 ^ 8 elements, the twiddle high is the same.
                 // Multiply it by every mid twiddle factor to get the factors for the current chunk.
                 let high_twiddle_factors =

--- a/crates/stwo/src/prover/backend/simd/column.rs
+++ b/crates/stwo/src/prover/backend/simd/column.rs
@@ -134,11 +134,12 @@ impl Column<BaseField> for BaseColumn {
 
 impl FromIterator<BaseField> for BaseColumn {
     fn from_iter<I: IntoIterator<Item = BaseField>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks).map(PackedBaseField::from_array).collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;
@@ -215,11 +216,12 @@ impl Column<CM31> for CM31Column {
 
 impl FromIterator<CM31> for CM31Column {
     fn from_iter<I: IntoIterator<Item = CM31>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks).map(PackedCM31::from_array).collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;
@@ -349,13 +351,14 @@ impl Column<SecureField> for SecureColumn {
 
 impl FromIterator<SecureField> for SecureColumn {
     fn from_iter<I: IntoIterator<Item = SecureField>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks)
             .map(PackedSecureField::from_array)
             .collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;

--- a/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
@@ -134,7 +134,9 @@ fn next_grand_product_layer(layer: &Mle<SimdBackend, SecureField>) -> Layer<Simd
 
     let data = layer
         .data
-        .array_chunks()
+        .as_chunks()
+        .0
+        .iter()
         .map(|&[a, b]| {
             let (evens, odds) = a.deinterleave(b);
             evens * odds

--- a/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
@@ -4,6 +4,7 @@ use num_traits::Zero;
 
 use crate::core::fields::m31::BaseField;
 use crate::core::fields::qm31::SecureField;
+use crate::core::utils::SliceExt;
 use crate::core::Fraction;
 use crate::prover::backend::cpu::lookups::gkr::gen_eq_evals as cpu_gen_eq_evals;
 use crate::prover::backend::simd::column::SecureColumn;
@@ -134,8 +135,7 @@ fn next_grand_product_layer(layer: &Mle<SimdBackend, SecureField>) -> Layer<Simd
 
     let data = layer
         .data
-        .as_chunks()
-        .0
+        .checked_as_chunks()
         .iter()
         .map(|&[a, b]| {
             let (evens, odds) = a.deinterleave(b);

--- a/crates/stwo/src/prover/backend/simd/prefix_sum.rs
+++ b/crates/stwo/src/prover/backend/simd/prefix_sum.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 
 use crate::core::fields::m31::BaseField;
 use crate::core::utils::{
-    bit_reverse, circle_domain_order_to_coset_order, coset_order_to_circle_domain_order,
+    bit_reverse, circle_domain_order_to_coset_order, coset_order_to_circle_domain_order, SliceExt,
 };
 use crate::prover::backend::simd::m31::{PackedBaseField, N_LANES};
 use crate::prover::backend::simd::SimdBackend;
@@ -34,8 +34,8 @@ pub fn inclusive_prefix_sum(
     // Required due different ordering of `CircleDomain` and `Coset`.
     // Evaluations are provided in bit-reversed `CircleDomain` order.
     for ([l0, l1], [r0, r1]) in izip!(
-        l_half.as_chunks_mut::<2>().0.iter_mut(),
-        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+        l_half.checked_as_chunks_mut::<2>().iter_mut(),
+        r_half.checked_as_chunks_mut::<2>().iter_mut().rev()
     ) {
         let (mut half_coset0_lo, half_coset1_hi_rev) = l0.deinterleave(*l1);
         let half_coset1_hi = half_coset1_hi_rev.reverse();
@@ -60,8 +60,8 @@ pub fn inclusive_prefix_sum(
     while chunk_size > 1 {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
         zip(
-            lows.as_chunks_mut::<2>().0.iter_mut(),
-            highs.as_chunks::<2>().0.iter(),
+            lows.checked_as_chunks_mut::<2>().iter_mut(),
+            highs.checked_as_chunks::<2>().iter(),
         )
         .for_each(|([lo, _], [hi, _])| up_sweep_val(lo, *hi));
         chunk_size /= 2;
@@ -91,8 +91,8 @@ pub fn inclusive_prefix_sum(
     while chunk_size < half_coset0_sums.len() {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
         zip(
-            lows.as_chunks_mut::<2>().0.iter_mut(),
-            highs.as_chunks_mut::<2>().0.iter_mut(),
+            lows.checked_as_chunks_mut::<2>().iter_mut(),
+            highs.checked_as_chunks_mut::<2>().iter_mut(),
         )
         .for_each(|([lo, _], [hi, _])| down_sweep_val(lo, hi));
         chunk_size *= 2;
@@ -108,8 +108,8 @@ pub fn inclusive_prefix_sum(
         (half_coset0_sums[lo_index], half_coset0_sums[hi_index]) = (lo, hi);
     }
     for ([l0, l1], [r0, r1]) in izip!(
-        l_half.as_chunks_mut::<2>().0.iter_mut(),
-        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+        l_half.checked_as_chunks_mut::<2>().iter_mut(),
+        r_half.checked_as_chunks_mut::<2>().iter_mut().rev()
     ) {
         let mut half_coset0_lo = *l0;
         let mut half_coset1_lo = *r0;

--- a/crates/stwo/src/prover/backend/simd/prefix_sum.rs
+++ b/crates/stwo/src/prover/backend/simd/prefix_sum.rs
@@ -33,7 +33,10 @@ pub fn inclusive_prefix_sum(
     // Handle the first two up sweep rounds manually.
     // Required due different ordering of `CircleDomain` and `Coset`.
     // Evaluations are provided in bit-reversed `CircleDomain` order.
-    for ([l0, l1], [r0, r1]) in izip!(l_half.array_chunks_mut(), r_half.array_chunks_mut().rev()) {
+    for ([l0, l1], [r0, r1]) in izip!(
+        l_half.as_chunks_mut::<2>().0.iter_mut(),
+        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+    ) {
         let (mut half_coset0_lo, half_coset1_hi_rev) = l0.deinterleave(*l1);
         let half_coset1_hi = half_coset1_hi_rev.reverse();
         let (mut half_coset0_hi, half_coset1_lo_rev) = r0.deinterleave(*r1);
@@ -56,8 +59,11 @@ pub fn inclusive_prefix_sum(
     let mut chunk_size = half_coset0_sums.len() / 2;
     while chunk_size > 1 {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
-        zip(lows.array_chunks_mut(), highs.array_chunks())
-            .for_each(|([lo, _], [hi, _])| up_sweep_val(lo, *hi));
+        zip(
+            lows.as_chunks_mut::<2>().0.iter_mut(),
+            highs.as_chunks::<2>().0.iter(),
+        )
+        .for_each(|([lo, _], [hi, _])| up_sweep_val(lo, *hi));
         chunk_size /= 2;
     }
     // Up sweep the last SIMD vector.
@@ -84,8 +90,11 @@ pub fn inclusive_prefix_sum(
     let mut chunk_size = 2;
     while chunk_size < half_coset0_sums.len() {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
-        zip(lows.array_chunks_mut(), highs.array_chunks_mut())
-            .for_each(|([lo, _], [hi, _])| down_sweep_val(lo, hi));
+        zip(
+            lows.as_chunks_mut::<2>().0.iter_mut(),
+            highs.as_chunks_mut::<2>().0.iter_mut(),
+        )
+        .for_each(|([lo, _], [hi, _])| down_sweep_val(lo, hi));
         chunk_size *= 2;
     }
     // Handle last two down sweep rounds manually.
@@ -98,7 +107,10 @@ pub fn inclusive_prefix_sum(
         down_sweep_val(&mut lo, &mut hi);
         (half_coset0_sums[lo_index], half_coset0_sums[hi_index]) = (lo, hi);
     }
-    for ([l0, l1], [r0, r1]) in izip!(l_half.array_chunks_mut(), r_half.array_chunks_mut().rev()) {
+    for ([l0, l1], [r0, r1]) in izip!(
+        l_half.as_chunks_mut::<2>().0.iter_mut(),
+        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+    ) {
         let mut half_coset0_lo = *l0;
         let mut half_coset1_lo = *r0;
         down_sweep_val(&mut half_coset0_lo, &mut half_coset1_lo);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-07-14"
+channel = "nightly-2026-01-15"

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -4,7 +4,7 @@
 # status, or there's a reference to an undefined variable.
 set -eou pipefail
 
-cargo +nightly-2025-07-14 clippy --workspace "$@" --all-targets --all-features -- -D warnings \
+cargo +nightly-2026-01-15 clippy --workspace "$@" --all-targets --all-features -- -D warnings \
     -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused
 
 # Extract all crate names from the workspace metadata
@@ -14,6 +14,6 @@ crates=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' 
 # clippy on the entire workspace
 for crate in $crates; do
   echo "Clippy on crate: $crate"
-  cargo +nightly-2025-07-14 clippy -p "$crate" --all-targets --all-features -- -D warnings \
+  cargo +nightly-2026-01-15 clippy -p "$crate" --all-targets --all-features -- -D warnings \
     -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused
 done

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2025-07-14 fmt --all -- "$@"
+cargo +nightly-2026-01-15 fmt --all -- "$@"

--- a/scripts/test_avx.sh
+++ b/scripts/test_avx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Can be used as a drop in replacement for `cargo test` with avx512f flag on.
 # For example, `./scripts/test_avx.sh` will run all tests(not only avx).
-RUSTFLAGS="-Awarnings -C target-cpu=native -C target-feature=+avx512f -C opt-level=2" cargo +nightly-2025-07-14 test "$@"
+RUSTFLAGS="-Awarnings -C target-cpu=native -C target-feature=+avx512f -C opt-level=2" cargo +nightly-2026-01-15 test "$@"


### PR DESCRIPTION
Cherry-picks the Rust 1.94 fixes onto current `dev`:
- Remove the unstable `array_chunks` slice feature (removed in 1.94); replace call sites with `as_chunks::<N>().0.iter()`
- Fix a rayon-on-wasm regression exposed by the 1.94 toolchain
- Bump toolchain to `nightly-2026-01-15`

Cherry-picked cleanly from `6ede6d3c` + `489a0f3e` (previously landed on `gil/rust-1.94-nightly` off v2.2.0).