### PR TITLE
Align dev with the published 2.3.0 release (version + repository metadata)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ version = "1.0.0"
 
 [[package]]
 name = "stwo"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aligned",
  "blake2",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-examples"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "criterion",
  "educe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ exclude = ["ensure-verifier-no_std"]
 resolver = "2"
 
 [workspace.package]
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/starkware-libs/stwo"
 
 [workspace.dependencies]
 itertools = { version = "0.12", default-features = false, features = [

--- a/crates/air-utils-derive/Cargo.toml
+++ b/crates/air-utils-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-air-utils-derive"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Derive macros for AIR utilities"
 
 [lib]

--- a/crates/air-utils/Cargo.toml
+++ b/crates/air-utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-air-utils"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Utility functions for AIR (Algebraic Intermediate Representation) in STWO"
 
 [dependencies]

--- a/crates/constraint-framework/Cargo.toml
+++ b/crates/constraint-framework/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "stwo-constraint-framework"
-version = "2.2.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Constraint framework for building AIR constraints with STWO"
 
 [features]

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo-examples"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Example implementations using the STWO prover"
 
 [features]

--- a/crates/std-shims/Cargo.toml
+++ b/crates/std-shims/Cargo.toml
@@ -3,6 +3,7 @@ name = "std-shims"
 version = "1.0.0"
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Standard library shims for `no_std` compatibility"
 
 [features]

--- a/crates/stwo/Cargo.toml
+++ b/crates/stwo/Cargo.toml
@@ -3,6 +3,7 @@ name = "stwo"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library implementing the Circle STARK prover and verifier"
 
 [features]


### PR DESCRIPTION
## What

Brings the `dev` branch in line with the published **2.3.0** crates.io release — version and metadata only, no dependency or code changes.

- Workspace version `2.2.0 → 2.3.0` (dev was declaring an older version than what's published).
- Adds the `repository` metadata field: `repository` in `[workspace.package]` and `repository.workspace = true` in each member crate (matching the published crates).
- Restores `stwo-constraint-framework` to `version.workspace = true` (it had drifted to a pinned `2.2.0` on dev).

## Not included (deliberately)

- **No dependency changes** — dev keeps its current dep graph.
- **No renames** — stwo's crates were already published-named. (Note: `std-shims` is published on crates.io as `stwo-std-shims` because the bare `std-shims` name is taken by an unrelated crate; the source manifest still says `std-shims`. That naming mismatch is pre-existing and left as-is here.)

## Verification

`cargo metadata` parses; all workspace crates resolve at `2.3.0` (std-shims keeps its own `1.0.0`) with `repository` set. `Cargo.lock` updated for the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)