### PR TITLE
Add MerkleChannelForCircuit.

### DIFF
--- a/crates/stwo/src/core/channel/blake2s.rs
+++ b/crates/stwo/src/core/channel/blake2s.rs
@@ -12,6 +12,8 @@ pub const BLAKE_BYTES_PER_HASH: usize = 32;
 pub const FELTS_PER_HASH: usize = 8;
 
 pub type Blake2sChannel = Blake2sChannelGeneric<false>;
+
+// TODO(ilya): Remove once the circuit is migrated to use MerkleChannelForCircuit.
 /// Same as [Blake2sChannel], expect that the hash output is taken modulo M31::P.
 pub type Blake2sM31Channel = Blake2sChannelGeneric<true>;
 

--- a/crates/stwo/src/core/vcs_lifted/blake2_merkle.rs
+++ b/crates/stwo/src/core/vcs_lifted/blake2_merkle.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use super::merkle_hasher::MerkleHasherLifted;
-use crate::core::channel::{Blake2sChannelGeneric, MerkleChannel};
+use crate::core::channel::{Blake2sChannelGeneric, Blake2sM31Channel, MerkleChannel};
 use crate::core::fields::m31::BaseField;
-use crate::core::vcs::blake2_hash::{Blake2sHash, Blake2sHasherGeneric};
+use crate::core::vcs::blake2_hash::{reduce_to_m31, Blake2sHash, Blake2sHasherGeneric};
 
 pub type Blake2sMerkleHasherGeneric<const IS_M31_OUTPUT: bool> =
     Blake2sHasherGeneric<IS_M31_OUTPUT>;
@@ -49,6 +49,34 @@ impl<const IS_M31_OUTPUT: bool> MerkleChannel for Blake2sMerkleChannelGeneric<IS
     fn mix_root(channel: &mut Self::C, root: <Self::H as MerkleHasherLifted>::Hash) {
         use crate::core::vcs::blake2_hash::Blake2sHasherGeneric;
         channel.update_digest(Blake2sHasherGeneric::<IS_M31_OUTPUT>::concat_and_hash(
+            &channel.digest(),
+            &root,
+        ));
+    }
+}
+
+/// A [`MerkleChannel`] that commits with the **standard** (non-`M31`-reduced) Blake2s Merkle
+/// hasher, while running Fiat-Shamir through the **`M31`** Blake2s channel.
+///
+/// Standard Blake2s gives lossless commitments (each 32-bit word kept in full as two 16-bit
+/// limbs), while the `M31` channel keeps all challenge and query derivation in the reduced field.
+/// This avoids the standard channel's rejection sampling and raw-word query draws
+/// (`Channel::draw_u32s`), so the in-circuit Fiat-Shamir logic stays in `M31` exactly as before.
+#[derive(Default)]
+pub struct MerkleChannelForCircuit;
+
+impl MerkleChannel for MerkleChannelForCircuit {
+    type C = Blake2sM31Channel;
+    type H = Blake2sMerkleHasher;
+
+    fn mix_root(channel: &mut Self::C, root: Blake2sHash) {
+        // Reduce the (standard, lossless) Merkle root mod `M31::P` before mixing. The root's words
+        // can exceed `M31::P`, but the in-circuit channel represents the root as `M31` limbs, so
+        // reducing here keeps the out-of-circuit Fiat-Shamir consistent with the in-circuit logic.
+        let root = Blake2sHash(reduce_to_m31(root.0));
+        // Mix the reduced root into the `M31` channel, reducing the result mod `M31::P`
+        // (the `M31` channel's `concat_and_hash`).
+        channel.update_digest(Blake2sHasherGeneric::<true>::concat_and_hash(
             &channel.digest(),
             &root,
         ));

--- a/crates/stwo/src/prover/backend/cpu/mod.rs
+++ b/crates/stwo/src/prover/backend/cpu/mod.rs
@@ -16,7 +16,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{Backend, BackendForChannel, Column, ColumnOps};
 use crate::core::utils::bit_reverse;
-use crate::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
+use crate::core::vcs_lifted::blake2_merkle::{
+    Blake2sM31MerkleChannel, Blake2sMerkleChannel, MerkleChannelForCircuit,
+};
 use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
@@ -29,6 +31,7 @@ pub struct CpuBackend;
 impl Backend for CpuBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for CpuBackend {}
 impl BackendForChannel<Blake2sM31MerkleChannel> for CpuBackend {}
+impl BackendForChannel<MerkleChannelForCircuit> for CpuBackend {}
 impl BackendForChannel<Keccak256MerkleChannel> for CpuBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for CpuBackend {}

--- a/crates/stwo/src/prover/backend/simd/mod.rs
+++ b/crates/stwo/src/prover/backend/simd/mod.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use super::{Backend, BackendForChannel};
-use crate::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
+use crate::core::vcs_lifted::blake2_merkle::{
+    Blake2sM31MerkleChannel, Blake2sMerkleChannel, MerkleChannelForCircuit,
+};
 use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
@@ -40,6 +42,7 @@ pub struct SimdBackend;
 impl Backend for SimdBackend {}
 impl BackendForChannel<Blake2sMerkleChannel> for SimdBackend {}
 impl BackendForChannel<Blake2sM31MerkleChannel> for SimdBackend {}
+impl BackendForChannel<MerkleChannelForCircuit> for SimdBackend {}
 impl BackendForChannel<Keccak256MerkleChannel> for SimdBackend {}
 #[cfg(not(target_arch = "wasm32"))]
 impl BackendForChannel<Poseidon252MerkleChannel> for SimdBackend {}


### PR DESCRIPTION
## What

Adds `MerkleChannelForCircuit`: a `MerkleChannel` that commits with the **standard** (non-`M31`-reduced, lossless) Blake2s Merkle hasher while running Fiat-Shamir through the **`M31`** Blake2s channel.

- `type C = Blake2sM31Channel`, `type H = Blake2sMerkleHasher`.
- `mix_root` reduces the lossless root mod `M31::P` before mixing, so the out-of-circuit Fiat-Shamir stays consistent with the in-circuit logic (which represents the root as `M31` limbs).
- This keeps challenge/query derivation in `M31`, avoiding the standard channel's rejection sampling and raw-word query draws.

## Changes

- `core/vcs_lifted/blake2_merkle.rs` — the `MerkleChannelForCircuit` type + `MerkleChannel` impl, co-located with `Blake2sMerkleChannelGeneric`.
- `prover/backend/cpu/mod.rs`, `prover/backend/simd/mod.rs` — `BackendForChannel<MerkleChannelForCircuit>` marker impls.
- `core/channel/blake2s.rs` — TODO on `Blake2sM31Channel` pointing future circuit migration at the new type.

## Verification

- `cargo build --features prover -p stwo` ✅
- `cargo build --no-default-features -p stwo` ✅ (verifier-only / no_std path)
- `scripts/clippy.sh` ✅
- `scripts/rust_fmt.sh --check` ✅

> Touches the soundness/security-critical Fiat-Shamir `mix_root` path; logic added without behavior changes to existing channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)