### PR TITLE
refactor: drop redundant `ref` bindings in reference patterns

### DIFF
--- a/crates/air-utils-derive/src/iterable_field.rs
+++ b/crates/air-utils-derive/src/iterable_field.rs
@@ -31,7 +31,7 @@ impl IterableField {
             // Case that type is [Vec<T>; N].
             Type::Array(ref outer_array) => {
                 let inner_type = match outer_array.elem.as_ref() {
-                    Type::Path(ref type_path) => parse_inner_type(type_path)?,
+                    Type::Path(type_path) => parse_inner_type(type_path)?,
                     _ => Err(syn::Error::new_spanned(
                         outer_array.elem.clone(),
                         "Expected Vec<T> type",

--- a/crates/stwo/src/core/utils.rs
+++ b/crates/stwo/src/core/utils.rs
@@ -19,7 +19,7 @@ impl<T> Deref for MaybeOwned<'_, T> {
     fn deref(&self) -> &T {
         match self {
             MaybeOwned::Borrowed(r) => r,
-            MaybeOwned::Owned(ref v) => v,
+            MaybeOwned::Owned(v) => v,
         }
     }
 }


### PR DESCRIPTION
Two match arms use an explicit `ref` binding while the scrutinee is
already a reference, so match ergonomics binds by-reference regardless:

- `air-utils-derive` `iterable_field`: inner scrutinee
  `outer_array.elem.as_ref()` is `&Type`.
- `stwo` `MaybeOwned::deref`: `self` is `&MaybeOwned`.

The explicit `ref` is redundant today and becomes a hard error under the
Rust 2024 match-ergonomics rules ("cannot explicitly borrow within an
implicitly-borrowing pattern"). Confirmed via `-W rust_2024_incompatible_pat`
that these are the only two edition-2024-incompatible patterns in the
workspace.

No behavioral change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>