### PR TITLE
Prepare crates for crates.io publishing v2.3.0 (v0.14.3-rust-bump snapshot)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "criterion",
  "educe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/starkware-libs/stwo"
 
 [workspace.dependencies]
 itertools = { version = "0.12", default-features = false, features = [

--- a/crates/air-utils-derive/Cargo.toml
+++ b/crates/air-utils-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-air-utils-derive"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Derive macros for AIR utilities"
 
 [lib]

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -3,14 +3,15 @@ name = "stwo-air-utils"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Utility functions for AIR (Algebraic Intermediate Representation) in STWO"
 
 [dependencies]
 bytemuck.workspace = true
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = false }
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.2.0" }
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.3.0" }
 
 [lib]
 bench = false

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
 
 [features]
@@ -16,7 +17,7 @@ rayon = { workspace = true, optional = true }
 num-traits.workspace = true
 itertools.workspace = true
 tracing.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", default-features = false }
+stwo = { path = "../stwo", version = "2.3.0", default-features = false }
 rand.workspace = true
 hashbrown.workspace = true
 stwo-std-shims = { version = "1.0.0", default-features = false }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-examples"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Example implementations using the STWO prover"
 
 [features]
@@ -20,8 +21,8 @@ itertools.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "prover",
 ] }
 rand.workspace = true
@@ -31,7 +32,7 @@ educe.workspace = true
 # so the `parallel` feature (which pulls in rayon) is only enabled off-wasm. On wasm
 # the crates fall back to their sequential code paths.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "parallel",
 ] }
 

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library implementing the Circle STARK prover and verifier"
 
 [features]


### PR DESCRIPTION
## Summary

Prepares the stwo workspace crates for crates.io publishing at version **2.3.0**.

This PR is based on the **exact commit** pinned by the proving-utils tag `v0.14.3-rust-bump`
(`489a0f3e` — "Fix rayon-on-wasm regression exposed by the 1.94 toolchain"). The base branch
`gil/v0.14.3-rust-bump-publish-base` is that exact snapshot, so this prep diff is reviewable in
isolation.

(Supersedes the earlier #1426, which carried the same changes but was based on the moved
`gil/rust-1.94-nightly` tip rather than the pinned snapshot.)

## Changes

- Bump `[workspace.package] version` from `2.2.0` -> `2.3.0`.
- Add a `repository` field to `[workspace.package]` and inherit it (`repository.workspace = true`)
  in each crate manifest (crates.io requires this metadata).
- Make `stwo-constraint-framework` inherit the workspace version (`version.workspace = true`)
  instead of hardcoding it.
- Update inter-crate path-dependency version requirements (`2.2.0` -> `2.3.0`).
- Refresh `Cargo.lock`.

Minor (feature-additive) bump over 2.2.0: new public API (`Keccak256MerkleChannel`, SIMD
Keccak-f[1600]), `fold_line` signature change, and parallelization work.

## Notes

- This **will not compile against crates.io** until the crates are actually published, because
  the path dependencies now also carry a version requirement (`2.3.0`) that does not yet exist on
  the registry. That is expected for publish-prep.
- Suggested publish order:
  `stwo` -> `stwo-constraint-framework` -> `stwo-air-utils-derive` -> `stwo-air-utils`.
- `cargo metadata --no-deps` parses cleanly; no real `cargo publish` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
