### PR TITLE
Merge crates.io publishing line (v0.14.3-rust-bump) into dev

### DIFF
--- a/.github/workflows/benchmarks-pages.yaml
+++ b/.github/workflows/benchmarks-pages.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/bootstrap_runners
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - name: Run benchmark
         run: |
           cargo install cargo-criterion

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  NIGHTLY_VERSION: "nightly-2025-07-14"
+  NIGHTLY_VERSION: "nightly-2026-01-15"
   STABLE_VERSION: "1.88.0"
 
 on:
@@ -249,7 +249,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - uses: Swatinem/rust-cache@v2
       - name: Install Machete
         run: cargo install --locked cargo-machete

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,14 +13,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2025-07-14
+          toolchain: nightly-2026-01-15
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
         # TODO: Merge coverage reports for tests on different architectures.
         # <https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#merge-coverages-generated-under-different-test-conditions>
       - name: Generate code coverage
-        run: cargo +nightly-2025-07-14 llvm-cov --codecov --output-path codecov.json
+        run: cargo +nightly-2026-01-15 llvm-cov --codecov --output-path codecov.json
         env:
           RUSTFLAGS: "-C target-feature=+avx512f"
       - name: Upload coverage to Codecov

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ All agent behavior is governed by this hierarchy. No exception, no override.
 
 | Layer | Technology | Notes |
 |-------|-----------|-------|
-| Language | Rust nightly-2025-07-14 | Stable features except SIMD. See `rust-toolchain.toml` |
+| Language | Rust nightly-2026-01-15 | Stable features except SIMD. See `rust-toolchain.toml` |
 | Field | Mersenne31 (M31) | CM31, QM31 extension tower. p = 2^31 - 1 |
 | Proof system | Circle STARKs | FRI-based, circle group C(F_p) |
 | Test framework | Rust built-in + criterion | No proptest (coverage gap) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "criterion",
  "educe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "criterion",
  "educe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/starkware-libs/stwo"
 
 [workspace.dependencies]
 itertools = { version = "0.12", default-features = false, features = [

--- a/crates/air-utils-derive/Cargo.toml
+++ b/crates/air-utils-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-air-utils-derive"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Derive macros for AIR utilities"
 
 [lib]

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -9,8 +9,8 @@ description = "Utility functions for AIR (Algebraic Intermediate Representation)
 bytemuck.workspace = true
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = false }
-stwo = { path = "../stwo", version = "2.1.0", features = ["prover"] }
-stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.1.0" }
+stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
+stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.2.0" }
 
 [lib]
 bench = false

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -3,14 +3,15 @@ name = "stwo-air-utils"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Utility functions for AIR (Algebraic Intermediate Representation) in STWO"
 
 [dependencies]
 bytemuck.workspace = true
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = false }
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.2.0" }
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-air-utils-derive = { path = "../air-utils-derive", version = "2.3.0" }
 
 [lib]
 bench = false

--- a/crates/air-utils/src/lib.rs
+++ b/crates/air-utils/src/lib.rs
@@ -1,3 +1,3 @@
-#![feature(exact_size_is_empty, raw_slice_split, portable_simd, array_chunks)]
+#![feature(exact_size_is_empty, raw_slice_split, portable_simd)]
 pub mod lookup_data;
 pub mod trace;

--- a/crates/air-utils/src/lib.rs
+++ b/crates/air-utils/src/lib.rs
@@ -1,3 +1,19 @@
 #![feature(exact_size_is_empty, raw_slice_split, portable_simd)]
 pub mod lookup_data;
 pub mod trace;
+
+/// Ensures a usable rayon global thread pool exists before running parallel code in tests.
+///
+/// On threadless wasm targets (e.g. `wasm32-wasip1`) rayon cannot spawn worker threads, so its
+/// default lazily-built global pool aborts. Build a single-threaded global pool that runs work on
+/// the calling thread instead. Idempotent and a no-op off wasm, where the default pool is fine.
+#[cfg(test)]
+pub(crate) fn ensure_rayon_pool() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .use_current_thread()
+            .build_global();
+    }
+}

