### PR TITLE
chore: upgrade rand to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -992,7 +992,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1002,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1010,6 +1019,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "rawpointer"
@@ -1304,7 +1319,7 @@ dependencies = [
  "itertools 0.12.1",
  "keccak",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rayon",
  "serde",
  "sha3",
@@ -1346,7 +1361,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rayon",
  "stwo",
  "stwo-std-shims",
@@ -1362,7 +1377,7 @@ dependencies = [
  "itertools 0.12.1",
  "ndarray",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "rayon",
  "serde",
  "stwo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bytemuck = { version = "1.14.3", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false }
 rayon = { version = "1.10.0", optional = false }
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9", default-features = false, features = ["small_rng"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 hashbrown = { version = ">=0.15.2", features = ["serde"] }
 

--- a/crates/constraint-framework/src/expr/simplify.rs
+++ b/crates/constraint-framework/src/expr/simplify.rs
@@ -175,9 +175,10 @@ mod tests {
 
         let mut rng = SmallRng::seed_from_u64(0);
         let columns: HashMap<(usize, usize, isize), BaseField> =
-            HashMap::from([((1, 0, 0), rng.gen()), ((1, 1, 0), rng.gen())]);
-        let vars: HashMap<String, BaseField> = HashMap::from([("a".to_string(), rng.gen())]);
-        let ext_vars: HashMap<String, SecureField> = HashMap::from([("b".to_string(), rng.gen())]);
+            HashMap::from([((1, 0, 0), rng.random()), ((1, 1, 0), rng.random())]);
+        let vars: HashMap<String, BaseField> = HashMap::from([("a".to_string(), rng.random())]);
+        let ext_vars: HashMap<String, SecureField> =
+            HashMap::from([("b".to_string(), rng.random())]);
 
         let base_expr = (((zero.clone() + c0.clone()) + (a.clone() + zero.clone()))
             * ((-c1.clone()) + (-c0.clone()))

--- a/crates/examples/src/xor/gkr_lookups/mle_eval.rs
+++ b/crates/examples/src/xor/gkr_lookups/mle_eval.rs
@@ -793,9 +793,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         // Setup protocol.
         let twiddles = SimdBackend::precompute_twiddles(
@@ -869,9 +869,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         // Setup protocol.
         let twiddles = SimdBackend::precompute_twiddles(
@@ -958,9 +958,9 @@ mod tests {
         let mut rng = SmallRng::seed_from_u64(0);
         let log_size = N_VARIABLES as u32;
         let size = 1 << log_size;
-        let mle_coeffs = (0..size).map(|_| rng.gen::<SecureField>()).collect();
+        let mle_coeffs = (0..size).map(|_| rng.random::<SecureField>()).collect();
         let mle = Mle::<SimdBackend, SecureField>::new(mle_coeffs);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let claim = mle_eval_at_point(&mle, &eval_point);
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let mle_eval_trace = build_trace(&mle, &eval_point, claim);
@@ -1005,7 +1005,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1042,7 +1042,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1079,7 +1079,7 @@ mod tests {
         const AUX_TRACE: usize = 1;
         let mut rng = SmallRng::seed_from_u64(0);
         let mle = Mle::new(repeat_n(SecureField::one(), 1 << N_VARIABLES).collect());
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let trace = build_trace(&mle, &eval_point, mle_eval_at_point(&mle, &eval_point));
         let carry_quotients_col = gen_carry_quotient_col(&eval_point).into_coordinate_evals();
@@ -1113,7 +1113,7 @@ mod tests {
     fn inclusive_prefix_sum_constraints_with_log_size_5() {
         const LOG_SIZE: u32 = 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let vals = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let vals = (0..1 << LOG_SIZE).map(|_| rng.random()).collect_vec();
         let cumulative_sum = vals.iter().sum::<SecureField>();
         let cumulative_sum_shift = cumulative_sum / BaseField::from(vals.len());
         let trace = TreeVec::new(vec![gen_prefix_sum_trace(vals)]);
@@ -1150,7 +1150,7 @@ mod tests {
     fn eval_carry_quotient_col_works() {
         const N_VARIABLES: usize = 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.gen());
+        let eval_point: [SecureField; N_VARIABLES] = array::from_fn(|_| rng.random());
         let mle_eval_point = MleEvalPoint::new(&eval_point);
         let col_eval = gen_carry_quotient_col(&eval_point);
         let twiddles = SimdBackend::precompute_twiddles(col_eval.domain.half_coset);

--- a/crates/stwo/benches/barycentric_eval_at_point.rs
+++ b/crates/stwo/benches/barycentric_eval_at_point.rs
@@ -16,8 +16,8 @@ fn bench_barycentric_eval_at_secure_point<B: PolyOps>(c: &mut Criterion, id: &st
     let coset = CanonicCoset::new(LOG_SIZE);
     let evals = poly.evaluate(coset.circle_domain());
     let mut rng = SmallRng::seed_from_u64(0);
-    let x = rng.gen();
-    let y = rng.gen();
+    let x = rng.random();
+    let y = rng.random();
     let point = CirclePoint { x, y };
     let weights =
         CircleEvaluation::<B, BaseField, BitReversedOrder>::barycentric_weights(coset, point);
@@ -34,8 +34,8 @@ fn bench_barycentric_eval_at_secure_point_weights_calculation<B: PolyOps>(
     id: &str,
 ) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let x = rng.gen();
-    let y = rng.gen();
+    let x = rng.random();
+    let y = rng.random();
     let point = CirclePoint { x, y };
     let coset = CanonicCoset::new(LOG_SIZE);
     c.bench_function(

--- a/crates/stwo/benches/eval_at_point.rs
+++ b/crates/stwo/benches/eval_at_point.rs
@@ -12,8 +12,8 @@ const LOG_SIZE: u32 = 20;
 fn bench_eval_at_secure_point<B: PolyOps>(c: &mut Criterion, id: &str) {
     let poly = CircleCoefficients::new((0..1 << LOG_SIZE).map(BaseField::from).collect());
     let mut rng = SmallRng::seed_from_u64(0);
-    let x = rng.gen();
-    let y = rng.gen();
+    let x = rng.random();
+    let y = rng.random();
     let point = CirclePoint { x, y };
     c.bench_function(
         &format!("{id} eval_at_secure_field_point 2^{LOG_SIZE}"),

--- a/crates/stwo/benches/eval_at_point_by_folding.rs
+++ b/crates/stwo/benches/eval_at_point_by_folding.rs
@@ -16,8 +16,8 @@ fn bench_eval_at_secure_point_by_folding<B: PolyOps>(c: &mut Criterion, id: &str
         B::precompute_twiddles(CanonicCoset::new(LOG_SIZE + 1).circle_domain().half_coset);
     let evals = poly.evaluate(CanonicCoset::new(LOG_SIZE).circle_domain());
     let mut rng = SmallRng::seed_from_u64(0);
-    let x = rng.gen();
-    let y = rng.gen();
+    let x = rng.random();
+    let y = rng.random();
     let point = CirclePoint { x, y };
     c.bench_function(
         &format!("{id} eval_at_secure_field_point_by_folding 2^{LOG_SIZE}"),

--- a/crates/stwo/benches/field.rs
+++ b/crates/stwo/benches/field.rs
@@ -12,8 +12,8 @@ pub const N_STATE_ELEMENTS: usize = 8;
 
 pub fn m31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<M31> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [M31; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<M31> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [M31; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("M31 mul", |b| {
         b.iter(|| {
@@ -42,8 +42,8 @@ pub fn m31_operations_bench(c: &mut Criterion) {
 
 pub fn cm31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<CM31> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [CM31; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<CM31> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [CM31; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("CM31 mul", |b| {
         b.iter(|| {
@@ -72,8 +72,8 @@ pub fn cm31_operations_bench(c: &mut Criterion) {
 
 pub fn qm31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<SecureField> = (0..N_ELEMENTS).map(|_| rng.gen()).collect();
-    let mut state: [SecureField; N_STATE_ELEMENTS] = rng.gen();
+    let elements: Vec<SecureField> = (0..N_ELEMENTS).map(|_| rng.random()).collect();
+    let mut state: [SecureField; N_STATE_ELEMENTS] = rng.random();
 
     c.bench_function("SecureField mul", |b| {
         b.iter(|| {
@@ -102,7 +102,7 @@ pub fn qm31_operations_bench(c: &mut Criterion) {
 
 pub fn simd_m31_operations_bench(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(0);
-    let elements: Vec<PackedBaseField> = (0..N_ELEMENTS / N_LANES).map(|_| rng.gen()).collect();
+    let elements: Vec<PackedBaseField> = (0..N_ELEMENTS / N_LANES).map(|_| rng.random()).collect();
     let mut states = vec![PackedBaseField::broadcast(BaseField::one()); N_STATE_ELEMENTS];
 
     c.bench_function("mul_simd", |b| {

--- a/crates/stwo/benches/fri_quotients.rs
+++ b/crates/stwo/benches/fri_quotients.rs
@@ -35,7 +35,11 @@ fn setup(
 
     let polys: Vec<CircleCoefficients<SimdBackend>> = (0..n_cols)
         .map(|_| {
-            CircleCoefficients::new((0..1 << trace_log_size).map(|_| rng.gen::<M31>()).collect())
+            CircleCoefficients::new(
+                (0..1 << trace_log_size)
+                    .map(|_| rng.random::<M31>())
+                    .collect(),
+            )
         })
         .collect();
 
@@ -60,7 +64,7 @@ fn setup(
         .collect();
 
     let random_coeff =
-        SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.gen::<u32>())));
+        SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.random::<u32>())));
 
     let sample_batches = ColumnSampleBatch::new_vec(
         &build_samples_with_randomness_and_periodicity(
@@ -121,7 +125,7 @@ fn bench_compute_quotients_and_combine(c: &mut Criterion) {
                 columns: std::array::from_fn(|_| {
                     BaseColumn::from_cpu(
                         &(0..(1 << trace_log_size))
-                            .map(|_| rng.gen::<M31>())
+                            .map(|_| rng.random::<M31>())
                             .collect::<Vec<_>>(),
                     )
                 }),

--- a/crates/stwo/benches/lookups.rs
+++ b/crates/stwo/benches/lookups.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use stwo::core::channel::Blake2sChannel;
@@ -83,9 +83,9 @@ fn bench_gkr_logup_singles<B: GkrOps>(c: &mut Criterion, id: &str) {
 /// Generates a random multilinear polynomial.
 fn gen_random_mle<B: MleOps<F>, F: Field>(rng: &mut impl Rng, n_variables: u32) -> Mle<B, F>
 where
-    Standard: Distribution<F>,
+    StandardUniform: Distribution<F>,
 {
-    Mle::new((0..1 << n_variables).map(|_| rng.gen()).collect())
+    Mle::new((0..1 << n_variables).map(|_| rng.random()).collect())
 }
 
 fn gkr_lookup_benches(c: &mut Criterion) {

--- a/crates/stwo/benches/pcs.rs
+++ b/crates/stwo/benches/pcs.rs
@@ -46,7 +46,7 @@ fn bench_pcs<B: BackendForChannel<Blake2sMerkleChannel>>(c: &mut Criterion, id: 
     let evals: Vec<CircleEvaluation<B, BaseField, BitReversedOrder>> = iter::repeat_with(|| {
         CircleEvaluation::new(
             small_domain.circle_domain(),
-            (0..1 << LOG_COSET_SIZE).map(|_| rng.gen()).collect(),
+            (0..1 << LOG_COSET_SIZE).map(|_| rng.random()).collect(),
         )
     })
     .take(N_POLYS)

--- a/crates/stwo/src/core/air/accumulation.rs
+++ b/crates/stwo/src/core/air/accumulation.rs
@@ -53,13 +53,13 @@ mod tests {
         const MAX_LOG_SIZE: u32 = 10;
         const MASK: u32 = P;
         let log_sizes = (0..100)
-            .map(|_| rng.gen_range(4..MAX_LOG_SIZE))
+            .map(|_| rng.random_range(4..MAX_LOG_SIZE))
             .collect::<Vec<_>>();
 
         // Generate random evaluations.
         let evaluations = log_sizes
             .iter()
-            .map(|_| M31::from_u32_unchecked(rng.gen::<u32>() & MASK))
+            .map(|_| M31::from_u32_unchecked(rng.random::<u32>() & MASK))
             .collect::<Vec<_>>();
         let alpha = qm31!(2, 3, 4, 5);
 

--- a/crates/stwo/src/core/fields/m31.rs
+++ b/crates/stwo/src/core/fields/m31.rs
@@ -4,7 +4,7 @@ use core::ops::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use serde::{Deserialize, Serialize};
 
 use super::{ComplexConjugate, FieldExpOps};
@@ -166,10 +166,10 @@ impl From<i32> for M31 {
     }
 }
 
-impl Distribution<M31> for Standard {
+impl Distribution<M31> for StandardUniform {
     // Not intended for cryptographic use. Should only be used in tests and benchmarks.
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> M31 {
-        M31(rng.gen_range(0..P))
+        M31(rng.random_range(0..P))
     }
 }
 
@@ -239,8 +239,8 @@ mod tests {
     fn test_basic_ops() {
         let mut rng = SmallRng::seed_from_u64(0);
         for _ in 0..10000 {
-            let x: u32 = rng.gen::<u32>() % P;
-            let y: u32 = rng.gen::<u32>() % P;
+            let x: u32 = rng.random::<u32>() % P;
+            let y: u32 = rng.random::<u32>() % P;
             assert_eq!(m31!(add_p(x, y)), m31!(x) + m31!(y));
             assert_eq!(m31!(mul_p(x, y)), m31!(x) * m31!(y));
             assert_eq!(m31!(neg_p(x)), -m31!(x));

--- a/crates/stwo/src/core/fields/mod.rs
+++ b/crates/stwo/src/core/fields/mod.rs
@@ -290,7 +290,7 @@ macro_rules! impl_field {
 #[macro_export]
 macro_rules! impl_extension_field {
     ($field_name: ident, $extended_field_name: ty) => {
-        use rand::distributions::{Distribution, Standard};
+        use rand::distr::{Distribution, StandardUniform};
         use $crate::core::fields::ExtensionOf;
 
         impl ExtensionOf<M31> for $field_name {
@@ -462,10 +462,10 @@ macro_rules! impl_extension_field {
             }
         }
 
-        impl Distribution<$field_name> for Standard {
+        impl Distribution<$field_name> for StandardUniform {
             // Not intended for cryptographic use. Should only be used in tests and benchmarks.
             fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> $field_name {
-                $field_name(rng.gen(), rng.gen())
+                $field_name(rng.random(), rng.random())
             }
         }
     };
@@ -486,7 +486,7 @@ mod tests {
     #[test]
     fn test_batch_inverse() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let expected = elements.iter().map(|e| e.inverse()).collect::<Vec<_>>();
 
         let actual = batch_inverse(&elements);
@@ -498,7 +498,7 @@ mod tests {
     #[should_panic]
     fn test_slice_batch_inverse_wrong_dst_size() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let mut dst = [M31::zero(); 15];
 
         batch_inverse_in_place(&elements, &mut dst);
@@ -507,7 +507,7 @@ mod tests {
     #[test]
     fn test_batch_inverse_chunked() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let elements: [M31; 16] = rng.gen();
+        let elements: [M31; 16] = rng.random();
         let chunk_size = 4;
         let expected = batch_inverse(&elements);
 

--- a/crates/stwo/src/core/vcs/poseidon252_merkle.rs
+++ b/crates/stwo/src/core/vcs/poseidon252_merkle.rs
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn test_construct_word() {
         let mut rng = SmallRng::seed_from_u64(1638);
-        let random_values = (0..8 * 1000 + 5).map(|_| rng.gen::<M31>()).collect_vec();
+        let random_values = (0..8 * 1000 + 5).map(|_| rng.random::<M31>()).collect_vec();
 
         let expected = random_values
             .chunks(ELEMENTS_IN_BLOCK)

--- a/crates/stwo/src/core/vcs/test_utils.rs
+++ b/crates/stwo/src/core/vcs/test_utils.rs
@@ -28,13 +28,13 @@ where
 
     let mut rng = SmallRng::seed_from_u64(0);
     let log_sizes = (0..N_COLS)
-        .map(|_| rng.gen_range(log_size_range.clone()))
+        .map(|_| rng.random_range(log_size_range.clone()))
         .collect_vec();
     let cols = log_sizes
         .iter()
         .map(|&log_size| {
             (0..(1 << log_size))
-                .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
+                .map(|_| BaseField::from(rng.random_range(0..(1 << 30))))
                 .collect_vec()
         })
         .collect_vec();
@@ -43,7 +43,7 @@ where
     let mut queries = BTreeMap::<u32, Vec<usize>>::new();
     for log_size in log_size_range.rev() {
         let layer_queries = (0..N_QUERIES)
-            .map(|_| rng.gen_range(0..(1 << log_size)))
+            .map(|_| rng.random_range(0..(1 << log_size)))
             .sorted()
             .dedup()
             .collect_vec();

--- a/crates/stwo/src/core/vcs_lifted/test_utils.rs
+++ b/crates/stwo/src/core/vcs_lifted/test_utils.rs
@@ -30,13 +30,13 @@ where
 
     let mut rng = SmallRng::seed_from_u64(0);
     let log_sizes = (0..N_COLS)
-        .map(|_| rng.gen_range(log_size_range.clone()))
+        .map(|_| rng.random_range(log_size_range.clone()))
         .collect_vec();
     let cols = log_sizes
         .iter()
         .map(|&log_size| {
             (0..(1 << log_size))
-                .map(|_| BaseField::from(rng.gen_range(0..(1 << 30))))
+                .map(|_| BaseField::from(rng.random_range(0..(1 << 30))))
                 .collect_vec()
         })
         .collect_vec();
@@ -45,7 +45,7 @@ where
         MerkleProverLifted::<CpuBackend, H>::commit(cols.iter().collect_vec(), max_log_size, 0);
 
     let queries = (0..N_QUERIES)
-        .map(|_| rng.gen_range(0..(1 << max_log_size)))
+        .map(|_| rng.random_range(0..(1 << max_log_size)))
         .sorted()
         .dedup()
         .collect_vec();

--- a/crates/stwo/src/core/vcs_lifted/verifier.rs
+++ b/crates/stwo/src/core/vcs_lifted/verifier.rs
@@ -296,7 +296,7 @@ mod tests {
             .iter()
             .map(|&log_size| {
                 (0..(1 << log_size))
-                    .map(|_| BaseField::from(rng.gen_range(1..(1u32 << 30))))
+                    .map(|_| BaseField::from(rng.random_range(1..(1u32 << 30))))
                     .collect()
             })
             .collect();

--- a/crates/stwo/src/prover/air/accumulation.rs
+++ b/crates/stwo/src/prover/air/accumulation.rs
@@ -249,7 +249,7 @@ mod tests {
         const LOG_SIZE_MIN: u32 = 4;
         const LOG_SIZE_BOUND: u32 = 10;
         let mut log_sizes = (0..100)
-            .map(|_| rng.gen_range(LOG_SIZE_MIN..LOG_SIZE_BOUND))
+            .map(|_| rng.random_range(LOG_SIZE_MIN..LOG_SIZE_BOUND))
             .collect::<Vec<_>>();
         log_sizes.sort();
 
@@ -258,7 +258,7 @@ mod tests {
             .iter()
             .map(|log_size| {
                 (0..(1 << *log_size))
-                    .map(|_| M31::from(rng.gen::<u32>()))
+                    .map(|_| M31::from(rng.random::<u32>()))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();

--- a/crates/stwo/src/prover/backend/cpu/accumulation.rs
+++ b/crates/stwo/src/prover/backend/cpu/accumulation.rs
@@ -99,7 +99,7 @@ mod tests {
             .map(|i| {
                 CpuCirclePoly::new(
                     (0..1 << (LOG_SIZE_MIN as usize + (i / SECURE_EXTENSION_DEGREE)))
-                        .map(|_| M31::from(rng.gen::<u32>()))
+                        .map(|_| M31::from(rng.random::<u32>()))
                         .collect(),
                 )
             })

--- a/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/cpu/lookups/gkr.rs
@@ -348,8 +348,8 @@ mod tests {
     fn logup_with_generic_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerator_values, &denominator_values)
             .map(|(&n, &d)| Fraction::new(n, d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -387,7 +387,7 @@ mod tests {
     fn logup_with_singles_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = denominator_values
             .iter()
             .map(|&d| Fraction::new(SecureField::one(), d))
@@ -421,8 +421,8 @@ mod tests {
     fn logup_with_multiplicities_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 5;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerator_values = (0..N).map(|_| rng.gen()).collect::<Vec<BaseField>>();
-        let denominator_values = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerator_values = (0..N).map(|_| rng.random()).collect::<Vec<BaseField>>();
+        let denominator_values = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerator_values, &denominator_values)
             .map(|(&n, &d)| Fraction::new(n.into(), d))
             .sum::<Fraction<SecureField, SecureField>>();

--- a/crates/stwo/src/prover/backend/cpu/mod.rs
+++ b/crates/stwo/src/prover/backend/cpu/mod.rs
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn batch_inverse_in_place_test() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let column = rng.gen::<[QM31; 16]>().to_vec();
+        let column = rng.random::<[QM31; 16]>().to_vec();
         let expected = column.iter().map(|e| e.inverse()).collect_vec();
         let mut dst = Vec::zeros(column.len());
 

--- a/crates/stwo/src/prover/backend/simd/accumulation.rs
+++ b/crates/stwo/src/prover/backend/simd/accumulation.rs
@@ -113,10 +113,10 @@ mod tests {
         const LOG_SIZE_LONG: u32 = 8;
         let mut rng = SmallRng::seed_from_u64(0);
         let col_short = (0..1 << LOG_SIZE_SHORT)
-            .map(|_| M31::from(rng.gen::<u32>()))
+            .map(|_| M31::from(rng.random::<u32>()))
             .collect_vec();
         let col_long = (0..1 << LOG_SIZE_LONG)
-            .map(|_| M31::from(rng.gen::<u32>()))
+            .map(|_| M31::from(rng.random::<u32>()))
             .collect_vec();
 
         // Prepare CPU inputs.

--- a/crates/stwo/src/prover/backend/simd/blake2s.rs
+++ b/crates/stwo/src/prover/backend/simd/blake2s.rs
@@ -478,7 +478,7 @@ mod tests {
     #[test]
     fn hash_16_works() {
         let mut rng = SmallRng::seed_from_u64(1055);
-        let msgs: [[u32; 16]; 16] = array::from_fn(|_| rng.gen::<[u32; 16]>());
+        let msgs: [[u32; 16]; 16] = array::from_fn(|_| rng.random::<[u32; 16]>());
         let expected: [[u8; 32]; 16] = array::from_fn(|i| {
             let state = msgs[i];
             let mut hasher = Blake2sHasher::new();

--- a/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/crates/stwo/src/prover/backend/simd/circle.rs
@@ -753,8 +753,8 @@ mod tests {
                 (0..1 << log_size).map(BaseField::from).collect(),
             );
             let poly = evaluation.bit_reverse().interpolate();
-            let x = rng.gen();
-            let y = rng.gen();
+            let x = rng.random();
+            let y = rng.random();
             let p = CirclePoint { x, y };
 
             let eval = PolyOps::eval_at_point(&poly, p);

--- a/crates/stwo/src/prover/backend/simd/cm31.rs
+++ b/crates/stwo/src/prover/backend/simd/cm31.rs
@@ -192,8 +192,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -205,8 +205,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -218,8 +218,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedCM31::from_array(lhs);
         let packed_rhs = PackedCM31::from_array(rhs);
 
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedCM31::from_array(values);
 
         let res = -packed_values;

--- a/crates/stwo/src/prover/backend/simd/column.rs
+++ b/crates/stwo/src/prover/backend/simd/column.rs
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     fn secure_field_vec_from_iter_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [SecureField; 30] = rng.gen();
+        let values: [SecureField; 30] = rng.random();
 
         let res = values.into_iter().collect::<SecureColumn>();
 
@@ -885,8 +885,8 @@ mod tests {
         };
 
         let mut rng = SmallRng::seed_from_u64(0);
-        let rand0 = PackedQM31::from_array(rng.gen());
-        let rand1 = PackedQM31::from_array(rng.gen());
+        let rand0 = PackedQM31::from_array(rng.random());
+        let rand1 = PackedQM31::from_array(rng.random());
 
         const CHUNK_SIZE: usize = 4;
         let mut chunks: Vec<_> = col.chunks_mut(CHUNK_SIZE).collect();

--- a/crates/stwo/src/prover/backend/simd/conversion.rs
+++ b/crates/stwo/src/prover/backend/simd/conversion.rs
@@ -98,13 +98,13 @@ mod tests {
         type MyType = (M31, [M31; 3], [M31; 15]);
         let mut rand_input = || -> MyType {
             (
-                M31::from(rng.gen::<u32>()),
+                M31::from(rng.random::<u32>()),
                 [
-                    M31::from(rng.gen::<u32>()),
-                    M31::from(rng.gen::<u32>()),
-                    M31::from(rng.gen::<u32>()),
+                    M31::from(rng.random::<u32>()),
+                    M31::from(rng.random::<u32>()),
+                    M31::from(rng.random::<u32>()),
                 ],
-                std::array::from_fn(|_| M31::from(rng.gen::<u32>())),
+                std::array::from_fn(|_| M31::from(rng.random::<u32>())),
             )
         };
         let inputs: [_; N_LANES] = std::array::from_fn(|_| rand_input());

--- a/crates/stwo/src/prover/backend/simd/fft/ifft.rs
+++ b/crates/stwo/src/prover/backend/simd/fft/ifft.rs
@@ -563,9 +563,9 @@ mod tests {
     #[test]
     fn test_ibutterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let mut v0: [BaseField; N_LANES] = rng.gen();
-        let mut v1: [BaseField; N_LANES] = rng.gen();
-        let twiddle: [BaseField; N_LANES] = rng.gen();
+        let mut v0: [BaseField; N_LANES] = rng.random();
+        let mut v1: [BaseField; N_LANES] = rng.random();
+        let twiddle: [BaseField; N_LANES] = rng.random();
         let twiddle_dbl = twiddle.map(|v| v.0 * 2);
 
         let (r0, r1) = simd_ibutterfly(v0.into(), v1.into(), twiddle_dbl.into());
@@ -581,10 +581,12 @@ mod tests {
     #[test]
     fn test_ifft3() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
-        let twiddles0: [BaseField; 4] = rng.gen();
-        let twiddles1: [BaseField; 2] = rng.gen();
-        let twiddles2: [BaseField; 1] = rng.gen();
+        let values = rng
+            .random::<[BaseField; 8]>()
+            .map(PackedBaseField::broadcast);
+        let twiddles0: [BaseField; 4] = rng.random();
+        let twiddles1: [BaseField; 2] = rng.random();
+        let twiddles2: [BaseField; 1] = rng.random();
         let twiddles0_dbl = twiddles0.map(|v| v.0 * 2);
         let twiddles1_dbl = twiddles1.map(|v| v.0 * 2);
         let twiddles2_dbl = twiddles2.map(|v| v.0 * 2);
@@ -644,7 +646,7 @@ mod tests {
         let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
         assert_eq!(twiddle_dbls.len(), 4);
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [[BaseField; 16]; 2] = rng.gen();
+        let values: [[BaseField; 16]; 2] = rng.random();
 
         let res = {
             let (val0, val1) = vecwise_ibutterflies(
@@ -666,7 +668,7 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -688,7 +690,7 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_itwiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();

--- a/crates/stwo/src/prover/backend/simd/fft/rfft.rs
+++ b/crates/stwo/src/prover/backend/simd/fft/rfft.rs
@@ -587,9 +587,9 @@ mod tests {
     #[test]
     fn test_butterfly() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let mut v0: [BaseField; N_LANES] = rng.gen();
-        let mut v1: [BaseField; N_LANES] = rng.gen();
-        let twiddle: [BaseField; N_LANES] = rng.gen();
+        let mut v0: [BaseField; N_LANES] = rng.random();
+        let mut v1: [BaseField; N_LANES] = rng.random();
+        let twiddle: [BaseField; N_LANES] = rng.random();
         let twiddle_dbl = twiddle.map(|v| v.0 * 2);
 
         let (r0, r1) = simd_butterfly(v0.into(), v1.into(), twiddle_dbl.into());
@@ -605,10 +605,12 @@ mod tests {
     #[test]
     fn test_fft3() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen::<[BaseField; 8]>().map(PackedBaseField::broadcast);
-        let twiddles0: [BaseField; 4] = rng.gen();
-        let twiddles1: [BaseField; 2] = rng.gen();
-        let twiddles2: [BaseField; 1] = rng.gen();
+        let values = rng
+            .random::<[BaseField; 8]>()
+            .map(PackedBaseField::broadcast);
+        let twiddles0: [BaseField; 4] = rng.random();
+        let twiddles1: [BaseField; 2] = rng.random();
+        let twiddles2: [BaseField; 1] = rng.random();
         let twiddles0_dbl = twiddles0.map(|v| v.0 * 2);
         let twiddles1_dbl = twiddles1.map(|v| v.0 * 2);
         let twiddles2_dbl = twiddles2.map(|v| v.0 * 2);
@@ -669,7 +671,7 @@ mod tests {
         let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
         assert_eq!(twiddle_dbls.len(), 4);
         let mut rng = SmallRng::seed_from_u64(0);
-        let values: [[BaseField; 16]; 2] = rng.gen();
+        let values: [[BaseField; 16]; 2] = rng.random();
 
         let res = {
             let (val0, val1) = simd_butterfly(
@@ -695,7 +697,7 @@ mod tests {
         for log_size in 5..12 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();
@@ -718,7 +720,7 @@ mod tests {
         for log_size in CACHED_FFT_LOG_SIZE + 1..CACHED_FFT_LOG_SIZE + 3 {
             let domain = CanonicCoset::new(log_size).circle_domain();
             let mut rng = SmallRng::seed_from_u64(0);
-            let values = (0..domain.size()).map(|_| rng.gen()).collect_vec();
+            let values = (0..domain.size()).map(|_| rng.random()).collect_vec();
             let twiddle_dbls = get_twiddle_dbls(domain.half_coset);
 
             let mut res = values.iter().copied().collect::<BaseColumn>();

--- a/crates/stwo/src/prover/backend/simd/fri.rs
+++ b/crates/stwo/src/prover/backend/simd/fri.rs
@@ -321,7 +321,7 @@ mod tests {
     fn test_fold_line() {
         const LOG_SIZE: u32 = 7;
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = (0..1 << LOG_SIZE).map(|_| rng.gen()).collect_vec();
+        let values = (0..1 << LOG_SIZE).map(|_| rng.random()).collect_vec();
         let alpha = qm31!(1, 3, 5, 7);
         let domain = LineDomain::new(CanonicCoset::new(LOG_SIZE + 1).half_coset());
         let cpu_fold = CpuBackend::fold_line(

--- a/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
+++ b/crates/stwo/src/prover/backend/simd/lookups/gkr.rs
@@ -583,8 +583,8 @@ mod tests {
     fn logup_with_generic_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerators, &denominators)
             .map(|(&n, &d)| Fraction::new(n, d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -622,8 +622,8 @@ mod tests {
     fn logup_with_multiplicities_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let numerators = (0..N).map(|_| rng.gen()).collect::<Vec<BaseField>>();
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let numerators = (0..N).map(|_| rng.random()).collect::<Vec<BaseField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = zip(&numerators, &denominators)
             .map(|(&n, &d)| Fraction::new(n.into(), d))
             .sum::<Fraction<SecureField, SecureField>>();
@@ -661,7 +661,7 @@ mod tests {
     fn logup_with_singles_trace_works() -> Result<(), GkrError> {
         const N: usize = 1 << 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let denominators = (0..N).map(|_| rng.gen()).collect::<Vec<SecureField>>();
+        let denominators = (0..N).map(|_| rng.random()).collect::<Vec<SecureField>>();
         let sum = denominators
             .iter()
             .map(|&d| Fraction::new(SecureField::one(), d))

--- a/crates/stwo/src/prover/backend/simd/m31.rs
+++ b/crates/stwo/src/prover/backend/simd/m31.rs
@@ -6,7 +6,7 @@ use std::simd::{u32x16, Simd};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 
 use super::qm31::PackedQM31;
 use super::PACKED_M31_BATCH_INVERSE_CHUNK_SIZE;
@@ -321,9 +321,9 @@ impl From<BaseField> for PackedM31 {
     }
 }
 
-impl Distribution<PackedM31> for Standard {
+impl Distribution<PackedM31> for StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedM31 {
-        PackedM31::from_array(rng.gen())
+        PackedM31::from_array(rng.random())
     }
 }
 
@@ -650,8 +650,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -663,8 +663,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -676,8 +676,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedM31::from_array(lhs);
         let packed_rhs = PackedM31::from_array(rhs);
 
@@ -689,7 +689,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedM31::from_array(values);
 
         let res = -packed_values;
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn inverse_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedM31::from_array(values);
 
         let res = packed_values.inverse();
@@ -730,7 +730,7 @@ mod tests {
     #[test]
     fn test_reduction() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let vals = std::array::from_fn(|_| rng.gen::<u32>());
+        let vals = std::array::from_fn(|_| rng.random::<u32>());
         let simd_val = u32x16::from_array(vals);
 
         assert_eq!(

--- a/crates/stwo/src/prover/backend/simd/prefix_sum.rs
+++ b/crates/stwo/src/prover/backend/simd/prefix_sum.rs
@@ -166,7 +166,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_3_works() {
         const LOG_N: u32 = 3;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);
@@ -178,7 +178,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_6_works() {
         const LOG_N: u32 = 6;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);
@@ -190,7 +190,7 @@ mod tests {
     fn exclusive_prefix_sum_simd_with_log_size_8_works() {
         const LOG_N: u32 = 8;
         let mut rng = SmallRng::seed_from_u64(0);
-        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.gen()).collect();
+        let evals: BaseColumn = (0..1 << LOG_N).map(|_| rng.random()).collect();
         let expected = inclusive_prefix_sum_slow(evals.clone());
 
         let res = inclusive_prefix_sum(evals);

--- a/crates/stwo/src/prover/backend/simd/qm31.rs
+++ b/crates/stwo/src/prover/backend/simd/qm31.rs
@@ -4,7 +4,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use bytemuck::{Pod, Zeroable};
 use num_traits::{One, Zero};
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 
 use super::cm31::PackedCM31;
 use super::m31::{PackedM31, N_LANES};
@@ -308,9 +308,9 @@ impl Neg for PackedQM31 {
     }
 }
 
-impl Distribution<PackedQM31> for Standard {
+impl Distribution<PackedQM31> for StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> PackedQM31 {
-        PackedQM31::from_array(rng.gen())
+        PackedQM31::from_array(rng.random())
     }
 }
 
@@ -343,8 +343,8 @@ mod tests {
     #[test]
     fn addition_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -356,8 +356,8 @@ mod tests {
     #[test]
     fn subtraction_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -369,8 +369,8 @@ mod tests {
     #[test]
     fn multiplication_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let lhs = rng.gen();
-        let rhs = rng.gen();
+        let lhs = rng.random();
+        let rhs = rng.random();
         let packed_lhs = PackedQM31::from_array(lhs);
         let packed_rhs = PackedQM31::from_array(rhs);
 
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn negation_works() {
         let mut rng = SmallRng::seed_from_u64(0);
-        let values = rng.gen();
+        let values = rng.random();
         let packed_values = PackedQM31::from_array(values);
 
         let res = -packed_values;

--- a/crates/stwo/src/prover/backend/simd/quotients.rs
+++ b/crates/stwo/src/prover/backend/simd/quotients.rs
@@ -316,10 +316,10 @@ mod tests {
         let columns =
             CircleEvaluation::<SimdBackend, BaseField, BitReversedOrder>::new(domain, values);
 
-        let mask_structure = (0..N_COLS).map(|_| rng.gen_range(1..=2)).collect_vec();
+        let mask_structure = (0..N_COLS).map(|_| rng.random_range(1..=2)).collect_vec();
         let points = [
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
         ];
         let samples = (0..N_COLS)
             .zip(mask_structure.iter())
@@ -327,8 +327,8 @@ mod tests {
                 points
                     .into_iter()
                     .zip_eq([
-                        SecureField::from(rng.gen::<u32>()),
-                        SecureField::from(rng.gen::<u32>()),
+                        SecureField::from(rng.random::<u32>()),
+                        SecureField::from(rng.random::<u32>()),
                     ])
                     .take(*i)
                     .map(|(point, value)| PointSample { point, value })

--- a/crates/stwo/src/prover/channel/logging_channel.rs
+++ b/crates/stwo/src/prover/channel/logging_channel.rs
@@ -134,14 +134,14 @@ mod tests {
         let mut regular_channel = Blake2sChannel::default();
 
         let felts = [
-            rng.gen::<SecureField>(),
-            rng.gen::<SecureField>(),
-            rng.gen::<SecureField>(),
+            rng.random::<SecureField>(),
+            rng.random::<SecureField>(),
+            rng.random::<SecureField>(),
         ];
         logging_channel.mix_felts(&felts);
         regular_channel.mix_felts(&felts);
 
-        let value = rng.gen::<u64>();
+        let value = rng.random::<u64>();
         logging_channel.mix_u64(value);
         regular_channel.mix_u64(value);
 
@@ -149,7 +149,7 @@ mod tests {
         let felt2 = regular_channel.draw_secure_felt();
         assert_eq!(felt1, felt2);
 
-        let n_felts = rng.gen_range(1..10);
+        let n_felts = rng.random_range(1..10);
         let felts1 = logging_channel.draw_secure_felts(n_felts);
         let felts2 = regular_channel.draw_secure_felts(n_felts);
         assert_eq!(felts1, felts2);

--- a/crates/stwo/src/prover/pcs/quotient_ops.rs
+++ b/crates/stwo/src/prover/pcs/quotient_ops.rs
@@ -202,8 +202,8 @@ mod tests {
         let eval = polynomial.evaluate(eval_domain);
 
         let sample_points = [
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
         ];
         let samples = sample_points
             .into_iter()
@@ -213,7 +213,7 @@ mod tests {
             })
             .collect_vec();
         let rand_coeff =
-            SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.gen::<u32>())));
+            SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.random::<u32>())));
         let quot_eval = compute_fri_quotients(
             &TreeVec(vec![vec![&eval]]),
             &TreeVec(vec![vec![samples]]),
@@ -241,7 +241,7 @@ mod tests {
         let mut polys: Vec<CircleCoefficients<B>> = (0..N_COLS - 1)
             .map(|_| {
                 CircleCoefficients::new(
-                    (0..1 << rng.gen_range(4..LIFTING_LOG_SIZE - 1))
+                    (0..1 << rng.random_range(4..LIFTING_LOG_SIZE - 1))
                         .map(M31::from)
                         .collect(),
                 )
@@ -279,10 +279,10 @@ mod tests {
         tree_builder.commit(&mut channel);
 
         let mut rng = SmallRng::seed_from_u64(0);
-        let mask_structure = (0..N_COLS).map(|_| rng.gen_range(1..=2)).collect_vec();
+        let mask_structure = (0..N_COLS).map(|_| rng.random_range(1..=2)).collect_vec();
         let samples = [
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
         ];
         let sampled_points = vec![(0..N_COLS)
             .zip(mask_structure.iter())
@@ -325,8 +325,8 @@ mod tests {
         let simd_eval = CircleEvaluation::new(eval_domain, BaseColumn::from_cpu(&cpu_eval.values));
 
         let sample_points = [
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
-            SECURE_FIELD_CIRCLE_GEN.mul(rng.gen::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
+            SECURE_FIELD_CIRCLE_GEN.mul(rng.random::<u128>()),
         ];
         let samples = sample_points
             .into_iter()
@@ -336,7 +336,7 @@ mod tests {
             })
             .collect_vec();
         let rand_coeff =
-            SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.gen::<u32>())));
+            SecureField::from_m31_array(std::array::from_fn(|_| M31::from(rng.random::<u32>())));
         let twiddles = SimdBackend::precompute_twiddles(eval_domain.half_coset);
         let quot_eval = compute_fri_quotients(
             &TreeVec(vec![vec![&simd_eval]]),

--- a/ensure-verifier-no_std/Cargo.lock
+++ b/ensure-verifier-no_std/Cargo.lock
@@ -69,7 +69,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -599,7 +599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -609,7 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -617,6 +626,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
 name = "redox_syscall"
@@ -781,7 +796,7 @@ dependencies = [
  "indexmap",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "serde",
  "sha3",
  "starknet-crypto",
@@ -799,7 +814,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "itertools 0.12.1",
  "num-traits",
- "rand",
+ "rand 0.9.5",
  "stwo",
  "stwo-std-shims",
  "tracing",


### PR DESCRIPTION
## What

Upgrades `rand` from **0.8.5 → 0.9** and migrates the renamed API surface:

| 0.8 | 0.9 |
| --- | --- |
| `Rng::gen()` | `Rng::random()` |
| `Rng::gen_range()` | `Rng::random_range()` |
| `rand::distributions` | `rand::distr` |
| `Standard` | `StandardUniform` |

## Why

Two reasons:
1. Keeps us on a maintained `rand` release.
2. First of a few small prep PRs toward the **Rust edition 2024** migration — in 2024 `gen` becomes a reserved keyword, so `rng.gen()` would otherwise need `rng.r#gen()`. Moving to `random()` avoids the clunky raw-identifier escaping entirely.

## Notes

- No behavioral change. The full `cargo test` suite — including tests that assert exact values from seeded `SmallRng` streams — passes unchanged.
- `rand` 0.8.5 still appears in `Cargo.lock` as a transitive dependency of `starknet-crypto` (via `ark-std`); that is outside our control. Our direct dependency is now 0.9.
- Verified: `cargo build --all-targets`, `cargo test`, workspace `clippy` (`-D warnings …`), and `fmt --check` all clean on `nightly-2026-01-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)