### PR TITLE
perf(cpu): eliminate O(N×C/16) heap allocations in build_leaves inner loop

### DIFF
--- a/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
+++ b/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
@@ -64,16 +64,17 @@ impl<H: MerkleHasherLifted> MerkleOpsLifted<H> for CpuBackend {
             // absorption rate. For Keccak256 the rate is larger (136 bytes ≈ 34 M31s), so this
             // chunking is suboptimal but still correct.
             const COLS_PER_CHUNK: usize = 16;
+            // Reused across all chunks and rows to avoid heap allocations.
+            let mut col_buffer = [BaseField::default(); COLS_PER_CHUNK];
             for chunk in &group.into_iter().chunks(COLS_PER_CHUNK) {
                 let cols = chunk.into_iter().collect_vec();
                 let chunk_len = cols.len();
-                // Stack buffer reused across all rows to avoid O(N) per-row heap allocations.
-                let mut col_vals = [BaseField::default(); COLS_PER_CHUNK];
+                let col_vals = &mut col_buffer[..chunk_len];
                 for (i, hasher) in prev_layer.iter_mut().enumerate() {
-                    for (dst, col) in col_vals[..chunk_len].iter_mut().zip(cols.iter()) {
+                    for (dst, col) in col_vals.iter_mut().zip_eq(cols.iter()) {
                         *dst = col[i];
                     }
-                    hasher.update_leaf(&col_vals[..chunk_len]);
+                    hasher.update_leaf(col_vals);
                 }
             }
             prev_layer_log_size = log_size;

--- a/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
+++ b/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
@@ -59,15 +59,16 @@ impl<H: MerkleHasherLifted> MerkleOpsLifted<H> for CpuBackend {
                 .map(|idx| prev_layer[(idx >> (log_ratio + 1) << 1) + (idx & 1)].clone())
                 .collect();
 
-            // We chunk by 16 — the amount of M31 elements that triggers a hash permutation
-            // in Blake2s (block = 64 bytes = 16 × 4) and matches Poseidon252's absorption rate.
-            // For Keccak256 the rate is larger (136 bytes ≈ 34 M31s), so this chunking is
-            // suboptimal but still correct.
-            for chunk in &group.into_iter().chunks(16) {
+            // We chunk by COLS_PER_CHUNK — the amount of M31 elements that triggers a hash
+            // permutation in Blake2s (block = 64 bytes = 16 × 4) and matches Poseidon252's
+            // absorption rate. For Keccak256 the rate is larger (136 bytes ≈ 34 M31s), so this
+            // chunking is suboptimal but still correct.
+            const COLS_PER_CHUNK: usize = 16;
+            for chunk in &group.into_iter().chunks(COLS_PER_CHUNK) {
                 let cols = chunk.into_iter().collect_vec();
                 let chunk_len = cols.len();
                 // Stack buffer reused across all rows to avoid O(N) per-row heap allocations.
-                let mut col_vals = [BaseField::default(); 16];
+                let mut col_vals = [BaseField::default(); COLS_PER_CHUNK];
                 for (i, hasher) in prev_layer.iter_mut().enumerate() {
                     for (dst, col) in col_vals[..chunk_len].iter_mut().zip(cols.iter()) {
                         *dst = col[i];

--- a/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
+++ b/crates/stwo/src/prover/backend/cpu/merkle_lifted.rs
@@ -64,10 +64,16 @@ impl<H: MerkleHasherLifted> MerkleOpsLifted<H> for CpuBackend {
             // For Keccak256 the rate is larger (136 bytes ≈ 34 M31s), so this chunking is
             // suboptimal but still correct.
             for chunk in &group.into_iter().chunks(16) {
-                let vec = chunk.into_iter().collect_vec();
-                prev_layer.iter_mut().enumerate().for_each(|(i, hasher)| {
-                    hasher.update_leaf(&vec.iter().map(|v| v[i]).collect_vec());
-                })
+                let cols = chunk.into_iter().collect_vec();
+                let chunk_len = cols.len();
+                // Stack buffer reused across all rows to avoid O(N) per-row heap allocations.
+                let mut col_vals = [BaseField::default(); 16];
+                for (i, hasher) in prev_layer.iter_mut().enumerate() {
+                    for (dst, col) in col_vals[..chunk_len].iter_mut().zip(cols.iter()) {
+                        *dst = col[i];
+                    }
+                    hasher.update_leaf(&col_vals[..chunk_len]);
+                }
             }
             prev_layer_log_size = log_size;
         }


### PR DESCRIPTION
## Motivation

Follow-up performance optimization prompted by #1425 (merged: simplified `Blake2sMerkleHasher` to a non-generic type and removed M31 reduction from tree building).

While reviewing #1425 I noticed the CPU backend's `build_leaves` had an O(N × C/16) heap-allocation pattern in its innermost loop — one `Vec<BaseField>` allocated **per row** for every 16-column chunk.

## Change

**File:** `crates/stwo/src/prover/backend/cpu/merkle_lifted.rs`

**Before:**
```rust
for chunk in &group.into_iter().chunks(16) {
    let vec = chunk.into_iter().collect_vec();
    prev_layer.iter_mut().enumerate().for_each(|(i, hasher)| {
        hasher.update_leaf(&vec.iter().map(|v| v[i]).collect_vec());
    })
}
```

The inner `collect_vec()` on the mapped iterator allocates a new `Vec<BaseField>` for each of the N rows, for each chunk of 16 columns — O(N × ⌈C/16⌉) allocations total.

**After:**
```rust
const COLS_PER_CHUNK: usize = 16;
for chunk in &group.into_iter().chunks(COLS_PER_CHUNK) {
    let cols = chunk.into_iter().collect_vec();
    let chunk_len = cols.len();
    // Stack buffer reused across all rows to avoid O(N) per-row heap allocations.
    let mut col_vals = [BaseField::default(); COLS_PER_CHUNK];
    for (i, hasher) in prev_layer.iter_mut().enumerate() {
        for (dst, col) in col_vals[..chunk_len].iter_mut().zip(cols.iter()) {
            *dst = col[i];
        }
        hasher.update_leaf(&col_vals[..chunk_len]);
    }
}
```

A single 16-element stack array is allocated once per chunk (~⌈C/16⌉ times) and reused for all N rows. The `COLS_PER_CHUNK` const couples the `chunks(N)` call and the buffer size so they can't drift.

## Correctness

Semantics are byte-identical: `update_leaf` receives `[col_0[i], col_1[i], …, col_(chunk_len-1)[i]]` in both versions. The trailing slots in `col_vals` are never passed (only `col_vals[..chunk_len]` is sliced). Reviewed by an independent Opus agent: no blocking issues found.

## Expected Impact

CPU backend `build_leaves` with large N (e.g. 2²⁰ rows, 16 columns): reduces ~2²⁰ heap allocations per column chunk to ~1 stack alloc per chunk. Allocator pressure and cache churn drop proportionally. The SIMD backend (primary production path) is unaffected.

## Tests

```
cargo test -p stwo --features prover --lib -- backend::cpu   # 25 passed
cargo test -p stwo --features prover --lib -- vcs_lifted     # 13 passed
cargo test -p stwo --features prover --lib -- simd::blake2s_lifted  # 3 passed
cargo test -p stwo --features prover                          # doctests passed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011QsLyt7YYRicpNm7VHfRQ7)_