### PR TITLE
Prepare crates for crates.io publishing (v2.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "criterion",
  "educe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/starkware-libs/stwo"
 
 [workspace.dependencies]
 itertools = { version = "0.12", default-features = false, features = [

--- a/crates/air-utils-derive/Cargo.toml
+++ b/crates/air-utils-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-air-utils-derive"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Derive macros for AIR utilities"
 
 [lib]

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -3,14 +3,15 @@ name = "stwo-air-utils"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Utility functions for AIR (Algebraic Intermediate Representation) in STWO"
 
 [dependencies]
 bytemuck.workspace = true
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = false }
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.2.0" }
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.3.0" }
 
 [lib]
 bench = false

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
 
 [features]
@@ -16,7 +17,7 @@ rayon = { workspace = true, optional = true }
 num-traits.workspace = true
 itertools.workspace = true
 tracing.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", default-features = false }
+stwo = { path = "../stwo", version = "2.3.0", default-features = false }
 rand.workspace = true
 hashbrown.workspace = true
 stwo-std-shims = { version = "1.0.0", default-features = false }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-examples"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Example implementations using the STWO prover"
 
 [features]
@@ -20,8 +21,8 @@ itertools.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "prover",
 ] }
 rand.workspace = true
@@ -31,7 +32,7 @@ educe.workspace = true
 # so the `parallel` feature (which pulls in rayon) is only enabled off-wasm. On wasm
 # the crates fall back to their sequential code paths.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "parallel",
 ] }
 

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library implementing the Circle STARK prover and verifier"
 
 [features]


### PR DESCRIPTION
## Summary
Prepares the stwo workspace crates for publishing **v2.3.0** to crates.io.

- Bumps `[workspace.package] version` to **2.3.0**.
- Adds a missing `repository` field to `[workspace.package]` (inherited by all member crates).
- Fixes `constraint-framework` to use `version.workspace = true` instead of a hardcoded version.
- Refreshes `Cargo.lock` (version-only diff).

### Version rationale
Minor (feature-additive) bump over 2.2.0 — 24 commits since `v2.2.0`: new public API (`Keccak256MerkleChannel`, SIMD Keccak-f[1600], new error variants), a `fold_line` signature change, and parallelization work.

> **Base branch note:** targets `gil/rust-1.94-nightly` because that is the branch stwo-circuits currently depends on.

Publish order within this workspace: `stwo → stwo-constraint-framework → stwo-air-utils-derive → stwo-air-utils`.

First link in the publish chain: **stwo 2.3.0** → stwo-cairo 1.3.0 → stwo-circuits 1.0.0 → proving-utils privacy crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)