### PR TITLE
ci: show CPU and threading mode on benchmark results

### DIFF
--- a/.github/workflows/benchmarks-pages.yaml
+++ b/.github/workflows/benchmarks-pages.yaml
@@ -20,6 +20,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-01-15
+      - name: Detect benchmark environment
+        id: benchmark_environment
+        run: |
+          cpu_model=$(lscpu | sed -n 's/^Model name:[[:space:]]*//p' | head -n 1)
+          echo "cpu_model=${cpu_model}" >> "$GITHUB_OUTPUT"
       - name: Run benchmark
         run: |
           cargo install cargo-criterion
@@ -32,6 +37,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
+          name: Stwo (${{ steps.benchmark_environment.outputs.cpu_model }}, single-threaded)
           tool: "cargo"
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #1206

- Detect the benchmark runner's CPU model with `lscpu`.
- Include the CPU model and threading mode in the published benchmark dashboard heading.

The resulting benchmark group is named similarly to:

`Stwo (AMD EPYC ..., single-threaded)`




## Motivation

The benchmark dashboard currently publishes timing results without identifying the CPU used to produce them or whether parallel execution is enabled.

The benchmark Pages workflow invokes `scripts/bench.sh` with the `prover` feature only. Since the separate `parallel` feature is not enabled, these results are single-threaded.

Detecting the CPU at runtime avoids hard-coding runner hardware and keeps the displayed information accurate if the runner is changed later.

## Testing

- Validated the workflow with `actionlint`.
- Verified the CPU model extraction and GitHub Actions output.
- Ran `git diff --check`.

