### PR TITLE
perf: hoist per-column log-ratio computation out of blake2s_lifted hot loop

### DIFF
--- a/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
+++ b/crates/stwo/src/prover/backend/simd/blake2s_lifted.rs
@@ -98,6 +98,11 @@ impl MerkleOpsLifted<Blake2sMerkleHasher> for SimdBackend {
             let chunk_max_log_size: u32 = columns[end - 1].data.len().ilog2();
             let next_layer_state_slice = &mut next_layer_states[0..1 << chunk_max_log_size];
             let log_ratio = chunk_max_log_size - prev_chunk_max_log_size;
+            // Log-ratios of the first chunk `columns[start..start + 16]` w.r.t.
+            // `chunk_max_log_size`. Depends only on `j`, so it is computed once per chunk rather
+            // than once per lane inside the hot loop below.
+            let msg_log_ratios: [u32; N_FELTS_IN_BLAKE_MESSAGE] =
+                std::array::from_fn(|j| chunk_max_log_size - columns[start + j].data.len().ilog2());
             // Compute the new states of the current layer.
             #[cfg(not(feature = "parallel"))]
             let iter_states = next_layer_state_slice.iter_mut();
@@ -112,10 +117,12 @@ impl MerkleOpsLifted<Blake2sMerkleHasher> for SimdBackend {
                     to_lifted_simd(prev_state_limb, log_ratio, i)
                 });
                 let msgs: [u32x16; N_FELTS_IN_BLAKE_MESSAGE] = std::array::from_fn(|j| {
-                    let column = columns[start + j];
-                    let log_size = column.data.len().ilog2();
-                    let log_ratio = chunk_max_log_size - log_size;
-                    to_lifted_simd(column.data[i >> log_ratio].into_simd(), log_ratio, i)
+                    let log_ratio = msg_log_ratios[j];
+                    to_lifted_simd(
+                        columns[start + j].data[i >> log_ratio].into_simd(),
+                        log_ratio,
+                        i,
+                    )
                 });
 
                 *state = compress_unfinalized(prev_state, msgs, local_byte_count);
@@ -148,6 +155,13 @@ impl MerkleOpsLifted<Blake2sMerkleHasher> for SimdBackend {
         #[cfg(feature = "parallel")]
         let iter_states = next_layer_state_slice.par_iter_mut();
 
+        // Log-ratios of the tail columns w.r.t. `chunk_max_log_size`. Depends only on the column
+        // index, so it is computed once for the whole tail rather than once per lane below.
+        let tail_log_ratios: Vec<u32> = columns[last_chunk_index..]
+            .iter()
+            .map(|column| chunk_max_log_size - column.data.len().ilog2())
+            .collect();
+
         byte_count += ((columns.len() - last_chunk_index) * N_BYTES_FELT) as u64;
         iter_states.enumerate().for_each(|(i, state)| {
             let prev_state = std::array::from_fn(|j| {
@@ -156,8 +170,7 @@ impl MerkleOpsLifted<Blake2sMerkleHasher> for SimdBackend {
             });
             let mut msgs: [u32x16; N_FELTS_IN_BLAKE_MESSAGE] = unsafe { std::mem::zeroed() };
             for (j, column) in columns[last_chunk_index..].iter().enumerate() {
-                let log_size = column.data.len().ilog2();
-                let log_ratio = chunk_max_log_size - log_size;
+                let log_ratio = tail_log_ratios[j];
                 msgs[j] = to_lifted_simd(column.data[i >> log_ratio].into_simd(), log_ratio, i);
             }
             *state = compress_finalize(prev_state, msgs, byte_count);


### PR DESCRIPTION
## What

Follow-up performance pass after #1440 (which touched this file only to fix a `trasposed_states` → `transposed_states` typo/rename). While reviewing that diff for hot-path opportunities, found a genuine one in the same file.

## Where

`crates/stwo/src/prover/backend/simd/blake2s_lifted.rs`, `SimdBackend::build_leaves` (`MerkleOpsLifted<Blake2sMerkleHasher>`).

## Problem

`build_leaves` builds SIMD Blake2s Merkle-tree leaves for lifted commitments. Two of its per-lane closures — run via `par_iter_mut()`/`iter_mut()` over up to `2^chunk_max_log_size` lanes per Merkle layer (potentially millions of iterations per commit) — recomputed, on *every lane*, a value that only depends on the column index, not the lane index:

```rust
let log_size = column.data.len().ilog2();
let log_ratio = chunk_max_log_size - log_size;
```

This happened once per lane for each of up to 16 columns in the main per-chunk loop, and again for up to 16 tail columns in the last-chunk loop — i.e. `O(16 * 2^chunk_max_log_size)` redundant `ilog2()` + subtraction calls per layer, none of which change across lanes.

## Fix

Hoist the per-column `log_ratio` computation out of the hot per-lane closures into two small precomputed lookups, built once per chunk before the parallel loop starts:
- `msg_log_ratios: [u32; N_FELTS_IN_BLAKE_MESSAGE]` for the main per-chunk loop.
- `tail_log_ratios: Vec<u32>` for the last-chunk loop (variable-length tail).

The closures now index into these instead of recomputing. Output is unchanged — the precomputed values are byte-for-byte the same as what was computed inline before.

## Verification

- `cargo +nightly-2026-01-15 fmt -p stwo -- --check`
- `cargo +nightly-2026-01-15 clippy --release --features "prover,parallel" -p stwo -- -D warnings`
- `cargo +nightly-2026-01-15 test --release --features "prover,parallel" -p stwo` — 269 passed, 0 failed, including `blake2s_lifted::tests::*`, `vcs_lifted::prover::test::*`, and the CPU-vs-SIMD bit-for-bit equality tests (`test_blake_merkle_commit`, `test_merkle_commit_small_column`) that would catch any output divergence.
- Independently reviewed by an Opus-based agent for behavioral equivalence (exact same `chunk_max_log_size`/column-order/bounds, no off-by-one across the two shadowed `chunk_max_log_size` bindings) and rayon `Send`/`Sync` correctness; no blocking or suggestion-level findings.

## Impact

Removes redundant per-lane `ilog2()`/subtraction work from the Merkle-leaf-building hot path used on every lifted commitment (traces, FRI layers, etc.) in the SIMD prover backend. Micro-optimization; no change to proof output or verifier behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HaScCVJsSPksNTVgBRf7ic)_