### PR TITLE
perf(constraint-framework): hoist loop-invariant trace.last() in LogUp finalize_col

### DIFF
--- a/crates/constraint-framework/src/prover/logup.rs
+++ b/crates/constraint-framework/src/prover/logup.rs
@@ -183,6 +183,10 @@ impl LogupColGenerator<'_> {
             &mut self.trace_gen.batch_inverse_buffer,
         );
 
+        // `trace` isn't mutated until after this loop, so the last column is the same for every
+        // row; look it up once instead of re-deriving it from the `Vec` on every row.
+        let prev_col = self.trace_gen.trace.last();
+
         #[cfg(feature = "parallel")]
         let chunks_iter = {
             let denom_inv_chunks = self.trace_gen.batch_inverse_buffer.par_chunks(chunk_size);
@@ -204,10 +208,7 @@ impl LogupColGenerator<'_> {
                     unsafe {
                         let vec_row = chunk_idx * chunk_size + idx_in_chunk;
                         let value = numerator_chunk.packed_at(idx_in_chunk) * *denom_item;
-                        let prev_value = self
-                            .trace_gen
-                            .trace
-                            .last()
+                        let prev_value = prev_col
                             .map(|col| col.packed_at(vec_row))
                             .unwrap_or_else(PackedSecureField::zero);
                         numerator_chunk.set_packed(idx_in_chunk, value + prev_value)


### PR DESCRIPTION
## Motivation

Follow-up performance optimization found while reviewing #1446 (merged: mechanical `gen` -> `trace_gen` field rename in `LogupColGenerator`, prep for the Rust edition 2024 migration where `gen` becomes a reserved keyword). That PR touched `crates/constraint-framework/src/prover/logup.rs`; while re-reading it I noticed `finalize_col`'s innermost per-row loop had a small but genuine hot-path inefficiency.

`finalize_col` runs once per LogUp interaction trace column during proving — a column can have up to `2^log_size / N_LANES` SIMD-packed rows, so this loop runs millions of times for large traces (LogUp underlies every lookup argument: range checks, memory arguments, etc.).

## Change

**File:** `crates/constraint-framework/src/prover/logup.rs`

**Before:** the loop body re-derived `self.trace_gen.trace.last()` — an `Option<&SecureColumnByCoords<SimdBackend>>` lookup into a `Vec` — on *every single row*, even though `self.trace_gen.trace` is never mutated until after the loop finishes (the only mutation, `trace.push(self.numerator)`, happens strictly after).

**After:** hoist the lookup to `let prev_col = self.trace_gen.trace.last();` once before the loop, and read the hoisted value on each row instead.

```rust
// `trace` isn't mutated until after this loop, so the last column is the same for every
// row; look it up once instead of re-deriving it from the `Vec` on every row.
let prev_col = self.trace_gen.trace.last();
...
let prev_value = prev_col
    .map(|col| col.packed_at(vec_row))
    .unwrap_or_else(PackedSecureField::zero);
```

## Correctness

Semantics are unchanged: `self.trace_gen.trace` is not mutated anywhere between the hoist point and the end of the loop, so `trace.last()` returns the identical value on every row in both the old and new code — including the empty case (first column being finalized), where both versions yield `PackedSecureField::zero()`. This holds in both the `#[cfg(feature = "parallel")]` (rayon) and non-parallel code paths; `prev_col` is `Copy` and safely shared read-only across rayon workers.

Reviewed by an independent Opus agent: no blocking issues found; verdict "safe to ship."

## Expected Impact

Removes a per-row bounds-checked `Vec` reload (redundant across an `unsafe` block and, in the parallel case, a rayon closure boundary that can prevent LLVM from proving/hoisting it automatically) from a hot LogUp trace-generation loop, replacing it with a single per-column lookup. Small constant-factor win on `finalize_col`, which is exercised by every lookup argument in every STARK proof.

## Tests

```
cargo test -p stwo-constraint-framework --features "prover,parallel" --lib    # 14 passed (logup: 4 passed)
cargo test -p stwo-constraint-framework --no-default-features                 # 3 passed
cargo clippy -p stwo-constraint-framework --features "prover,parallel" --all-targets -- -D warnings   # clean
cargo fmt --check (rustfmt on the touched file)                               # clean
```

---
🤖 Generated by an automated performance-review routine, triggered by the merge of #1446.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SSkyjeQPVUZ31EhnHhB6nW)_