### PR TITLE
chore: allow unsafe_op_in_unsafe_fn in prover crates

### DIFF
--- a/crates/air-utils/src/lib.rs
+++ b/crates/air-utils/src/lib.rs
@@ -1,4 +1,8 @@
 #![feature(exact_size_is_empty, raw_slice_split, portable_simd)]
+// `unsafe fn` bodies here (e.g. `ComponentTrace::uninitialized`) are unsafe by
+// design; opt back into pre-2024 behavior instead of wrapping each op in an
+// `unsafe {}` block.
+#![allow(unsafe_op_in_unsafe_fn)]
 pub mod lookup_data;
 pub mod trace;
 

--- a/crates/constraint-framework/src/lib.rs
+++ b/crates/constraint-framework/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(feature = "prover", feature(portable_simd))]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Some `unsafe fn` bodies here are unsafe by design; opt back into pre-2024
+// behavior instead of wrapping each op in an `unsafe {}` block.
+#![allow(unsafe_op_in_unsafe_fn)]
 
 /// ! This module contains helpers to express and use constraints for components.
 mod component;

--- a/crates/stwo/src/lib.rs
+++ b/crates/stwo/src/lib.rs
@@ -1,4 +1,8 @@
 #![allow(incomplete_features)]
+// The SIMD/FFT kernels rely on entire `unsafe fn` bodies being unsafe by design.
+// Rust 2024 makes `unsafe_op_in_unsafe_fn` deny-by-default; opt back into the
+// pre-2024 behavior rather than wrapping every operation in an `unsafe {}` block.
+#![allow(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(
     all(target_arch = "x86_64", target_feature = "avx512f"),
     feature(stdarch_x86_avx512)


### PR DESCRIPTION
Opt `stwo`, `air-utils`, and `constraint-framework` into
`#![allow(unsafe_op_in_unsafe_fn)]`. Their SIMD/FFT kernels and
`uninitialized` allocators are written as `unsafe fn`s whose entire
bodies are unsafe by design; this preserves the pre-2024 behavior
instead of wrapping every operation in an `unsafe {}` block.

Currently a no-op (the lint is allow-by-default in edition 2021). It is
decoupled prep for the upcoming edition 2024 migration, where the lint
becomes deny-by-default. Verified with `-D unsafe_op_in_unsafe_fn` that
these are the only three workspace crates with affected call sites
(examples/std-shims/air-utils-derive have none).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>