### PR TITLE
Change PcsConfig::lifting_log_size from Option<u32> to min_lifting_log_size: u32.

### DIFF
--- a/crates/examples/src/plonk/mod.rs
+++ b/crates/examples/src/plonk/mod.rs
@@ -308,7 +308,7 @@ mod tests {
         let config = PcsConfig {
             pow_bits: 10,
             fri_config: FriConfig::new(5, 4, 64, 1),
-            lifting_log_size: None,
+            min_lifting_log_size: 0,
         };
 
         // Prove.

--- a/crates/examples/src/poseidon/mod.rs
+++ b/crates/examples/src/poseidon/mod.rs
@@ -502,7 +502,7 @@ mod tests {
         let config = PcsConfig {
             pow_bits: 10,
             fri_config: FriConfig::new(5, 1, 64, 1),
-            lifting_log_size: None,
+            min_lifting_log_size: 0,
         };
 
         // Prove.
@@ -551,7 +551,7 @@ mod tests {
         let config = PcsConfig {
             pow_bits: 10,
             fri_config: FriConfig::new(5, 1, 64, 1),
-            lifting_log_size: None,
+            min_lifting_log_size: 0,
         };
 
         // Prove.

--- a/crates/examples/src/wide_fibonacci/fib_with_preprocessed.rs
+++ b/crates/examples/src/wide_fibonacci/fib_with_preprocessed.rs
@@ -265,8 +265,7 @@ mod tests {
             let mut config = PcsConfig::default();
             let log_size_unused_pp = log_n_instances + 3;
             // Set lifting log size to the largest preprocessed column (after LDE).
-            config.lifting_log_size =
-                Some(log_size_unused_pp + config.fri_config.log_blowup_factor);
+            config.min_lifting_log_size = log_size_unused_pp + config.fri_config.log_blowup_factor;
             // Precompute twiddles.
             let twiddles = SimdBackend::precompute_twiddles(
                 CanonicCoset::new(log_size_unused_pp + 1 + config.fri_config.log_blowup_factor)

--- a/crates/examples/src/wide_fibonacci/mod.rs
+++ b/crates/examples/src/wide_fibonacci/mod.rs
@@ -252,7 +252,7 @@ mod tests {
             let config = PcsConfig {
                 pow_bits: 10,
                 fri_config: FriConfig::new(0, 2, 3, 1),
-                lifting_log_size: None,
+                min_lifting_log_size: 0,
             };
             // Precompute twiddles for the larger committed domain.
             let twiddles = SimdBackend::precompute_twiddles(

--- a/crates/stwo/benches/pcs.rs
+++ b/crates/stwo/benches/pcs.rs
@@ -32,7 +32,7 @@ fn benched_fn<B: BackendForChannel<Blake2sMerkleChannel>>(
         LOG_BLOWUP_FACTOR,
         twiddles,
         false,
-        None,
+        0,
         &BaseColumnPool::new(),
     );
 }

--- a/crates/stwo/src/core/fri.rs
+++ b/crates/stwo/src/core/fri.rs
@@ -482,7 +482,7 @@ impl<H: MerkleHasherLifted> FriFirstLayerVerifier<H> {
                 self.column_commitment_domain.log_size() - leaf_log_size;
                 SECURE_EXTENSION_DEGREE * (1 << leaf_log_size)
             ],
-            None,
+            0,
         );
 
         merkle_verifier
@@ -567,7 +567,7 @@ impl<H: MerkleHasherLifted> FriInnerLayerVerifier<H> {
                 self.domain.log_size() - leaf_log_size;
                 SECURE_EXTENSION_DEGREE * (1 << leaf_log_size)
             ],
-            None,
+            0,
         );
 
         merkle_verifier

--- a/crates/stwo/src/core/pcs/mod.rs
+++ b/crates/stwo/src/core/pcs/mod.rs
@@ -32,13 +32,14 @@ pub struct PcsConfig {
     /// The number of proof of work bits before the FRI queries.
     pub pow_bits: u32,
     pub fri_config: FriConfig,
-    /// An optional integer which controls the size of the lifting domain (This size includes the
-    /// `log_blowup_factor`). When specified, the prover lifts all polynomials to the domain of
-    /// given log size.
-    /// If `None`, the prover lifts each tree’s polynomials to the largest domain within that tree
+    /// A lower bound on the size of the lifting domain (This size includes the
+    /// `log_blowup_factor`). Each tree is committed with height
+    /// `max(min_lifting_log_size, max_column_log_size)`, where `max_column_log_size` is the log
+    /// size of the largest (extended) domain within that tree.
+    /// In particular, `0` lifts each tree’s polynomials to the largest domain within that tree
     /// (an implicit assumption here is that the largest domains are all of equal size across
     /// trees, except possibly for the preprocessed tree).
-    pub lifting_log_size: Option<u32>,
+    pub min_lifting_log_size: u32,
 }
 impl PcsConfig {
     pub const fn security_bits(&self) -> u32 {
@@ -49,7 +50,7 @@ impl PcsConfig {
         let PcsConfig {
             pow_bits,
             fri_config,
-            lifting_log_size,
+            min_lifting_log_size,
         } = self;
         let FriConfig {
             log_blowup_factor,
@@ -65,7 +66,7 @@ impl PcsConfig {
                 *n_queries as u32,
                 *log_last_layer_degree_bound,
             ),
-            SecureField::from_u32_unchecked(*fold_step, lifting_log_size.unwrap_or(0), 0, 0),
+            SecureField::from_u32_unchecked(*fold_step, *min_lifting_log_size, 0, 0),
         ]);
     }
 }
@@ -75,7 +76,7 @@ impl Default for PcsConfig {
         Self {
             pow_bits: 10,
             fri_config: FriConfig::new(0, 1, 3, 1),
-            lifting_log_size: None,
+            min_lifting_log_size: 0,
         }
     }
 }
@@ -87,7 +88,7 @@ mod tests {
         let config = super::PcsConfig {
             pow_bits: 42,
             fri_config: super::FriConfig::new(10, 10, 70, 1),
-            lifting_log_size: None,
+            min_lifting_log_size: 0,
         };
         assert!(config.security_bits() == 10 * 70 + 42);
     }

--- a/crates/stwo/src/core/pcs/utils.rs
+++ b/crates/stwo/src/core/pcs/utils.rs
@@ -6,7 +6,6 @@ use std_shims::{vec, BTreeSet, Vec};
 use thiserror::Error;
 
 use super::TreeSubspan;
-use crate::core::pcs::PcsConfig;
 use crate::core::ColumnVec;
 
 /// A container that holds an element for each commitment tree.
@@ -214,23 +213,8 @@ pub fn prepare_preprocessed_query_positions(
 }
 
 #[derive(Clone, Copy, Debug, Error)]
-#[error("Lifting log size is too small ({lifting_log_size}). It must be at least {min_log_size}.")]
-pub struct InvalidLiftingLogSizeError {
-    pub lifting_log_size: u32,
-    pub min_log_size: u32,
-}
-
-pub fn try_get_lifting_log_size(
-    config: &PcsConfig,
-    log_trace_size: u32,
-) -> Result<u32, InvalidLiftingLogSizeError> {
-    let lifting_log_size = config.lifting_log_size.unwrap_or(log_trace_size);
-    if lifting_log_size < log_trace_size {
-        return Err(InvalidLiftingLogSizeError {
-            lifting_log_size,
-            min_log_size: log_trace_size,
-        });
-    }
-
-    Ok(lifting_log_size)
+#[error("Minimum lifting log size is too small ({min_lifting_log_size}). It must be at least the log size of the preprocessed trace ({preprocessed_log_size}).")]
+pub struct InvalidMinLiftingLogSizeError {
+    pub min_lifting_log_size: u32,
+    pub preprocessed_log_size: u32,
 }

--- a/crates/stwo/src/core/pcs/verifier.rs
+++ b/crates/stwo/src/core/pcs/verifier.rs
@@ -51,8 +51,11 @@ impl<MC: MerkleChannel> CommitmentSchemeVerifier<MC> {
             .iter()
             .map(|&log_size| log_size + self.config.fri_config.log_blowup_factor)
             .collect();
-        let verifier =
-            MerkleVerifierLifted::new(commitment, extended_log_sizes, self.config.lifting_log_size);
+        let verifier = MerkleVerifierLifted::new(
+            commitment,
+            extended_log_sizes,
+            self.config.min_lifting_log_size,
+        );
         self.trees.push(verifier);
     }
 

--- a/crates/stwo/src/core/vcs_lifted/test_utils.rs
+++ b/crates/stwo/src/core/vcs_lifted/test_utils.rs
@@ -52,7 +52,7 @@ where
 
     let (values, decommitment) = merkle.decommit(&queries, cols.iter().collect_vec());
 
-    let verifier = MerkleVerifierLifted::new(merkle.root(), log_sizes, None);
+    let verifier = MerkleVerifierLifted::new(merkle.root(), log_sizes, 0);
     (queries, decommitment.decommitment, values, verifier)
 }
 

--- a/crates/stwo/src/core/vcs_lifted/verifier.rs
+++ b/crates/stwo/src/core/vcs_lifted/verifier.rs
@@ -59,13 +59,9 @@ pub struct MerkleVerifierLifted<H: MerkleHasherLifted> {
 }
 
 impl<H: MerkleHasherLifted> MerkleVerifierLifted<H> {
-    pub fn new(root: H::Hash, column_log_sizes: Vec<u32>, lifting_log_size: Option<u32>) -> Self {
+    pub fn new(root: H::Hash, column_log_sizes: Vec<u32>, min_lifting_log_size: u32) -> Self {
         let max_column_log_size = column_log_sizes.iter().copied().max().unwrap_or_default();
-        let height = lifting_log_size.unwrap_or(max_column_log_size);
-        assert!(
-            max_column_log_size <= height,
-            "The lifting log size is smaller than the largest column."
-        );
+        let height = min_lifting_log_size.max(max_column_log_size);
         Self {
             root,
             column_log_sizes,
@@ -315,7 +311,7 @@ mod tests {
         // Queries given out of order with a duplicate.
         let queries = vec![13, 3, 7, 3, 1];
         let (values, decommitment) = merkle.decommit(&queries, cols.iter().collect());
-        let verifier = MerkleVerifierLifted::new(merkle.root(), log_sizes, None);
+        let verifier = MerkleVerifierLifted::new(merkle.root(), log_sizes, 0);
         verifier
             .verify(&queries, values, decommitment.decommitment)
             .unwrap();

--- a/crates/stwo/src/core/verifier.rs
+++ b/crates/stwo/src/core/verifier.rs
@@ -6,7 +6,6 @@ use crate::core::channel::{Channel, MerkleChannel};
 use crate::core::circle::CirclePoint;
 use crate::core::fields::qm31::{SecureField, SECURE_EXTENSION_DEGREE};
 use crate::core::fri::FriVerificationError;
-use crate::core::pcs::utils::try_get_lifting_log_size;
 use crate::core::pcs::CommitmentSchemeVerifier;
 use crate::core::proof::StarkProof;
 use crate::core::vcs_lifted::verifier::MerkleVerificationError;
@@ -54,24 +53,25 @@ pub fn verify_ex<MC: MerkleChannel>(
         split_composition_log_degree_bound
     );
 
-    // If `self.config.lifting_log_size` is None, the lifting size is the length of the split
-    // composition polynomials' domain.
-    let lifting_log_size = try_get_lifting_log_size(
-        &commitment_scheme.config,
-        split_composition_log_degree_bound + commitment_scheme.config.fri_config.log_blowup_factor,
-    )?;
+    let min_lifting_log_size = commitment_scheme.config.min_lifting_log_size;
     if include_all_preprocessed_columns {
-        let preprocessed_trace_height = commitment_scheme.trees[PREPROCESSED_TRACE_IDX].height;
-        if lifting_log_size < preprocessed_trace_height {
-            Err(crate::core::pcs::utils::InvalidLiftingLogSizeError {
-                lifting_log_size,
-                min_log_size: preprocessed_trace_height,
+        let preprocessed_log_size = commitment_scheme.trees[PREPROCESSED_TRACE_IDX].height;
+        if min_lifting_log_size < preprocessed_log_size {
+            Err(crate::core::pcs::utils::InvalidMinLiftingLogSizeError {
+                min_lifting_log_size,
+                preprocessed_log_size,
             })?;
         }
     }
+    // The effective lifting size is at least the length of the split composition polynomials'
+    // domain (in particular, a `min_lifting_log_size` of 0 lifts each tree to its largest column).
+    let lifting_log_size = min_lifting_log_size.max(
+        split_composition_log_degree_bound + commitment_scheme.config.fri_config.log_blowup_factor,
+    );
 
-    // The max degree of a committed polynomial. If `lifting_log_size` is not set,
-    // the largest degree is attained by the splits of the composition polynomial.
+    // The max degree of a committed polynomial. If `min_lifting_log_size` is 0 and
+    // `include_all_preprocessed_columns` is false, the largest degree is attained by the splits
+    // of the composition polynomial.
     let max_log_degree_bound =
         lifting_log_size - commitment_scheme.config.fri_config.log_blowup_factor;
 
@@ -137,7 +137,7 @@ pub enum VerificationError {
     #[error("Proof of work verification failed.")]
     ProofOfWork,
     #[error(transparent)]
-    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
+    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidMinLiftingLogSizeError),
     #[error(transparent)]
     InvalidCanonicCosetLogSize(#[from] crate::core::poly::circle::InvalidCanonicCosetLogSize),
 }

--- a/crates/stwo/src/prover/mod.rs
+++ b/crates/stwo/src/prover/mod.rs
@@ -4,7 +4,7 @@ use tracing::{info, instrument, span, Level};
 use crate::core::channel::{Channel, MerkleChannel};
 use crate::core::circle::CirclePoint;
 use crate::core::fields::qm31::{SecureField, SECURE_EXTENSION_DEGREE};
-use crate::core::pcs::utils::{try_get_lifting_log_size, InvalidLiftingLogSizeError};
+use crate::core::pcs::utils::InvalidMinLiftingLogSizeError;
 use crate::core::proof::{ExtendedStarkProof, StarkProof};
 use crate::core::verifier::PREPROCESSED_TRACE_IDX;
 use crate::prover::backend::BackendForChannel;
@@ -91,10 +91,12 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
         .len() as u32
         - 1;
 
-    // If `self.config.lifting_log_size` is None, the lifting size is the length of the split
-    // composition polynomials' domain.
-    let lifting_log_size =
-        try_get_lifting_log_size(&commitment_scheme.config, split_composition_log_size)?;
+    // The effective lifting size is at least the length of the split composition polynomials'
+    // domain (in particular, a `min_lifting_log_size` of 0 lifts each tree to its largest column).
+    let lifting_log_size = commitment_scheme
+        .config
+        .min_lifting_log_size
+        .max(split_composition_log_size);
     if include_all_preprocessed_columns {
         // If all the preprocessed columns are included, the lifting log size must be greater than
         // or equal to the preprocessed log size.
@@ -104,9 +106,9 @@ pub fn prove_ex<B: BackendForChannel<MC>, MC: MerkleChannel>(
             .len() as u32
             - 1;
         if lifting_log_size < preprocessed_log_size {
-            Err(InvalidLiftingLogSizeError {
-                lifting_log_size,
-                min_log_size: preprocessed_log_size,
+            Err(InvalidMinLiftingLogSizeError {
+                min_lifting_log_size: lifting_log_size,
+                preprocessed_log_size,
             })?;
         }
     }
@@ -156,7 +158,7 @@ pub enum ProvingError {
     #[error("Constraints not satisfied.")]
     ConstraintsNotSatisfied,
     #[error(transparent)]
-    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidLiftingLogSizeError),
+    InvalidLiftingLogSize(#[from] crate::core::pcs::utils::InvalidMinLiftingLogSizeError),
     #[error(transparent)]
     InvalidCanonicCosetLogSize(#[from] crate::core::poly::circle::InvalidCanonicCosetLogSize),
 }

--- a/crates/stwo/src/prover/pcs/mod.rs
+++ b/crates/stwo/src/prover/pcs/mod.rs
@@ -81,7 +81,7 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
             self.config.fri_config.log_blowup_factor,
             self.twiddles,
             self.store_polynomials_coefficients,
-            self.config.lifting_log_size,
+            self.config.min_lifting_log_size,
             &self.base_column_pool,
         );
         MC::mix_root(channel, tree.commitment.root());
@@ -362,7 +362,7 @@ impl<B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentTreeProver<B, MC> {
         log_blowup_factor: u32,
         twiddles: &TwiddleTree<B>,
         store_polynomials_coefficients: bool,
-        lifting_log_size: Option<u32>,
+        min_lifting_log_size: u32,
         base_column_pool: &BaseColumnPool<B>,
     ) -> Self {
         let span = span!(Level::INFO, "Extension").entered();
@@ -381,7 +381,7 @@ impl<B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentTreeProver<B, MC> {
             .map(|poly| poly.evals.domain.log_size())
             .max()
             .unwrap_or_default();
-        let lifting_log_size = lifting_log_size.unwrap_or(max_log_domain_size);
+        let lifting_log_size = min_lifting_log_size.max(max_log_domain_size);
         let tree = MerkleProverLifted::commit(
             polynomials
                 .iter()


### PR DESCRIPTION
Each tree is now committed with height max(min_lifting_log_size, max
column log size), so 0 reproduces the old None behavior (lift each tree
to its largest column), and a value >= all tree sizes reproduces the
old Some(x). The Fiat-Shamir encoding is unchanged (None was already
mixed as 0).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>