--- a/crates/air-utils/src/lookup_data/mod.rs
+++ b/crates/air-utils/src/lookup_data/mod.rs
@@ -48,7 +48,9 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .array_chunks::<N_LANES>()
+            .as_chunks::<N_LANES>()
+            .0
+            .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);
                 let x1 = x + PackedM31::broadcast(M31(1));
@@ -113,7 +115,9 @@ mod tests {
             Vec<_>,
             (Vec<_>, Vec<_>),
         ) = arr
-            .array_chunks::<N_LANES>()
+            .as_chunks::<N_LANES>()
+            .0
+            .iter()
             .map(|x| {
                 let x = PackedM31::from_array(*x);
                 let x1 = x + PackedM31::broadcast(M31(1));

--- a/crates/air-utils/src/lookup_data/mod.rs
+++ b/crates/air-utils/src/lookup_data/mod.rs
@@ -105,6 +105,7 @@ mod tests {
 
     #[test]
     fn test_derived_lookup_data_par_iter() {
+        crate::ensure_rayon_pool();
         const N_COLUMNS: usize = 5;
         const LOG_N_ROWS: u32 = 8;
         let mut trace = ComponentTrace::<N_COLUMNS>::zeroed(LOG_N_ROWS);

--- a/crates/air-utils/src/trace/component_trace.rs
+++ b/crates/air-utils/src/trace/component_trace.rs
@@ -161,6 +161,8 @@ mod tests {
         use rayon::iter::{IndexedParallelIterator, ParallelIterator};
         use rayon::slice::ParallelSlice;
 
+        crate::ensure_rayon_pool();
+
         const N_COLUMNS: usize = 3;
         const LOG_SIZE: u32 = 8;
         const CHUNK_SIZE: usize = 4;

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.1.0"
+version = "2.2.0"
 edition.workspace = true
 license.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
@@ -16,7 +16,7 @@ rayon = { workspace = true, optional = true }
 num-traits.workspace = true
 itertools.workspace = true
 tracing.workspace = true
-stwo = { path = "../stwo", version = "2.1.0", default-features = false }
+stwo = { path = "../stwo", version = "2.2.0", default-features = false }
 rand.workspace = true
 hashbrown.workspace = true
 stwo-std-shims = { version = "1.0.0", default-features = false }

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
 
 [features]
@@ -16,7 +17,7 @@ rayon = { workspace = true, optional = true }
 num-traits.workspace = true
 itertools.workspace = true
 tracing.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", default-features = false }
+stwo = { path = "../stwo", version = "2.3.0", default-features = false }
 rand.workspace = true
 hashbrown.workspace = true
 stwo-std-shims = { version = "1.0.0", default-features = false }

--- a/crates/constraint-framework/src/expr/degree.rs
+++ b/crates/constraint-framework/src/expr/degree.rs
@@ -71,7 +71,6 @@ impl ExtExpr {
         match self {
             ExtExpr::SecureCol(coefs) => coefs
                 .iter()
-                .cloned()
                 .map(|coef| coef.degree_bound(named_exprs))
                 .max()
                 .unwrap(),

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -20,8 +20,8 @@ itertools.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-stwo = { path = "../stwo", version = "2.1.0", features = ["prover"] }
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.1.0", features = [
+stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
     "prover",
     "parallel",
 ] }

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -23,10 +23,17 @@ serde.workspace = true
 stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
 stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
     "prover",
-    "parallel",
 ] }
 rand.workspace = true
 educe.workspace = true
+
+# rayon cannot build a thread pool on threadless wasm targets (e.g. wasm32-wasip1),
+# so the `parallel` feature (which pulls in rayon) is only enabled off-wasm. On wasm
+# the crates fall back to their sequential code paths.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+    "parallel",
+] }
 
 [dev-dependencies]
 criterion = { default-features = false, features = [

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-examples"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Example implementations using the STWO prover"
 
 [features]
@@ -20,8 +21,8 @@ itertools.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
-stwo = { path = "../stwo", version = "2.2.0", features = ["prover"] }
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo = { path = "../stwo", version = "2.3.0", features = ["prover"] }
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "prover",
 ] }
 rand.workspace = true
@@ -31,7 +32,7 @@ educe.workspace = true
 # so the `parallel` feature (which pulls in rayon) is only enabled off-wasm. On wasm
 # the crates fall back to their sequential code paths.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stwo-constraint-framework = { path = "../constraint-framework", version = "2.2.0", features = [
+stwo-constraint-framework = { path = "../constraint-framework", version = "2.3.0", features = [
     "parallel",
 ] }
 

--- a/crates/examples/src/blake/round/gen.rs
+++ b/crates/examples/src/blake/round/gen.rs
@@ -252,7 +252,7 @@ pub fn generate_interaction_trace(
     let _span = span!(Level::INFO, "Generate round interaction trace").entered();
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.array_chunks::<2>() {
+    for [(w0, l0), (w1, l1)] in lookup_data.xor_lookups.as_chunks::<2>().0.iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/scheduler/gen.rs
+++ b/crates/examples/src/blake/scheduler/gen.rs
@@ -126,7 +126,7 @@ pub fn gen_interaction_trace(
 
     let mut logup_gen = LogupTraceGenerator::new(log_size);
 
-    for [l0, l1] in lookup_data.round_lookups.array_chunks::<2>() {
+    for [l0, l1] in lookup_data.round_lookups.as_chunks::<2>().0.iter() {
         let mut col_gen = logup_gen.new_col();
 
         for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {

--- a/crates/examples/src/blake/xor_table/gen.rs
+++ b/crates/examples/src/blake/xor_table/gen.rs
@@ -100,34 +100,32 @@ macro_rules! xor_table_gen {
             }
 
             // If there is an odd number of lookup expressions, handle the last one.
-            if let Some(rem) = iter.into_remainder() {
-                if let Some((i, mults)) = rem.collect_vec().pop() {
-                    let mut col_gen = logup_gen.new_col();
-                    let ah = i as u32 >> EXPAND_BITS;
-                    let bh = i as u32 & ((1 << EXPAND_BITS) - 1);
+            let rem = iter.into_remainder();
+            if let Some((i, mults)) = rem.collect_vec().pop() {
+                let mut col_gen = logup_gen.new_col();
+                let ah = i as u32 >> EXPAND_BITS;
+                let bh = i as u32 & ((1 << EXPAND_BITS) - 1);
 
-                    for vec_row in 0..(1
-                        << (XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits() - LOG_N_LANES))
-                    {
-                        // vec_row is LIMB_BITS of a, and LIMB_BITS - LOG_N_LANES of b.
-                        let al = vec_row >> (limb_bits - LOG_N_LANES);
-                        let a = u32x16::splat((ah << limb_bits) | al);
-                        let bm = vec_row & ((1 << (limb_bits - LOG_N_LANES)) - 1);
-                        let b =
-                            u32x16::splat((bh << limb_bits) | (bm << LOG_N_LANES)) | offsets_vec;
+                for vec_row in
+                    0..(1 << (XorTable::new(ELEM_BITS, EXPAND_BITS, 0).column_bits() - LOG_N_LANES))
+                {
+                    // vec_row is LIMB_BITS of a, and LIMB_BITS - LOG_N_LANES of b.
+                    let al = vec_row >> (limb_bits - LOG_N_LANES);
+                    let a = u32x16::splat((ah << limb_bits) | al);
+                    let bm = vec_row & ((1 << (limb_bits - LOG_N_LANES)) - 1);
+                    let b = u32x16::splat((bh << limb_bits) | (bm << LOG_N_LANES)) | offsets_vec;
 
-                        let c = a ^ b;
+                    let c = a ^ b;
 
-                        let p: PackedSecureField = lookup_elements.combine(
-                            &[a, b, c].map(|x| unsafe { PackedBaseField::from_simd_unchecked(x) }),
-                        );
+                    let p: PackedSecureField = lookup_elements.combine(
+                        &[a, b, c].map(|x| unsafe { PackedBaseField::from_simd_unchecked(x) }),
+                    );
 
-                        let num = mults.data[vec_row as usize];
-                        let denom = p;
-                        col_gen.write_frac(vec_row as usize, PackedSecureField::from(-num), denom);
-                    }
-                    col_gen.finalize_col();
+                    let num = mults.data[vec_row as usize];
+                    let denom = p;
+                    col_gen.write_frac(vec_row as usize, PackedSecureField::from(-num), denom);
                 }
+                col_gen.finalize_col();
             }
 
             logup_gen.finalize_last()

--- a/crates/examples/src/lib.rs
+++ b/crates/examples/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, iter_array_chunks, array_chunks)]
+#![feature(portable_simd, iter_array_chunks)]
 pub mod blake;
 pub mod plonk;
 pub mod poseidon;

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library implementing the Circle STARK prover and verifier"
 
 [features]

--- a/crates/stwo/src/lib.rs
+++ b/crates/stwo/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
     feature = "prover",
-    feature(array_chunks, iter_array_chunks, portable_simd, slice_ptr_get)
+    feature(iter_array_chunks, portable_simd, slice_ptr_get)
 )]
 pub mod core;
 

--- a/crates/stwo/src/prover/backend/cpu/circle.rs
+++ b/crates/stwo/src/prover/backend/cpu/circle.rs
@@ -264,8 +264,10 @@ impl PolyOps for CpuBackend {
 
         let mut itwiddles = vec![BaseField::zero(); twiddles.len()];
         twiddles
-            .array_chunks::<CHUNK_SIZE>()
-            .zip(itwiddles.array_chunks_mut::<CHUNK_SIZE>())
+            .as_chunks::<CHUNK_SIZE>()
+            .0
+            .iter()
+            .zip(itwiddles.as_chunks_mut::<CHUNK_SIZE>().0.iter_mut())
             .for_each(|(src, dst)| {
                 batch_inverse_in_place(src, dst);
             });

--- a/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
@@ -231,7 +231,7 @@ pub fn gen_eq_evals(y: &[SecureField], v: SecureField) -> Vec<SecureField> {
 }
 
 fn next_grand_product_layer(layer: &Mle<CpuBackend, SecureField>) -> Layer<CpuBackend> {
-    let res = layer.array_chunks().map(|&[a, b]| a * b).collect();
+    let res = layer.as_chunks().0.iter().map(|&[a, b]| a * b).collect();
     Layer::GrandProduct(Mle::new(res))
 }
 

--- a/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
+++ b/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
@@ -279,6 +279,7 @@ impl PackLeavesOps for SimdBackend {
         let output_packed_len_floor = output_len / N_LANES;
 
         // TODO(Leo): parallelize.
+        #[allow(clippy::needless_range_loop)]
         for row in 0..output_packed_len_floor {
             let packed_start_idx = row * PACKED_LEAF_SIZE;
             let packed_values = core::array::from_fn(|j| {
@@ -303,6 +304,7 @@ impl PackLeavesOps for SimdBackend {
             let mut tail_columns: [[BaseField; N_LANES];
                 SECURE_EXTENSION_DEGREE * PACKED_LEAF_SIZE] =
                 core::array::from_fn(|_| [BaseField::zero(); N_LANES]);
+            #[allow(clippy::needless_range_loop)]
             for row in 0..tail_rows {
                 // The index in the input vector corresponding to `row`.
                 let source_row_start = (output_packed_len_floor * N_LANES + row) * PACKED_LEAF_SIZE;

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -197,7 +197,7 @@ impl PolyOps for SimdBackend {
                                  offset: usize| {
             let mut sum = PackedSecureField::zeroed();
             let mut twiddle_high = Self::twiddle_at(&mappings, offset * N_LANES);
-            for (i, coeff_chunk) in coeff_chunk.array_chunks::<N_LANES>().enumerate() {
+            for (i, coeff_chunk) in coeff_chunk.as_chunks::<N_LANES>().0.iter().enumerate() {
                 // For every chunk of 2 ^ 4 * 2 ^ 4 = 2 ^ 8 elements, the twiddle high is the same.
                 // Multiply it by every mid twiddle factor to get the factors for the current chunk.
                 let high_twiddle_factors =

--- a/crates/stwo/src/prover/backend/simd/column.rs
+++ b/crates/stwo/src/prover/backend/simd/column.rs
@@ -127,11 +127,12 @@ impl Column<BaseField> for BaseColumn {
 
 impl FromIterator<BaseField> for BaseColumn {
     fn from_iter<I: IntoIterator<Item = BaseField>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks).map(PackedBaseField::from_array).collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;
@@ -208,11 +209,12 @@ impl Column<CM31> for CM31Column {
 
 impl FromIterator<CM31> for CM31Column {
     fn from_iter<I: IntoIterator<Item = CM31>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks).map(PackedCM31::from_array).collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;
@@ -340,13 +342,14 @@ impl Column<SecureField> for SecureColumn {
 
 impl FromIterator<SecureField> for SecureColumn {
     fn from_iter<I: IntoIterator<Item = SecureField>>(iter: I) -> Self {
-        let mut chunks = iter.into_iter().array_chunks();
+        let mut chunks = iter.into_iter().array_chunks::<N_LANES>();
         let mut data = (&mut chunks)
             .map(PackedSecureField::from_array)
             .collect_vec();
         let mut length = data.len() * N_LANES;
 
-        if let Some(remainder) = chunks.into_remainder() {
+        {
+            let remainder = chunks.into_remainder();
             let rem = remainder.len();
             if rem > 0 {
                 length += rem;

--- a/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
@@ -134,7 +134,9 @@ fn next_grand_product_layer(layer: &Mle<SimdBackend, SecureField>) -> Layer<Simd
 
     let data = layer
         .data
-        .array_chunks()
+        .as_chunks()
+        .0
+        .iter()
         .map(|&[a, b]| {
             let (evens, odds) = a.deinterleave(b);
             evens * odds

--- a/crates/stwo/src/prover/backend/simd/prefix_sum.rs
+++ b/crates/stwo/src/prover/backend/simd/prefix_sum.rs
@@ -33,7 +33,10 @@ pub fn inclusive_prefix_sum(
     // Handle the first two up sweep rounds manually.
     // Required due different ordering of `CircleDomain` and `Coset`.
     // Evaluations are provided in bit-reversed `CircleDomain` order.
-    for ([l0, l1], [r0, r1]) in izip!(l_half.array_chunks_mut(), r_half.array_chunks_mut().rev()) {
+    for ([l0, l1], [r0, r1]) in izip!(
+        l_half.as_chunks_mut::<2>().0.iter_mut(),
+        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+    ) {
         let (mut half_coset0_lo, half_coset1_hi_rev) = l0.deinterleave(*l1);
         let half_coset1_hi = half_coset1_hi_rev.reverse();
         let (mut half_coset0_hi, half_coset1_lo_rev) = r0.deinterleave(*r1);
@@ -56,8 +59,11 @@ pub fn inclusive_prefix_sum(
     let mut chunk_size = half_coset0_sums.len() / 2;
     while chunk_size > 1 {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
-        zip(lows.array_chunks_mut(), highs.array_chunks())
-            .for_each(|([lo, _], [hi, _])| up_sweep_val(lo, *hi));
+        zip(
+            lows.as_chunks_mut::<2>().0.iter_mut(),
+            highs.as_chunks::<2>().0.iter(),
+        )
+        .for_each(|([lo, _], [hi, _])| up_sweep_val(lo, *hi));
         chunk_size /= 2;
     }
     // Up sweep the last SIMD vector.
@@ -84,8 +90,11 @@ pub fn inclusive_prefix_sum(
     let mut chunk_size = 2;
     while chunk_size < half_coset0_sums.len() {
         let (lows, highs) = half_coset0_sums.split_at_mut(chunk_size);
-        zip(lows.array_chunks_mut(), highs.array_chunks_mut())
-            .for_each(|([lo, _], [hi, _])| down_sweep_val(lo, hi));
+        zip(
+            lows.as_chunks_mut::<2>().0.iter_mut(),
+            highs.as_chunks_mut::<2>().0.iter_mut(),
+        )
+        .for_each(|([lo, _], [hi, _])| down_sweep_val(lo, hi));
         chunk_size *= 2;
     }
     // Handle last two down sweep rounds manually.
@@ -98,7 +107,10 @@ pub fn inclusive_prefix_sum(
         down_sweep_val(&mut lo, &mut hi);
         (half_coset0_sums[lo_index], half_coset0_sums[hi_index]) = (lo, hi);
     }
-    for ([l0, l1], [r0, r1]) in izip!(l_half.array_chunks_mut(), r_half.array_chunks_mut().rev()) {
+    for ([l0, l1], [r0, r1]) in izip!(
+        l_half.as_chunks_mut::<2>().0.iter_mut(),
+        r_half.as_chunks_mut::<2>().0.iter_mut().rev()
+    ) {
         let mut half_coset0_lo = *l0;
         let mut half_coset1_lo = *r0;
         down_sweep_val(&mut half_coset0_lo, &mut half_coset1_lo);

--- a/ensure-verifier-no_std/Cargo.lock
+++ b/ensure-verifier-no_std/Cargo.lock
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "stwo"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "blake2",
  "blake3",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.0.0"
+version = "2.2.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-07-14"
+channel = "nightly-2026-01-15"

--- a/scripts/bump_versions.sh
+++ b/scripts/bump_versions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CURRENT_VERSION='2.1.0'
+CURRENT_VERSION='2.2.0'
 NEW_VERSION="$@"
 
 if [ -z "$NEW_VERSION" ]; then

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -4,7 +4,7 @@
 # status, or there's a reference to an undefined variable.
 set -eou pipefail
 
-cargo +nightly-2025-07-14 clippy --workspace "$@" --all-targets --all-features -- -D warnings \
+cargo +nightly-2026-01-15 clippy --workspace "$@" --all-targets --all-features -- -D warnings \
     -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused
 
 # Extract all crate names from the workspace metadata
@@ -14,6 +14,6 @@ crates=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' 
 # clippy on the entire workspace
 for crate in $crates; do
   echo "Clippy on crate: $crate"
-  cargo +nightly-2025-07-14 clippy -p "$crate" --all-targets --all-features -- -D warnings \
+  cargo +nightly-2026-01-15 clippy -p "$crate" --all-targets --all-features -- -D warnings \
     -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused
 done

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2025-07-14 fmt --all -- "$@"
+cargo +nightly-2026-01-15 fmt --all -- "$@"

--- a/scripts/test_avx.sh
+++ b/scripts/test_avx.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Can be used as a drop in replacement for `cargo test` with avx512f flag on.
 # For example, `./scripts/test_avx.sh` will run all tests(not only avx).
-RUSTFLAGS="-Awarnings -C target-cpu=native -C target-feature=+avx512f -C opt-level=2" cargo +nightly-2025-07-14 test "$@"
+RUSTFLAGS="-Awarnings -C target-cpu=native -C target-feature=+avx512f -C opt-level=2" cargo +nightly-2026-01-15 test "$@"


### PR DESCRIPTION
Merges the v0.14.3-rust-bump crates.io publishing branch (`gil/v0.14.3-rust-bump-publish-base`) back into `dev`.

This branch holds the published state for **stwo 2.3.0**: crate metadata/renames for crates.io and all upstream deps resolved to published versions (no git revs). Now that 2.3.0 is published, this brings the publishing line back into the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)