### PR TITLE
feat: add From<[u32; 8]> for Blake2sHash

### DIFF
--- a/crates/stwo/src/core/vcs/blake2_hash.rs
+++ b/crates/stwo/src/core/vcs/blake2_hash.rs
@@ -50,6 +50,16 @@ impl From<Blake2sHash> for [u8; 32] {
     }
 }
 
+impl From<[u32; 8]> for Blake2sHash {
+    fn from(val: [u32; 8]) -> Self {
+        let mut bytes = [0u8; 32];
+        for (chunk, word) in bytes.chunks_exact_mut(4).zip(val) {
+            chunk.copy_from_slice(&word.to_le_bytes());
+        }
+        Self(bytes)
+    }
+}
+
 impl fmt::Display for Blake2sHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&hex::encode(self.0))


### PR DESCRIPTION
Adds a `From<[u32; 8]>` conversion for `Blake2sHash`, building a hash from 8 blake2s state words.

The conversion uses explicit little-endian serialization (`to_le_bytes` per word), which matches the canonical blake2s digest byte order and is correct regardless of target endianness. It stays `no_std`-safe for the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)