### PR TITLE
refactor(fri): move pow_bits from PcsConfig into FriConfig

### DIFF
--- a/crates/examples/src/plonk/mod.rs
+++ b/crates/examples/src/plonk/mod.rs
@@ -293,11 +293,8 @@ mod tests {
             .unwrap_or_else(|_| "10".to_string())
             .parse::<u32>()
             .unwrap();
-        let config = PcsConfig {
-            pow_bits: 10,
-            fri_config: FriConfig::new(5, 4, 64, 1),
-            min_lifting_log_size: 0,
-        };
+        let config =
+            PcsConfig { fri_config: FriConfig::new(5, 4, 64, 1, 10), min_lifting_log_size: 0 };
 
         // Prove.
         let (component, proof) = prove_fibonacci_plonk(log_n_instances, config);

--- a/crates/examples/src/poseidon/mod.rs
+++ b/crates/examples/src/poseidon/mod.rs
@@ -385,7 +385,7 @@ mod tests {
     #[wasm_bindgen_test::wasm_bindgen_test]
     fn test_poseidon_prove_wasm() {
         const LOG_N_INSTANCES: u32 = 10;
-        let config = PcsConfig { pow_bits: 10, fri_config: FriConfig::new(5, 1, 64, 1) };
+        let config = PcsConfig { fri_config: FriConfig::new(5, 1, 64, 1, 10) };
 
         // Prove.
         prove_poseidon(LOG_N_INSTANCES, config);
@@ -460,11 +460,8 @@ mod tests {
             .unwrap_or_else(|_| "10".to_string())
             .parse::<u32>()
             .unwrap();
-        let config = PcsConfig {
-            pow_bits: 10,
-            fri_config: FriConfig::new(5, 1, 64, 1),
-            min_lifting_log_size: 0,
-        };
+        let config =
+            PcsConfig { fri_config: FriConfig::new(5, 1, 64, 1, 10), min_lifting_log_size: 0 };
 
         // Prove.
         let (component, proof) = prove_poseidon(log_n_instances, config);
@@ -509,11 +506,8 @@ mod tests {
             .unwrap_or_else(|_| "10".to_string())
             .parse::<u32>()
             .unwrap();
-        let config = PcsConfig {
-            pow_bits: 10,
-            fri_config: FriConfig::new(5, 1, 64, 1),
-            min_lifting_log_size: 0,
-        };
+        let config =
+            PcsConfig { fri_config: FriConfig::new(5, 1, 64, 1, 10), min_lifting_log_size: 0 };
 
         // Prove.
         let _ = prove_poseidon(log_n_instances, config);

--- a/crates/examples/src/wide_fibonacci/mod.rs
+++ b/crates/examples/src/wide_fibonacci/mod.rs
@@ -241,11 +241,8 @@ mod tests {
     #[test_log::test]
     fn test_wide_fib_prove_with_larger_blowup() {
         for log_n_instances in 4..=7 {
-            let config = PcsConfig {
-                pow_bits: 10,
-                fri_config: FriConfig::new(0, 2, 3, 1),
-                min_lifting_log_size: 0,
-            };
+            let config =
+                PcsConfig { fri_config: FriConfig::new(0, 2, 3, 1, 10), min_lifting_log_size: 0 };
             // Precompute twiddles for the larger committed domain.
             let twiddles = SimdBackend::precompute_twiddles(
                 CanonicCoset::new(log_n_instances + 1 + config.fri_config.log_blowup_factor)

--- a/crates/stwo/src/core/fri.rs
+++ b/crates/stwo/src/core/fri.rs
@@ -33,6 +33,8 @@ pub struct FriConfig {
     pub log_last_layer_degree_bound: u32,
     pub n_queries: usize,
     pub fold_step: u32,
+    /// The number of proof of work bits before the FRI queries.
+    pub pow_bits: u32,
 }
 
 impl FriConfig {
@@ -58,11 +60,12 @@ impl FriConfig {
         log_blowup_factor: u32,
         n_queries: usize,
         fold_step: u32,
+        pow_bits: u32,
     ) -> Self {
         assert!(Self::LOG_LAST_LAYER_DEGREE_BOUND_RANGE.contains(&log_last_layer_degree_bound));
         assert!(Self::LOG_BLOWUP_FACTOR_RANGE.contains(&log_blowup_factor));
         assert!(fold_step > 0, "Line fold step must be positive.");
-        Self { log_blowup_factor, log_last_layer_degree_bound, n_queries, fold_step }
+        Self { log_blowup_factor, log_last_layer_degree_bound, n_queries, fold_step, pow_bits }
     }
 
     pub const fn last_layer_domain_size(&self) -> usize {
@@ -70,7 +73,7 @@ impl FriConfig {
     }
 
     pub const fn security_bits(&self) -> u32 {
-        self.log_blowup_factor * self.n_queries as u32
+        self.log_blowup_factor * self.n_queries as u32 + self.pow_bits
     }
 }
 
@@ -865,7 +868,7 @@ mod tests {
         let column = polynomial_evaluation(LOG_DEGREE, LOG_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
         let queries = Queries::from_positions(vec![5], column.domain.log_size());
-        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&column, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &column, &twiddles);
         let proof = prover.decommit_on_queries(&queries).proof;
@@ -884,7 +887,7 @@ mod tests {
         let column = polynomial_evaluation(LOG_DEGREE, LOG_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
         let queries = Queries::from_positions(vec![5], column.domain.log_size());
-        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&column, &queries);
         let prover =
             crate::prover::fri::FriProver::<'_, CpuBackend, Keccak256MerkleChannel>::commit(
@@ -914,7 +917,7 @@ mod tests {
         let column = polynomial_evaluation(LOG_DEGREE, LOG_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
         let queries = Queries::from_positions(vec![5], column.domain.log_size());
-        let config = FriConfig::new(LAST_LAYER_LOG_BOUND, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(LAST_LAYER_LOG_BOUND, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&column, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &column, &twiddles);
         let proof = prover.decommit_on_queries(&queries).proof;
@@ -931,7 +934,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![1], log_domain_size);
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let proof = prover.decommit_on_queries(&queries).proof;
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
@@ -955,7 +958,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![1], log_domain_size);
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let proof = prover.decommit_on_queries(&queries).proof;
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
@@ -979,7 +982,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![5], log_domain_size);
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&evaluation, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
@@ -1003,7 +1006,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![5], log_domain_size);
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&evaluation, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
@@ -1028,7 +1031,8 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![1, 7, 8], log_domain_size);
-        let config = FriConfig::new(LOG_MAX_LAST_LAYER_DEGREE, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config =
+            FriConfig::new(LOG_MAX_LAST_LAYER_DEGREE, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
         let mut proof = prover.decommit_on_queries(&queries).proof;
@@ -1047,7 +1051,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![1, 7, 8], log_domain_size);
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&evaluation, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let bound = CirclePolyDegreeBound::new(LOG_DEGREE);
@@ -1072,7 +1076,7 @@ mod tests {
         let twiddles = CpuBackend::precompute_twiddles(evaluation.domain.half_coset);
         let log_domain_size = evaluation.domain.log_size();
         let queries = Queries::from_positions(vec![5], log_domain_size);
-        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1);
+        let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), 1, 0);
         let decommitment_value = query_polynomial(&evaluation, &queries);
         let prover = FriProver::commit(&mut test_channel(), config, &evaluation, &twiddles);
         let proof = prover.decommit_on_queries(&queries).proof;
@@ -1147,7 +1151,7 @@ mod tests {
                 let column = polynomial_evaluation(log_degree, LOG_BLOWUP_FACTOR);
                 let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
                 let queries = Queries::from_positions(vec![5], column.domain.log_size());
-                let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), fold_step);
+                let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), fold_step, 0);
                 let decommitment_value = query_polynomial(&column, &queries);
                 let prover = FriProver::commit(&mut test_channel(), config, &column, &twiddles);
                 let proof = prover.decommit_on_queries(&queries).proof;
@@ -1174,7 +1178,7 @@ mod tests {
             let column = polynomial_evaluation(LOG_DEGREE, LOG_BLOWUP_FACTOR);
             let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
             let queries = Queries::from_positions(vec![5], column.domain.log_size());
-            let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), fold_step);
+            let config = FriConfig::new(1, LOG_BLOWUP_FACTOR, queries.len(), fold_step, 0);
             let decommitment_value = query_polynomial(&column, &queries);
             let prover = FriProver::commit(&mut test_channel(), config, &column, &twiddles);
             let proof = prover.decommit_on_queries(&queries).proof;

--- a/crates/stwo/src/core/pcs/mod.rs
+++ b/crates/stwo/src/core/pcs/mod.rs
@@ -29,8 +29,6 @@ pub struct TreeSubspan {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 /// Configuration parameters for the commitment scheme prover.
 pub struct PcsConfig {
-    /// The number of proof of work bits before the FRI queries.
-    pub pow_bits: u32,
     pub fri_config: FriConfig,
     /// A lower bound on the size of the lifting domain (This size includes the
     /// `log_blowup_factor`). Each tree is committed with height
@@ -43,13 +41,18 @@ pub struct PcsConfig {
 }
 impl PcsConfig {
     pub const fn security_bits(&self) -> u32 {
-        self.pow_bits + self.fri_config.security_bits()
+        self.fri_config.security_bits()
     }
 
     pub fn mix_into(&self, channel: &mut impl Channel) {
-        let PcsConfig { pow_bits, fri_config, min_lifting_log_size } = self;
-        let FriConfig { log_blowup_factor, n_queries, log_last_layer_degree_bound, fold_step } =
-            fri_config;
+        let PcsConfig { fri_config, min_lifting_log_size } = self;
+        let FriConfig {
+            log_blowup_factor,
+            n_queries,
+            log_last_layer_degree_bound,
+            fold_step,
+            pow_bits,
+        } = fri_config;
 
         channel.mix_felts(&[
             SecureField::from_u32_unchecked(
@@ -65,7 +68,7 @@ impl PcsConfig {
 
 impl Default for PcsConfig {
     fn default() -> Self {
-        Self { pow_bits: 10, fri_config: FriConfig::new(0, 1, 3, 1), min_lifting_log_size: 0 }
+        Self { fri_config: FriConfig::new(0, 1, 3, 1, 10), min_lifting_log_size: 0 }
     }
 }
 
@@ -74,8 +77,7 @@ mod tests {
     #[test]
     fn test_security_bits() {
         let config = super::PcsConfig {
-            pow_bits: 42,
-            fri_config: super::FriConfig::new(10, 10, 70, 1),
+            fri_config: super::FriConfig::new(10, 10, 70, 1, 42),
             min_lifting_log_size: 0,
         };
         assert!(config.security_bits() == 10 * 70 + 42);

--- a/crates/stwo/src/core/pcs/verifier.rs
+++ b/crates/stwo/src/core/pcs/verifier.rs
@@ -71,7 +71,7 @@ impl<MC: MerkleChannel> CommitmentSchemeVerifier<MC> {
             FriVerifier::<MC>::commit(channel, self.config.fri_config, proof.fri_proof, bound)?;
 
         // Verify proof of work.
-        if !channel.verify_pow_nonce(self.config.pow_bits, proof.proof_of_work) {
+        if !channel.verify_pow_nonce(self.config.fri_config.pow_bits, proof.proof_of_work) {
             return Err(VerificationError::ProofOfWork);
         }
         channel.mix_u64(proof.proof_of_work);

--- a/crates/stwo/src/prover/fri.rs
+++ b/crates/stwo/src/prover/fri.rs
@@ -456,7 +456,7 @@ mod tests {
     fn committing_high_degree_polynomial_fails() {
         const LOG_EXPECTED_BLOWUP_FACTOR: u32 = LOG_BLOWUP_FACTOR;
         const LOG_INVALID_BLOWUP_FACTOR: u32 = LOG_BLOWUP_FACTOR - 1;
-        let config = FriConfig::new(2, LOG_EXPECTED_BLOWUP_FACTOR, 3, 1);
+        let config = FriConfig::new(2, LOG_EXPECTED_BLOWUP_FACTOR, 3, 1, 0);
         let column = polynomial_evaluation(6, LOG_INVALID_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
 
@@ -468,7 +468,7 @@ mod tests {
     fn committing_column_from_invalid_domain_fails() {
         let invalid_domain = CircleDomain::new(Coset::new(CirclePointIndex::generator(), 3));
         assert!(!invalid_domain.is_canonic(), "must be an invalid domain");
-        let config = FriConfig::new(2, 2, 3, 1);
+        let config = FriConfig::new(2, 2, 3, 1, 0);
         let column = SecureEvaluation::new(
             invalid_domain,
             [SecureField::one(); 1 << 4].into_iter().collect(),
@@ -494,7 +494,7 @@ mod tests {
 
     #[test]
     fn test_fri_commit_decommit_with_jumps() {
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2, 0);
         let column = polynomial_evaluation(6, LOG_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
 
@@ -506,7 +506,7 @@ mod tests {
     #[test]
     fn test_fri_commit_decommit_with_packed_leaves() {
         for fold_step in 2..=4 {
-            let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, fold_step);
+            let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, fold_step, 0);
             let column = polynomial_evaluation(8, LOG_BLOWUP_FACTOR);
             let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
 
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn test_fri_commit_decommit_with_packed_leaves_simd() {
         for fold_step in 2..=4 {
-            let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, fold_step);
+            let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, fold_step, 0);
             let cpu_eval = polynomial_evaluation(8, LOG_BLOWUP_FACTOR);
             let column = SecureEvaluation::new(
                 cpu_eval.domain,
@@ -542,7 +542,7 @@ mod tests {
         use crate::core::channel::Keccak256Channel;
         use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2, 0);
         let column = polynomial_evaluation(6, LOG_BLOWUP_FACTOR);
         let twiddles = CpuBackend::precompute_twiddles(column.domain.half_coset);
 
@@ -561,7 +561,7 @@ mod tests {
         use crate::core::channel::Keccak256Channel;
         use crate::core::vcs_lifted::keccak256_merkle::Keccak256MerkleChannel;
 
-        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2);
+        let config = FriConfig::new(2, LOG_BLOWUP_FACTOR, 3, 2, 0);
         let cpu_eval = polynomial_evaluation(8, LOG_BLOWUP_FACTOR);
         let column =
             SecureEvaluation::new(cpu_eval.domain, cpu_eval.values.to_vec().into_iter().collect());

--- a/crates/stwo/src/prover/pcs/mod.rs
+++ b/crates/stwo/src/prover/pcs/mod.rs
@@ -224,7 +224,7 @@ impl<'a, B: BackendForChannel<MC>, MC: MerkleChannel> CommitmentSchemeProver<'a,
 
         // Proof of work.
         let span1 = span!(Level::INFO, "Grind", class = "Queries POW").entered();
-        let proof_of_work = B::grind(channel, self.config.pow_bits);
+        let proof_of_work = B::grind(channel, self.config.fri_config.pow_bits);
         span1.exit();
         channel.mix_u64(proof_of_work);
 


### PR DESCRIPTION
## What

Moves `pow_bits` (the proof-of-work grinding parameter applied before the FRI queries) from `PcsConfig` into `FriConfig`, next to the other FRI security parameters.

## Changes

- `FriConfig` gains a `pow_bits: u32` field; `FriConfig::new(..)` takes it as a **trailing** argument.
- `FriConfig::security_bits()` now returns `log_blowup_factor * n_queries + pow_bits`; `PcsConfig::security_bits()` delegates to it (numerically unchanged total).
- `PcsConfig` is now `{ fri_config, min_lifting_log_size }`. Its `mix_into` keeps the **byte-identical** Fiat-Shamir felt layout — the challenge transcript is unchanged.
- The two `self.config.pow_bits` accessors (FRI prover grind, verifier PoW check) now read `self.config.fri_config.pow_bits`.
- Updated all `FriConfig::new` call sites (FRI/prover unit tests pass `0`) and the example `PcsConfig` literals (fold `pow_bits: 10` into `FriConfig::new`).

## Note

The serialized proof `config` shape changes accordingly (config is embedded in `CommitmentSchemeProof`).

## Verification

- `cargo build --features prover` ✓; verifier-only `--no-default-features` pcs tests ✓
- prover `fri::` / `pcs::` tests ✓ (incl. `test_security_bits`)
- end-to-end prove→grind→verify examples: wide_fibonacci, plonk, blake (incl. `security_bits() >= REQUIRED_SECURITY_BITS`) ✓
- `scripts/rust_fmt.sh --check` ✓, `scripts/clippy.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)